### PR TITLE
refactor(common): audit pass — three Transform/Color bugs, first tests for Vector2 and Transform

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -118,10 +118,23 @@ up; the likely fix is a public read-only components view.
 ### CC-6 — Component data-purity is advisory, not enforced
 `BaseComponent` only *warns* on logic methods; `StrictComponent` errors but is
 opt-in and, at the time of the `ecs` audit, had no adopters outside tests.
-Real components across `physics`, `ui` and `ai` may carry logic. **Fix:**
-after those subsystems are audited, migrate the tree to `StrictComponent` and
-consider making it the default.
-*Discovered in:* `ecs`. *Status:* parked — measure adoption per subsystem.
+**Named offender:** `common.Transform` sets `_allow_methods = True` and carries
+the whole parent hierarchy, world-transform caching and coordinate conversion
+(~330 lines). It is the largest violation in the engine and the one a
+`TransformSystem` would have to absorb; every other subsystem touches it, so it
+is deliberately not attempted piecemeal. **Fix:** once `physics`, `ui` and `ai`
+are audited and the true extent is known, migrate the tree to `StrictComponent`
+and consider making it the default.
+*Discovered in:* `ecs`; offender identified in `common`. *Status:* parked.
+
+### CC-7 — `x or default` used with falsy value types
+`pymunk.Vec2d` defines `__bool__`, so `Vector2(0, 0)` is falsy. `Transform
+.__init__` used `scale or Vector2(1, 1)`, which silently rewrote an explicitly
+requested zero scale to unit scale. Fixed there, but the idiom is common and
+the same trap applies to any zero vector, `Color(0,0,0,0)`, an empty `Rect`, or
+`0.0` defaults. **Fix:** sweep `grep -rn "or Vector2(\\|or Color(" pyguara/` and
+convert to explicit `is None` checks as each subsystem is audited.
+*Discovered in:* `common`. *Status:* open.
 
 ---
 
@@ -174,3 +187,58 @@ test modules migrated; 7 further tests added (1168 total, from 1161).
 
 **Deferred out of this subsystem:** CC-1 through CC-4, CC-6, and the remaining
 half of CC-5 (`Entity._components` reached into by `persistence`/`prefabs`).
+
+
+### `pyguara/common` — awaiting approval (2026-09-06)
+
+**Verification:** 1236/1236 tests pass (up from 1168); ruff clean; mypy clean
+across 217 files (one fewer: `constants.py` deleted).
+
+**Correctness fixes (all three reproduced by probe before fixing):**
+- `Transform.up` returned `(0, +1)` — the exact opposite of `Vector2.up()`'s
+  `(0, -1)`, and pointing *down* on screen. Gravity defaults positive
+  (`gravity_y = 900.0` in the shipped games), so the engine is unambiguously
+  Y-down; `Transform.up` was wrong. Both now agree, and the convention is
+  stated in both module docstrings and the new doc page.
+- `Transform.set_parent()` had no cycle guard. `t.set_parent(t)`, or any
+  loop, made every later `world_*` read recurse until the stack blew.
+  Now raises `ValueError`; `is_ancestor_of()` exposes the check.
+- `Transform.__init__` used `scale or Vector2(1, 1)`. `Vector2(0, 0)` is falsy,
+  so an explicitly requested zero scale silently became unit scale. Now
+  `is None`. Found by a test written against the documented behaviour, not by
+  reading the code — see CC-7.
+
+**API changes:**
+- `Vector2.rotate(degrees)` → `Vector2.rotate_degrees(degrees)`. It sat one
+  letter from `rotated(radians)`, and `Transform.rotate()` also takes radians;
+  a one-letter difference deciding the angle unit is unreadable at a call site.
+  All three call sites migrated (`camera.py` ×2, `particles.py`); all were
+  correct beforehand, so this closes a latent trap rather than a live bug.
+- `Color` now coerces channels to `int` and clamps to 0-255. It lost pygame
+  .Color's own validation in the ticket-31 migration and gained no replacement,
+  so `Color.from_hsv(0, 5, 5)` produced `Color(1275, -5100, -5100)`. Clamping
+  rather than raising: colour arithmetic overshoots legitimately, and a crash
+  mid-render is worse than saturation.
+- Added `Vector2.down()`/`left()` and `Transform.left`/`down` — `up`/`right`
+  existed without their opposites.
+- Added `Color.to_hex()` and `Rect.size`.
+- `Tag` and `ResourceLink` are now `@dataclass(slots=True)`, as the ECS docs
+  require. This required replacing `super().__init__()` with an explicit
+  `BaseComponent.__init__(self)`: `slots=True` returns a *new* class, so a
+  zero-arg `super()` resolves against the discarded original and raises on
+  every instantiation. Caught by 10 failing tests, not by review.
+- `Rect.inflate()` now truncates the offset towards zero instead of flooring,
+  matching `pygame.Rect` for odd negative deltas (was off by one pixel).
+
+**Cleanup:** deleted `pyguara/common/constants.py` (a file containing only a
+docstring, imported nowhere). `palette.BasicColors` now re-exports the `Color`
+constants instead of redefining all nine.
+
+**Tests:** 52 in `test_common_types.py` (from 24) plus a new
+`test_transform.py` with 36. `Vector2` and `Transform` previously had **zero**
+direct tests — Transform appeared in ten other modules only as an incidental
+fixture, so the most intricate logic in the package was exercised by accident.
+
+**Docs:** new `docs/core/common-types.md`, added to the mkdocs nav.
+
+**Deferred:** CC-1 through CC-4, CC-6, CC-7, and the remaining half of CC-5.

--- a/docs/core/common-types.md
+++ b/docs/core/common-types.md
@@ -1,0 +1,162 @@
+# Core Types
+
+`pyguara.common` holds the primitives every other subsystem shares: `Vector2`,
+`Color`, `Rect`, and the `Transform` component.
+
+## Axis convention
+
+**Y increases downwards.** This matches SDL, pygame, and the engine's own
+defaults — `PhysicsConfig.gravity_y` is *positive* for a platformer.
+
+Everything follows from that: "up" is negative Y.
+
+```python
+Vector2.up()     # (0, -1)
+Vector2.down()   # (0,  1)
+Vector2.left()   # (-1, 0)
+Vector2.right()  # (1,  0)
+
+Transform().up   # (0, -1), rotated by the transform's world rotation
+```
+
+## Vector2
+
+An immutable 2D vector, subclassing `pymunk.Vec2d` for C-optimised math and to
+pass straight into the physics backend. Every operation returns a new
+`Vector2`; nothing mutates in place.
+
+```python
+v = Vector2(3, 4)
+v.magnitude        # 5.0
+v.sqr_magnitude    # 25.0 -- no square root, use it to compare distances
+v.normalize()      # (0.6, 0.8); a zero vector normalises to zero, not an error
+v.distance_to(other)
+v.lerp(target, 0.5)
+v.to_tuple(), v.to_int_tuple()
+```
+
+### Angles
+
+Two rotation methods, named so the unit is unmissable:
+
+```python
+v.rotated(math.pi / 2)      # radians
+v.rotate_degrees(90)        # degrees
+```
+
+!!! warning "`Vector2.rotate()` no longer exists"
+    It took **degrees** and sat one letter away from `rotated()`, which takes
+    **radians** — while `Transform.rotate()` also takes radians. A one-letter
+    difference deciding the angle unit cannot be read correctly at a call
+    site, so the ambiguous name was removed. Replace `v.rotate(deg)` with
+    `v.rotate_degrees(deg)`.
+
+Since `Vector2` is a tuple subclass, note that `Vector2(0, 0)` is **falsy**.
+Use `if v is not None`, never `if v`, when a zero vector is a legitimate value.
+
+## Color
+
+An RGBA colour, one byte per channel, with no backend dependency. Channels are
+coerced to `int` and **clamped to 0–255** on construction, so arithmetic that
+overshoots saturates instead of handing a backend an unrepresentable value:
+
+```python
+Color(300, -5, 128)          # Color(255, 0, 128)
+Color.from_hsv(0, 5, 5)      # Color(255, 0, 0), not garbage
+Color(0, 0, 0).lerp(Color.WHITE, 0.5)
+```
+
+```python
+Color.from_hex("#FF00AA")    # also "0xFF00AA" and "#FF00AAFF"
+color.to_hex()               # "#FF00AA"; to_hex(include_alpha=True) adds the pair
+color.normalized             # (r, g, b, a) as floats in 0.0-1.0, for shaders
+color.to_hsv()               # (hue 0-360, saturation 0-1, value 0-1)
+```
+
+Named constants live on `Color` itself — `Color.WHITE`, `Color.BLACK`,
+`Color.RED`, `Color.TRANSPARENT`, and so on. `pyguara.common.palette` re-exports
+them as `BasicColors` and adds `DebugColors` for debug drawing; it holds no
+independent definitions, so the two spellings cannot drift apart.
+
+## Rect
+
+An axis-aligned rectangle in integer pixel coordinates. Mutable, matching
+`pygame.Rect`, because the UI layout engine assigns to `rect.x` in place.
+Coordinates are truncated to `int` on construction, so building one straight
+from `Vector2` components works without an explicit cast.
+
+```python
+r = Rect(10, 20, 30, 40)
+r.left, r.top, r.right, r.bottom
+r.centerx, r.centery, r.center_vec, r.position, r.size
+
+r.contains_point(Vector2(15, 25))   # right/bottom edges exclusive
+r.colliderect(other)                # touching edges do not overlap
+r.contains(other)                   # edges inclusive
+r.inflate(4, 4)                     # grows around the same centre
+```
+
+## Transform
+
+Position, rotation and scale, with optional parenting. Angles are **radians**
+everywhere except `rotation_degrees`.
+
+```python
+t = Transform(position=Vector2(100, 50), rotation=math.pi / 2)
+t.position, t.rotation, t.rotation_degrees, t.scale
+t.translate(Vector2(5, 0))
+t.rotate(math.pi)          # radians
+t.look_at(Vector2(0, 0))   # points `forward` at a world position
+```
+
+### Hierarchy
+
+A parented transform stores values *local* to its parent; the `world_*`
+properties resolve the chain.
+
+```python
+child.set_parent(parent)                            # keeps world position
+child.set_parent(parent, keep_world_transform=False)  # keeps local values
+child.set_parent(None)                              # detach
+```
+
+World values are cached and rebuilt lazily: a setter marks the subtree dirty,
+and the next `world_*` read recomputes only what it needs. This is transparent
+— move a parent and every descendant's world position follows.
+
+Cycles are rejected:
+
+```python
+t.set_parent(t)          # ValueError
+a.set_parent(b); b.set_parent(a)   # ValueError
+```
+
+A cycle has no world transform, so without this guard every later `world_*`
+read recursed until the stack ran out. `is_ancestor_of(other)` exposes the same
+check.
+
+### Coordinate conversion
+
+```python
+t.local_to_world(Vector2(1, 0))
+t.world_to_local(Vector2(110, 55))
+t.distance_to(other_transform)      # world space
+```
+
+A zero world scale is not invertible; `world_to_local` returns the origin
+rather than raising mid-frame.
+
+### Why Transform has methods
+
+`Transform` sets `_allow_methods = True`, opting out of the data-only
+component rule. It is the engine's largest exception to that rule, and moving
+the hierarchy math into a `TransformSystem` is tracked as a cross-cutting
+concern rather than attempted piecemeal — it touches most of the engine.
+
+## Rules of thumb
+
+1. Y is down. "Up" is negative Y, in `Vector2` and `Transform` alike.
+2. Never test a `Vector2` for truthiness — `Vector2(0, 0)` is falsy.
+3. Radians everywhere, except `rotate_degrees()` and `rotation_degrees`.
+4. Let `Color` clamp; do not pre-clamp channels at call sites.
+5. Define colours once, on `Color`. `BasicColors` re-exports, never redefines.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
   - Core:
       - Architecture: core/architecture.md
       - Entity Component System: core/ecs.md
+      - Core Types: core/common-types.md
       - Application & Lifecycle: core/application.md
       - Logging: core/logging.md
   - Graphics:

--- a/pyguara/common/components.py
+++ b/pyguara/common/components.py
@@ -1,62 +1,109 @@
-"""Common ECS components used across the engine."""
+"""ECS components shared by every subsystem.
+
+Axis convention matches `pyguara.common.types`: Y increases downwards, so the
+`up` direction is negative Y.
+"""
+
+from __future__ import annotations
 
 import math
-from typing import List, Optional
 from dataclasses import dataclass
 
 from pyguara.common.types import Vector2
 from pyguara.ecs.component import BaseComponent
 
 
-@dataclass
+@dataclass(slots=True)
 class Tag(BaseComponent):
-    """Component for labeling entities with a human-readable name."""
+    """A human-readable name for an entity, for debugging and editor display.
+
+    Attributes:
+        name: The display name.
+    """
 
     name: str = "Entity"
 
     def __post_init__(self) -> None:
-        """Initialize the component."""
-        super().__init__()
+        """Initialise the BaseComponent state the dataclass __init__ skips.
+
+        Calls the base explicitly rather than via `super()`: with
+        `slots=True` the decorator returns a *new* class, and a zero-argument
+        `super()` still resolves against the discarded original, raising
+        TypeError on every instantiation.
+        """
+        BaseComponent.__init__(self)
 
 
-@dataclass
+@dataclass(slots=True)
 class ResourceLink(BaseComponent):
-    """Component that links an entity/component to its source DataResource."""
+    """Records the data resource an entity was built from.
+
+    Attributes:
+        resource_path: Path of the source resource.
+    """
 
     resource_path: str
 
     def __post_init__(self) -> None:
-        """Initialize the component."""
-        super().__init__()
+        """Initialise the BaseComponent state the dataclass __init__ skips.
+
+        Calls the base explicitly rather than via `super()`: with
+        `slots=True` the decorator returns a *new* class, and a zero-argument
+        `super()` still resolves against the discarded original, raising
+        TypeError on every instantiation.
+        """
+        BaseComponent.__init__(self)
 
 
 class Transform(BaseComponent):
-    """Component representing position, rotation, and scale in 2D space.
+    """Position, rotation and scale in 2D space, with optional parenting.
+
+    A transform may be parented to another, in which case its stored values
+    are local to that parent and the `world_*` properties resolve the chain.
+    World values are cached and recomputed lazily: a setter marks the subtree
+    dirty, and the next `world_*` read rebuilds only what it needs.
+
+    Angles are in **radians** throughout, except `rotation_degrees`.
 
     Note:
-        This is a legacy component with methods for convenience. Ideally,
-        transform manipulation logic would be in a TransformSystem.
+        This component carries logic, which the data-only ECS rule otherwise
+        forbids (hence `_allow_methods`). Moving the hierarchy math to a
+        TransformSystem is tracked as cross-cutting concern CC-6; it touches
+        most of the engine, so it is not attempted piecemeal.
+
+    Attributes:
+        interpolate: Opt in to fixed-timestep render interpolation.
+        previous_position: Position at the previous fixed tick, maintained by
+            `SceneManager.fixed_update()` when `interpolate` is set.
     """
 
-    _allow_methods = True  # Legacy component with helper methods
+    _allow_methods = True  # See the note above: hierarchy math lives here.
 
     def __init__(
         self,
-        position: Optional[Vector2] = None,
+        position: Vector2 | None = None,
         rotation: float = 0.0,
-        scale: Optional[Vector2] = None,
+        scale: Vector2 | None = None,
         interpolate: bool = False,
     ) -> None:
-        """Initialize the transform."""
-        super().__init__()  # Initialize BaseComponent (sets self.entity = None)
+        """Initialise an unparented transform.
 
-        self._local_position = position or Vector2(0.0, 0.0)
+        Args:
+            position: Local position. Defaults to the origin.
+            rotation: Local rotation in radians.
+            scale: Local scale. Defaults to `(1, 1)`.
+            interpolate: Opt in to fixed-timestep render interpolation.
+        """
+        super().__init__()
+
+        # `is None`, not `or`: pymunk's Vec2d is falsy at (0, 0), so `scale or
+        # default` silently rewrote an explicitly requested zero scale to (1, 1).
+        self._local_position = position if position is not None else Vector2(0.0, 0.0)
         self._local_rotation = rotation
-        self._local_scale = scale or Vector2(1.0, 1.0)
+        self._local_scale = scale if scale is not None else Vector2(1.0, 1.0)
 
-        # Hierarchy
-        self._parent: Optional["Transform"] = None
-        self._children: List["Transform"] = []
+        self._parent: Transform | None = None
+        self._children: list[Transform] = []
 
         # Cached world transform
         self._world_position: Vector2 = self._local_position
@@ -160,38 +207,66 @@ class Transform(BaseComponent):
     # --- Hierarchy Management ---
 
     @property
-    def parent(self) -> Optional["Transform"]:
-        """Get the parent transform."""
+    def parent(self) -> Transform | None:
+        """The parent transform, or None if this one is a root."""
         return self._parent
 
+    def is_ancestor_of(self, other: Transform) -> bool:
+        """Report whether this transform is somewhere above `other`.
+
+        Args:
+            other: The candidate descendant.
+
+        Returns:
+            True if `other` is this transform or below it in the hierarchy.
+        """
+        node: Transform | None = other
+        while node is not None:
+            if node is self:
+                return True
+            node = node._parent
+        return False
+
     def set_parent(
-        self, parent: Optional["Transform"], keep_world_transform: bool = True
+        self, parent: Transform | None, keep_world_transform: bool = True
     ) -> None:
-        """Set the parent transform."""
-        if parent == self._parent:
+        """Attach this transform to a parent, or detach it with None.
+
+        Args:
+            parent: The new parent, or None to make this a root.
+            keep_world_transform: Preserve the current world position,
+                rotation and scale by rewriting the local values.
+
+        Raises:
+            ValueError: If `parent` is this transform or one of its own
+                descendants. Such a cycle has no world transform, and every
+                later `world_*` read would recurse until the stack ran out.
+        """
+        if parent is self._parent:
             return
 
-        # Store current world state if we need to maintain it
-        world_pos: Optional[Vector2] = None
-        world_rot: Optional[float] = None
-        world_scl: Optional[Vector2] = None
+        if parent is not None and self.is_ancestor_of(parent):
+            raise ValueError(
+                "Cannot parent a Transform to itself or to one of its own "
+                "descendants; the resulting cycle has no world transform."
+            )
+
+        world_pos: Vector2 | None = None
+        world_rot: float | None = None
+        world_scl: Vector2 | None = None
 
         if keep_world_transform:
             world_pos = self.world_position
             world_rot = self.world_rotation
             world_scl = self.world_scale
 
-        # Remove from old parent
-        if self._parent:
-            if self in self._parent._children:
-                self._parent._children.remove(self)
+        if self._parent and self in self._parent._children:
+            self._parent._children.remove(self)
 
-        # Attach to new parent
         self._parent = parent
         if parent:
             parent._children.append(self)
 
-        # Restore world state relative to new parent
         if keep_world_transform and world_pos is not None:
             assert world_rot is not None
             assert world_scl is not None
@@ -201,7 +276,8 @@ class Transform(BaseComponent):
                 self.position = parent.world_to_local(world_pos)
                 self.rotation = world_rot - parent.world_rotation
 
-                # Scale logic
+                # A zero-scaled parent has no invertible transform; leave the
+                # local scale alone rather than dividing by zero.
                 p_scale = parent.world_scale
                 if p_scale.x != 0 and p_scale.y != 0:
                     self.scale = Vector2(
@@ -215,70 +291,116 @@ class Transform(BaseComponent):
         self._mark_dirty()
 
     @property
-    def children(self) -> List["Transform"]:
-        """Get a copy of the list of children."""
+    def children(self) -> list[Transform]:
+        """A snapshot copy of this transform's direct children."""
         return list(self._children)
 
     # --- Direction Vectors ---
 
     @property
     def right(self) -> Vector2:
-        """Get the world-space Right direction vector."""
-        return Vector2(1, 0).rotated(self.world_rotation)
+        """The world-space right direction, `(1, 0)` at zero rotation."""
+        return Vector2.right().rotated(self.world_rotation)
+
+    @property
+    def left(self) -> Vector2:
+        """The world-space left direction, `(-1, 0)` at zero rotation."""
+        return Vector2.left().rotated(self.world_rotation)
 
     @property
     def up(self) -> Vector2:
-        """Get the world-space Up direction vector."""
-        return Vector2(0, 1).rotated(self.world_rotation)
+        """The world-space up direction, `(0, -1)` at zero rotation.
+
+        Y increases downwards, so up is negative Y -- the same convention as
+        `Vector2.up()`, which this used to contradict by returning `(0, 1)`.
+        """
+        return Vector2.up().rotated(self.world_rotation)
+
+    @property
+    def down(self) -> Vector2:
+        """The world-space down direction, `(0, 1)` at zero rotation."""
+        return Vector2.down().rotated(self.world_rotation)
 
     @property
     def forward(self) -> Vector2:
-        """Get the forward vector."""
+        """The facing direction; an alias for `right`.
+
+        Zero rotation faces `(1, 0)`, and `look_at()` rotates to match.
+        """
         return self.right
 
     # --- Operations ---
 
     def translate(self, translation: Vector2) -> None:
-        """Move the transform by the given vector in local space."""
+        """Move by an offset in local space.
+
+        Args:
+            translation: The offset to add to the local position.
+        """
         self.position += translation
 
-    def rotate(self, angle: float) -> None:
-        """Rotate the transform by the given angle in radians."""
-        self.rotation += angle
+    def rotate(self, angle_radians: float) -> None:
+        """Turn by an angle in **radians**.
+
+        Args:
+            angle_radians: The angle to add to the local rotation. Use
+                `math.radians()` to convert, or set `rotation_degrees`.
+        """
+        self.rotation += angle_radians
 
     def look_at(self, target: Vector2) -> None:
-        """Rotate the transform to face a target world position."""
+        """Rotate so `forward` points at a world position.
+
+        Args:
+            target: The world point to face.
+        """
         direction = target - self.world_position
         self.world_rotation = math.atan2(direction.y, direction.x)
 
-    def distance_to(self, other: "Transform") -> float:
-        """Calculate distance to another transform."""
+    def distance_to(self, other: Transform) -> float:
+        """Return the world-space distance to another transform.
+
+        Args:
+            other: The transform to measure to.
+
+        Returns:
+            The straight-line distance between world positions.
+        """
         return self.world_position.distance_to(other.world_position)
 
     # --- Coordinate Conversion ---
 
     def local_to_world(self, local_point: Vector2) -> Vector2:
-        """Transform a point from local space to world space."""
+        """Convert a point from this transform's local space to world space.
+
+        Args:
+            local_point: The point in local space.
+
+        Returns:
+            The same point in world space.
+        """
         self._update_world_transform()
 
-        # Scale
         scaled = Vector2(
             local_point.x * self._world_scale.x, local_point.y * self._world_scale.y
         )
-        # Rotate
         rotated = scaled.rotated(self._world_rotation)
-        # Translate
         return rotated + self._world_position
 
     def world_to_local(self, world_point: Vector2) -> Vector2:
-        """Transform a point from world space to local space."""
+        """Convert a point from world space to this transform's local space.
+
+        Args:
+            world_point: The point in world space.
+
+        Returns:
+            The same point in local space, or the origin if either world scale
+            axis is zero, which makes the transform non-invertible.
+        """
         self._update_world_transform()
 
-        # Inverse Translate
         translated = world_point - self._world_position
-        # Inverse Rotate
         unrotated = translated.rotated(-self._world_rotation)
-        # Inverse Scale
         if self._world_scale.x == 0 or self._world_scale.y == 0:
             return Vector2(0, 0)
 
@@ -289,21 +411,25 @@ class Transform(BaseComponent):
     # --- Internal Updates ---
 
     def _mark_dirty(self) -> None:
-        """Mark this transform and all children as dirty."""
+        """Invalidate the cached world transform of this subtree.
+
+        Stops at an already-dirty node. That is safe because cleaning a node
+        also cleans all of its ancestors, so a dirty node can never have a
+        clean descendant.
+        """
         if not self._is_dirty:
             self._is_dirty = True
             for child in self._children:
                 child._mark_dirty()
 
     def _update_world_transform(self) -> None:
-        """Recalculate world transform if dirty."""
+        """Recompute the cached world transform if it is stale."""
         if not self._is_dirty:
             return
 
         if self._parent:
             self._parent._update_world_transform()
 
-            # Apply parent transform
             scaled_pos = Vector2(
                 self._local_position.x * self._parent._world_scale.x,
                 self._local_position.y * self._parent._world_scale.y,
@@ -324,7 +450,7 @@ class Transform(BaseComponent):
         self._is_dirty = False
 
     def __repr__(self) -> str:
-        """Return string representation of the transform."""
+        """Return a debug representation with degrees for readability."""
         return (
             f"Transform(pos={self.position}, "
             f"rot={math.degrees(self.rotation):.1f}°, "

--- a/pyguara/common/constants.py
+++ b/pyguara/common/constants.py
@@ -1,1 +1,0 @@
-"""General purpose constants Definition."""

--- a/pyguara/common/palette.py
+++ b/pyguara/common/palette.py
@@ -1,43 +1,39 @@
-"""
-Standard color definitions for Engine utilities and Debugging.
+"""Named colours for engine utilities and debug drawing.
 
-This module provides quick access to common colors.
-For game-specific artistic palettes, prefer loading them as Resources.
+`BasicColors` re-exports the constants defined on `Color` itself, so the two
+spellings can never drift apart. For game-specific artistic palettes, load a
+palette as a resource instead of extending these.
 """
 
 from pyguara.common.types import Color
 
 
 class BasicColors:
-    """Standard CSS/HTML colors for rapid prototyping."""
+    """Standard colours for rapid prototyping."""
 
-    WHITE = Color(255, 255, 255)
-    BLACK = Color(0, 0, 0)
-    TRANSPARENT = Color(0, 0, 0, 0)
+    WHITE = Color.WHITE
+    BLACK = Color.BLACK
+    TRANSPARENT = Color.TRANSPARENT
 
-    RED = Color(255, 0, 0)
-    GREEN = Color(0, 255, 0)
-    BLUE = Color(0, 0, 255)
-    YELLOW = Color(255, 255, 0)
-    CYAN = Color(0, 255, 255)
-    MAGENTA = Color(255, 0, 255)
+    RED = Color.RED
+    GREEN = Color.GREEN
+    BLUE = Color.BLUE
+    YELLOW = Color.YELLOW
+    CYAN = Color.CYAN
+    MAGENTA = Color.MAGENTA
 
 
 class DebugColors:
+    """Semantic colours for the engine's debug visualisation.
+
+    Most are semi-transparent so the game stays visible behind debug shapes.
     """
-    Semantic colors for the Engine's debug visualization system.
 
-    Using semi-transparency allows seeing the game behind the debug shapes.
-    """
+    COLLIDER_ACTIVE = Color(0, 255, 0, 150)
+    COLLIDER_SLEEPING = Color(128, 128, 128, 150)
+    COLLIDER_CONTACT = Color(255, 0, 0, 180)
 
-    # Physics
-    COLLIDER_ACTIVE = Color(0, 255, 0, 150)  # Green: Safe/Active
-    COLLIDER_SLEEPING = Color(128, 128, 128, 150)  # Gray: Sleeping body
-    COLLIDER_CONTACT = Color(255, 0, 0, 180)  # Red: Collision happening
+    RAYCAST = Color(255, 255, 0)
+    PATHFINDING = Color(0, 255, 255, 100)
 
-    # Logic
-    RAYCAST = Color(255, 255, 0)  # Yellow Line
-    PATHFINDING = Color(0, 255, 255, 100)  # Cyan Path
-
-    # UI Bounds
-    UI_BORDER = Color(255, 0, 255)  # Magenta Rect
+    UI_BORDER = Color(255, 0, 255)

--- a/pyguara/common/types.py
+++ b/pyguara/common/types.py
@@ -1,237 +1,246 @@
-"""
-Common data structures and mathematical primitives for the pyGuara engine.
+"""Foundational value types for the PyGuara engine.
 
-This module provides the foundational types (Vector2, Color, Rect) used throughout
-the engine. `Vector2` inherits from `pymunk.Vec2d` for C-optimized physics math.
-`Color` and `Rect` are plain, backend-agnostic dataclasses -- neither pygame nor
-ModernGL is a dependency of this module. Conversion to a backend's native types
-(e.g. `pygame.Color`/`pygame.Rect`) happens only at that backend's boundary.
+`Vector2`, `Color` and `Rect` are the primitives every other subsystem shares.
+
+`Vector2` subclasses `pymunk.Vec2d` for C-optimised math and to pass into the
+physics backend without conversion. `Color` and `Rect` are plain dataclasses
+with no backend dependency -- neither pygame nor ModernGL is imported here.
+Conversion to a backend's native types happens only at that backend's
+boundary, in `graphics/backends/pygame/conversions.py`.
+
+Axis convention:
+    Y increases downwards, matching SDL, pygame and the engine's own default
+    gravity (`PhysicsConfig.gravity_y` is positive for a platformer). "Up" is
+    therefore negative Y. Every direction helper in this module and in
+    `Transform` follows that convention.
 """
 
 from __future__ import annotations
+
 import colorsys
 import math
 from dataclasses import dataclass
-from typing import ClassVar, Union, Tuple, List, Any
+from typing import Any, ClassVar
 
 import pymunk
 
-# Type alias for coordinates to allow flexibility in inputs
-Coordinate = Union[Tuple[float, float], List[float], pymunk.Vec2d]
+Coordinate = tuple[float, float] | list[float] | pymunk.Vec2d
+"""Anything accepted where a 2D coordinate is expected."""
+
+_CHANNEL_MIN = 0
+_CHANNEL_MAX = 255
 
 
 class Vector2(pymunk.Vec2d):
-    """
-    A 2D column vector used for positions, velocities, and physics.
+    """An immutable 2D vector for positions, velocities and directions.
 
-    Inherits from `pymunk.Vec2d` to utilize C-optimized math operations essential
-    for the physics engine. It standardizes method names to avoid leaking
-    Pymunk-specific naming (like `cpvrotate`) into the game logic.
+    Subclasses `pymunk.Vec2d` for C-optimised math, overriding the operators
+    and transforms so they return `Vector2` rather than `Vec2d`, and renaming
+    Pymunk-specific spellings so they do not leak into game code.
+
+    Being a `NamedTuple` subclass, a `Vector2` is immutable and hashable:
+    every method here returns a new vector rather than mutating in place.
 
     Attributes:
-        x (float): The X component.
-        y (float): The Y component.
+        x: The X component.
+        y: The Y component, increasing downwards.
     """
 
     @property
     def magnitude(self) -> float:
-        """
-        Get the length (magnitude) of the vector.
-
-        Returns:
-            float: The length of the vector.
-        """
+        """The length of the vector."""
         return float(self.length)
 
     @property
     def sqr_magnitude(self) -> float:
-        """
-        Get the squared length of the vector.
+        """The squared length of the vector.
 
-        Faster than magnitude() as it avoids the square root calculation.
-        Useful for distance comparisons.
-
-        Returns:
-            float: The squared length.
+        Avoids the square root in `magnitude`, so prefer it when comparing
+        distances rather than needing a real one.
         """
         return float(self.x * self.x + self.y * self.y)
 
-    # --- Operator Overloads (Fixing Return Types) ---
-
     def __add__(self, other: Any) -> Vector2:
-        """Vector addition."""
+        """Add another vector or coordinate pair."""
         if hasattr(other, "x") and hasattr(other, "y"):
             return Vector2(self.x + other.x, self.y + other.y)
         v = super().__add__(other)
         return Vector2(v.x, v.y)
 
     def __sub__(self, other: Any) -> Vector2:
-        """Vector subtraction."""
+        """Subtract another vector or coordinate pair."""
         if hasattr(other, "x") and hasattr(other, "y"):
             return Vector2(self.x - other.x, self.y - other.y)
         v = super().__sub__(other)
         return Vector2(v.x, v.y)
 
     def __mul__(self, other: float) -> Vector2:  # type: ignore[override]
-        """Scalar multiplication (Vector * float)."""
-        # Ignored override because Tuple expects int (repetition), we want float (math)
+        """Scale by a scalar."""
+        # Overrides tuple.__mul__, which would repeat the tuple for an int.
         v = super().__mul__(other)
         return Vector2(v.x, v.y)
 
     def __rmul__(self, other: float) -> Vector2:  # type: ignore[override]
-        """Reverse scalar multiplication (float * Vector)."""
-        # Ignored override because Tuple expects int (repetition), we want float (math)
+        """Scale by a scalar, with the scalar on the left."""
         v = super().__rmul__(other)
         return Vector2(v.x, v.y)
 
     def __truediv__(self, other: float) -> Vector2:
-        """Scalar division (Vector / float)."""
+        """Divide by a scalar.
+
+        Raises:
+            ZeroDivisionError: If `other` is zero.
+        """
         v = super().__truediv__(other)
         return Vector2(v.x, v.y)
 
     def __neg__(self) -> Vector2:
-        """Negation (-Vector)."""
+        """Return the vector pointing the opposite way."""
         return Vector2(-self.x, -self.y)
 
     def dot(self, other: Any) -> float:
-        """
-        Dot product.
+        """Return the dot product with another vector or coordinate pair.
 
-        Accepts Any (tuples or Vectors) to satisfy LSP against pymunk.Vec2d.
+        Args:
+            other: Any object with `x` and `y`, or a coordinate pair. Typed
+                loosely to stay substitutable for `pymunk.Vec2d.dot`.
+
+        Returns:
+            The scalar dot product.
         """
         return float(super().dot(other))
 
     def cross(self, other: Any) -> float:
-        """
-        Cross product / Determinant.
+        """Return the 2D cross product (determinant) with another vector.
 
-        Accepts Any (tuples or Vectors) to satisfy LSP against pymunk.Vec2d.
+        Args:
+            other: Any object with `x` and `y`, or a coordinate pair.
+
+        Returns:
+            The scalar cross product.
         """
         return float(super().cross(other))
 
     def normalize(self) -> Vector2:
-        """
-        Return a new vector with the same direction but length of 1.0.
+        """Return a unit vector in the same direction.
 
         Returns:
-            Vector2: The normalized vector.
+            The normalised vector, or a zero vector if this one has no length.
         """
-        # We cast the result back to Vector2 to maintain type consistency
         v = super().normalized()
         return Vector2(v.x, v.y)
 
     def rotated(self, angle_radians: float) -> Vector2:
-        """
-        Return a new vector rotated by the given angle in radians.
-
-        Overrides pymunk.Vec2d.rotated to ensure Vector2 return type.
+        """Return this vector rotated by an angle in **radians**.
 
         Args:
-            angle_radians (float): Rotation angle in radians.
+            angle_radians: Rotation angle in radians.
 
         Returns:
-            Vector2: The rotated vector.
+            The rotated vector.
         """
         v = super().rotated(angle_radians)
         return Vector2(v.x, v.y)
 
-    def rotate(self, angle_degrees: float) -> Vector2:
-        """
-        Return a new vector rotated by the given angle.
+    def rotate_degrees(self, angle_degrees: float) -> Vector2:
+        """Return this vector rotated by an angle in **degrees**.
+
+        Named explicitly rather than `rotate`: a bare `rotate`/`rotated` pair
+        differing only in angle unit is impossible to read correctly at a call
+        site, and `Transform.rotate()` takes radians.
 
         Args:
-            angle_degrees (float): The angle to rotate by, in degrees.
+            angle_degrees: Rotation angle in degrees.
 
         Returns:
-            Vector2: The rotated vector.
+            The rotated vector.
         """
         return self.rotated(math.radians(angle_degrees))
 
     def distance_to(self, other: Vector2) -> float:
-        """
-        Calculate the distance between this vector and another.
+        """Return the distance to another point.
 
         Args:
-            other (Vector2): The target vector.
+            other: The target point.
 
         Returns:
-            float: The distance between the points.
+            The straight-line distance.
         """
         return float(self.get_distance(other))
 
     def lerp(self, target: Vector2, t: float) -> Vector2:
-        """
-        Linearly interpolate between this vector and the target.
+        """Linearly interpolate towards a target.
+
+        `t` is not clamped, so values outside 0..1 extrapolate.
 
         Args:
-            target (Vector2): The end vector.
-            t (float): The interpolation factor (0.0 to 1.0).
+            target: The end point.
+            t: Interpolation factor, 0.0 at self and 1.0 at target.
 
         Returns:
-            Vector2: A new vector representing the interpolated position.
+            The interpolated point.
         """
-        # Helper implementation since Pymunk's interpolate can be obscure
-        x = self.x + (target.x - self.x) * t
-        y = self.y + (target.y - self.y) * t
-        return Vector2(x, y)
+        return Vector2(
+            self.x + (target.x - self.x) * t,
+            self.y + (target.y - self.y) * t,
+        )
 
-    def to_tuple(self) -> Tuple[float, float]:
-        """
-        Convert the vector to a standard Python float tuple.
-
-        Returns:
-            Tuple[float, float]: (x, y)
-        """
+    def to_tuple(self) -> tuple[float, float]:
+        """Return the components as a plain float tuple."""
         return (self.x, self.y)
 
-    def to_int_tuple(self) -> Tuple[int, int]:
-        """
-        Convert the vector to an integer tuple.
+    def to_int_tuple(self) -> tuple[int, int]:
+        """Return the components truncated to a plain int tuple.
 
-        Essential for pixel-perfect rendering calls in Pygame which
-        do not accept floats.
-
-        Returns:
-            Tuple[int, int]: (int(x), int(y))
+        Truncates towards zero, matching how pygame treats float coordinates.
         """
         return (int(self.x), int(self.y))
 
     @staticmethod
     def zero() -> Vector2:
-        """Return a Vector2(0, 0)."""
+        """Return `(0, 0)`."""
         return Vector2(0, 0)
 
     @staticmethod
     def one() -> Vector2:
-        """Return a Vector2(1, 1)."""
+        """Return `(1, 1)`."""
         return Vector2(1, 1)
 
     @staticmethod
     def up() -> Vector2:
-        """Return a Vector2(0, -1). Note: Y is down in Pygame/SDL."""
+        """Return `(0, -1)`. Y increases downwards, so up is negative."""
         return Vector2(0, -1)
 
     @staticmethod
+    def down() -> Vector2:
+        """Return `(0, 1)`. Y increases downwards, so down is positive."""
+        return Vector2(0, 1)
+
+    @staticmethod
+    def left() -> Vector2:
+        """Return `(-1, 0)`."""
+        return Vector2(-1, 0)
+
+    @staticmethod
     def right() -> Vector2:
-        """Return a Vector2(1, 0)."""
+        """Return `(1, 0)`."""
         return Vector2(1, 0)
 
 
 @dataclass(slots=True)
 class Color:
-    """
-    A container for RGBA color values (0-255 per channel).
+    """An RGBA colour, one byte per channel.
 
-    A plain, backend-agnostic value type -- no longer a `pygame.Color`
-    subclass (wayfinder ticket 31), so ModernGL never has to touch pygame to
-    represent a color. Only the pygame backend ever constructs a real
-    `pygame.Color`, via `graphics/backends/pygame/conversions.py`.
+    A backend-agnostic value type. Channels are coerced to `int` and clamped
+    to 0-255 on construction, so colour arithmetic that overshoots -- a fade,
+    a brightness multiplier, an out-of-range HSV conversion -- saturates
+    instead of handing a backend a value it cannot represent.
 
     Attributes:
-        r (int): Red channel, 0-255.
-        g (int): Green channel, 0-255.
-        b (int): Blue channel, 0-255.
-        a (int): Alpha channel, 0-255. Defaults to fully opaque.
+        r: Red channel, 0-255.
+        g: Green channel, 0-255.
+        b: Blue channel, 0-255.
+        a: Alpha channel, 0-255. Defaults to fully opaque.
     """
 
     r: int
@@ -239,11 +248,9 @@ class Color:
     b: int
     a: int = 255
 
-    # Common named colors -- assigned after the class body below, since a
-    # dataclass can't reference its own not-yet-defined type in its class
-    # body. Declared here (ClassVar, so the dataclass doesn't treat them as
-    # instance fields) purely for parity with Rect's added surface; no
-    # in-repo caller uses them yet.
+    # Assigned below the class body: a dataclass cannot reference its own
+    # not-yet-defined type from inside it. ClassVar keeps them off the
+    # generated __init__.
     WHITE: ClassVar[Color]
     BLACK: ClassVar[Color]
     RED: ClassVar[Color]
@@ -254,20 +261,26 @@ class Color:
     MAGENTA: ClassVar[Color]
     TRANSPARENT: ClassVar[Color]
 
+    def __post_init__(self) -> None:
+        """Coerce every channel to an int within 0-255."""
+        self.r = _clamp_channel(self.r)
+        self.g = _clamp_channel(self.g)
+        self.b = _clamp_channel(self.b)
+        self.a = _clamp_channel(self.a)
+
     @staticmethod
     def from_hex(hex_str: str) -> Color:
-        """
-        Create a Color object from a hex string.
+        """Parse a colour from a hex string.
 
         Args:
-            hex_str (str): A string like "#FF00AA", "0xFF00AA", or with an
-                optional alpha pair ("#FF00AAFF").
+            hex_str: A string such as `"#FF00AA"`, `"0xFF00AA"`, or with an
+                alpha pair, `"#FF00AAFF"`.
 
         Returns:
-            Color: The parsed color object.
+            The parsed colour.
 
         Raises:
-            ValueError: If the string isn't a valid 6 or 8-digit hex color.
+            ValueError: If the string is not a valid 6- or 8-digit hex colour.
         """
         s = hex_str.strip()
         if s.startswith("#"):
@@ -275,36 +288,43 @@ class Color:
         elif s.startswith(("0x", "0X")):
             s = s[2:]
 
-        if len(s) == 6:
-            return Color(int(s[0:2], 16), int(s[2:4], 16), int(s[4:6], 16))
-        if len(s) == 8:
-            return Color(
-                int(s[0:2], 16), int(s[2:4], 16), int(s[4:6], 16), int(s[6:8], 16)
-            )
+        try:
+            if len(s) == 6:
+                return Color(int(s[0:2], 16), int(s[2:4], 16), int(s[4:6], 16))
+            if len(s) == 8:
+                return Color(
+                    int(s[0:2], 16), int(s[2:4], 16), int(s[4:6], 16), int(s[6:8], 16)
+                )
+        except ValueError:
+            raise ValueError(f"Invalid hex color string: {hex_str!r}") from None
         raise ValueError(f"Invalid hex color string: {hex_str!r}")
 
-    @property
-    def normalized(self) -> Tuple[float, float, float, float]:
-        """
-        Get the RGBA values normalized to the 0.0 - 1.0 range.
+    def to_hex(self, include_alpha: bool = False) -> str:
+        """Format the colour as a `#RRGGBB` string.
 
-        Useful for integration with shaders or OpenGL backends.
+        Args:
+            include_alpha: Append the alpha pair, giving `#RRGGBBAA`.
 
         Returns:
-            Tuple[float, float, float, float]: (r, g, b, a) as floats.
+            The hex string, upper case.
         """
+        base = f"#{self.r:02X}{self.g:02X}{self.b:02X}"
+        return f"{base}{self.a:02X}" if include_alpha else base
+
+    @property
+    def normalized(self) -> tuple[float, float, float, float]:
+        """The channels as floats in 0.0-1.0, for shaders and GL backends."""
         return (self.r / 255.0, self.g / 255.0, self.b / 255.0, self.a / 255.0)
 
     def lerp(self, target: Color, t: float) -> Color:
-        """
-        Linearly interpolate this color towards a target color.
+        """Linearly interpolate towards another colour.
 
         Args:
-            target (Color): The destination color.
-            t (float): Interpolation factor (0.0 to 1.0).
+            target: The destination colour.
+            t: Interpolation factor, clamped to 0.0-1.0.
 
         Returns:
-            Color: The blended color.
+            The blended colour.
         """
         t = max(0.0, min(1.0, t))
         return Color(
@@ -314,40 +334,50 @@ class Color:
             round(self.a + (target.a - self.a) * t),
         )
 
-    def to_hsv(self) -> Tuple[float, float, float]:
-        """
-        Convert to HSV.
+    def to_hsv(self) -> tuple[float, float, float]:
+        """Convert to HSV, discarding alpha.
 
         Returns:
-            Tuple[float, float, float]: (hue in 0-360, saturation 0-1, value 0-1).
+            `(hue in 0-360, saturation in 0-1, value in 0-1)`.
         """
         h, s, v = colorsys.rgb_to_hsv(self.r / 255.0, self.g / 255.0, self.b / 255.0)
         return (h * 360.0, s, v)
 
     @staticmethod
     def from_hsv(hue: float, saturation: float, value: float, a: int = 255) -> Color:
-        """
-        Create a Color from HSV components.
+        """Build a colour from HSV components.
 
         Args:
-            hue (float): Hue in degrees (0-360).
-            saturation (float): Saturation (0.0-1.0).
-            value (float): Value/brightness (0.0-1.0).
-            a (int): Alpha channel, 0-255.
+            hue: Hue in degrees; wraps at 360.
+            saturation: Saturation in 0.0-1.0.
+            value: Brightness in 0.0-1.0.
+            a: Alpha channel, 0-255.
 
         Returns:
-            Color: The resulting RGB color.
+            The resulting colour, with channels clamped to 0-255.
         """
         r, g, b = colorsys.hsv_to_rgb((hue % 360.0) / 360.0, saturation, value)
         return Color(round(r * 255), round(g * 255), round(b * 255), a)
 
     def __getitem__(self, index: int) -> int:
-        """Support tuple-like indexing (color[0] == r, ..., color[3] == a)."""
+        """Return a channel by index, ordered r, g, b, a."""
         return (self.r, self.g, self.b, self.a)[index]
 
     def __len__(self) -> int:
-        """Return 4, the number of channels (r, g, b, a)."""
+        """Return 4, the number of channels."""
         return 4
+
+
+def _clamp_channel(value: float) -> int:
+    """Coerce a channel value to an int within 0-255.
+
+    Args:
+        value: The raw channel value.
+
+    Returns:
+        The truncated, clamped channel.
+    """
+    return max(_CHANNEL_MIN, min(_CHANNEL_MAX, int(value)))
 
 
 Color.WHITE = Color(255, 255, 255)
@@ -363,20 +393,16 @@ Color.TRANSPARENT = Color(0, 0, 0, 0)
 
 @dataclass(slots=True)
 class Rect:
-    """
-    A 2D Rectangle defined by position (x, y) and size (width, height).
+    """An axis-aligned rectangle in integer pixel coordinates.
 
-    A plain, backend-agnostic value type -- no longer a `pygame.Rect`
-    subclass (wayfinder ticket 31). Only the pygame backend ever constructs
-    a real `pygame.Rect`, via `graphics/backends/pygame/conversions.py`.
-    Mutable, matching pygame.Rect's own semantics -- in-place assignment
-    (`rect.x = 5`) stays legal, which the UI layout engine relies on.
+    A backend-agnostic value type. Mutable, matching `pygame.Rect`, because
+    the UI layout engine assigns to `rect.x` and friends in place.
 
     Attributes:
-        x (int): Left position.
-        y (int): Top position.
-        width (int): Rectangle width.
-        height (int): Rectangle height.
+        x: Left position.
+        y: Top position.
+        width: Width in pixels.
+        height: Height in pixels.
     """
 
     x: int
@@ -385,11 +411,10 @@ class Rect:
     height: int
 
     def __post_init__(self) -> None:
-        """Truncate to int, matching pygame.Rect's own coordinate semantics.
+        """Truncate the fields to int, as `pygame.Rect` always did.
 
-        Several call sites construct a Rect directly from Vector2
-        components (floats) without an explicit `int()` cast, relying on
-        this truncation exactly as pygame.Rect always performed it.
+        Several call sites build a Rect straight from `Vector2` components
+        without an explicit cast and rely on this.
         """
         self.x = int(self.x)
         self.y = int(self.y)
@@ -398,77 +423,73 @@ class Rect:
 
     @property
     def left(self) -> int:
-        """Get the left edge (alias for x)."""
+        """The left edge; an alias for `x`."""
         return self.x
 
     @property
     def top(self) -> int:
-        """Get the top edge (alias for y)."""
+        """The top edge; an alias for `y`."""
         return self.y
 
     @property
     def right(self) -> int:
-        """Get the right edge (x + width)."""
+        """The right edge, `x + width`."""
         return self.x + self.width
 
     @property
     def bottom(self) -> int:
-        """Get the bottom edge (y + height)."""
+        """The bottom edge, `y + height`."""
         return self.y + self.height
 
     @property
     def centerx(self) -> int:
-        """Get the horizontal center."""
+        """The horizontal centre."""
         return self.x + self.width // 2
 
     @property
     def centery(self) -> int:
-        """Get the vertical center."""
+        """The vertical centre."""
         return self.y + self.height // 2
 
     @property
     def position(self) -> Vector2:
-        """
-        Get the top-left position as a Vector2.
-
-        Returns:
-            Vector2: The (x, y) coordinates.
-        """
+        """The top-left corner as a vector."""
         return Vector2(self.x, self.y)
 
     @property
     def center_vec(self) -> Vector2:
-        """
-        Get the center point as a Vector2.
-
-        Returns:
-            Vector2: The (center_x, center_y) coordinates.
-        """
+        """The centre point as a vector."""
         return Vector2(self.centerx, self.centery)
 
-    def contains_point(self, point: Vector2) -> bool:
-        """
-        Check if a vector point is inside this rectangle.
+    @property
+    def size(self) -> tuple[int, int]:
+        """The `(width, height)` pair."""
+        return (self.width, self.height)
 
-        Right/bottom edges are exclusive, matching pygame.Rect.collidepoint.
+    def contains_point(self, point: Vector2) -> bool:
+        """Report whether a point falls inside this rectangle.
+
+        Right and bottom edges are exclusive, matching
+        `pygame.Rect.collidepoint`.
 
         Args:
-            point (Vector2): The point to check.
+            point: The point to test.
 
         Returns:
-            bool: True if inside, False otherwise.
+            True if the point is inside.
         """
         return self.left <= point.x < self.right and self.top <= point.y < self.bottom
 
     def colliderect(self, other: Rect) -> bool:
-        """
-        Check if this rectangle overlaps another.
+        """Report whether this rectangle overlaps another.
+
+        Touching edges do not count as an overlap.
 
         Args:
-            other (Rect): The other rectangle.
+            other: The rectangle to test against.
 
         Returns:
-            bool: True if the two rectangles overlap at all.
+            True if the two rectangles overlap.
         """
         return (
             self.left < other.right
@@ -478,14 +499,13 @@ class Rect:
         )
 
     def contains(self, other: Rect) -> bool:
-        """
-        Check if another rectangle is entirely within this one.
+        """Report whether another rectangle lies entirely within this one.
 
         Args:
-            other (Rect): The candidate rectangle.
+            other: The candidate rectangle.
 
         Returns:
-            bool: True if `other` is completely inside this rectangle.
+            True if `other` is fully inside, edges inclusive.
         """
         return (
             self.left <= other.left
@@ -495,16 +515,22 @@ class Rect:
         )
 
     def inflate(self, dx: int, dy: int) -> Rect:
-        """
-        Return a new Rect grown (or shrunk) by dx/dy, keeping the same center.
+        """Return a copy grown by `dx`/`dy`, keeping the same centre.
+
+        Negative deltas shrink. The offset truncates towards zero rather than
+        flooring, so odd negative deltas land where `pygame.Rect.inflate`
+        puts them.
 
         Args:
-            dx (int): Amount to grow the width by (split evenly on each side).
-            dy (int): Amount to grow the height by (split evenly top/bottom).
+            dx: Amount to grow the width by, split across both sides.
+            dy: Amount to grow the height by, split across top and bottom.
 
         Returns:
-            Rect: The new, resized rectangle.
+            The resized rectangle.
         """
         return Rect(
-            self.x - dx // 2, self.y - dy // 2, self.width + dx, self.height + dy
+            self.x - int(dx / 2),
+            self.y - int(dy / 2),
+            self.width + dx,
+            self.height + dy,
         )

--- a/pyguara/graphics/components/camera.py
+++ b/pyguara/graphics/components/camera.py
@@ -198,7 +198,7 @@ class Camera2D:
 
         # 3. Rotate (around camera center)
         if self.rotation != 0:
-            local_pos = local_pos.rotate(-self.rotation)
+            local_pos = local_pos.rotate_degrees(-self.rotation)
 
         screen_pos = local_pos + self.offset
 
@@ -223,7 +223,7 @@ class Camera2D:
 
         # 2. Inverse Rotate
         if self.rotation != 0:
-            local_pos = local_pos.rotate(self.rotation)
+            local_pos = local_pos.rotate_degrees(self.rotation)
 
         # 3. Inverse Scale
         # Avoid division by zero

--- a/pyguara/graphics/components/particles.py
+++ b/pyguara/graphics/components/particles.py
@@ -157,7 +157,7 @@ class ParticleSystem:
 
                 # Random Velocity Calculation
                 angle = random.uniform(0, spread)
-                direction = Vector2(1, 0).rotate(angle)
+                direction = Vector2.right().rotate_degrees(angle)
                 random_velocity = direction * random.uniform(speed * 0.5, speed * 1.5)
                 p.velocity = random_velocity
 

--- a/tests/test_common_types.py
+++ b/tests/test_common_types.py
@@ -115,3 +115,162 @@ class TestRect:
         inflated = r.inflate(4, 4)
         assert inflated == Rect(8, 8, 14, 14)
         assert inflated.center_vec == r.center_vec
+
+
+class TestColorChannelClamping:
+    """Channels are coerced and clamped, as Rect's coordinates already were.
+
+    Color stopped being a pygame.Color subclass (which validated its own
+    range) and gained no replacement, so out-of-range values propagated
+    silently all the way to the backend.
+    """
+
+    def test_channels_above_range_saturate(self) -> None:
+        assert Color(300, 256, 999) == Color(255, 255, 255)
+
+    def test_channels_below_range_clamp_to_zero(self) -> None:
+        assert Color(-5, -1, -999, -3) == Color(0, 0, 0, 0)
+
+    def test_float_channels_are_coerced_to_int(self) -> None:
+        c = Color(1.9, 2.1, 3.5)  # type: ignore[arg-type]
+        assert (c.r, c.g, c.b) == (1, 2, 3)
+        assert all(isinstance(v, int) for v in (c.r, c.g, c.b))
+
+    def test_out_of_range_hsv_saturates_instead_of_producing_garbage(self) -> None:
+        """from_hsv with saturation/value > 1 used to yield Color(1275, -5100, -5100)."""
+        assert Color.from_hsv(0, 5, 5) == Color(255, 0, 0)
+
+    def test_lerp_result_stays_in_range(self) -> None:
+        assert Color(0, 0, 0).lerp(Color(255, 255, 255), 0.5) == Color(128, 128, 128)
+
+    def test_normalized_never_exceeds_one(self) -> None:
+        assert Color(999, 999, 999, 999).normalized == (1.0, 1.0, 1.0, 1.0)
+
+
+class TestColorHex:
+    def test_to_hex_round_trips(self) -> None:
+        assert Color.from_hex(Color(255, 0, 170).to_hex()) == Color(255, 0, 170)
+
+    def test_to_hex_with_alpha(self) -> None:
+        assert Color(255, 0, 170, 128).to_hex(include_alpha=True) == "#FF00AA80"
+
+    def test_from_hex_rejects_non_hex_digits(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="Invalid hex color"):
+            Color.from_hex("#GGHHII")
+
+
+class TestRectInflate:
+    def test_inflate_matches_pygame_for_odd_negative_deltas(self) -> None:
+        """Floor division put the origin at 3; pygame truncates towards zero,
+        giving 2. Rect exists to stand in for pygame.Rect, so it must agree."""
+        assert Rect(0, 0, 10, 10).inflate(-5, -5) == Rect(2, 2, 5, 5)
+
+    def test_inflate_grows_keeping_center(self) -> None:
+        r = Rect(10, 10, 10, 10)
+        assert r.inflate(4, 4).center_vec == r.center_vec
+
+    def test_size(self) -> None:
+        assert Rect(1, 2, 30, 40).size == (30, 40)
+
+
+class TestVector2Arithmetic:
+    def test_add_and_subtract_return_vector2(self) -> None:
+        result = Vector2(1, 2) + Vector2(3, 4)
+        assert result == Vector2(4, 6)
+        assert isinstance(result, Vector2)
+        assert isinstance(Vector2(1, 2) - Vector2(3, 4), Vector2)
+
+    def test_scalar_multiplication_both_sides(self) -> None:
+        assert Vector2(1, 2) * 3 == Vector2(3, 6)
+        assert 3 * Vector2(1, 2) == Vector2(3, 6)
+        assert isinstance(3 * Vector2(1, 2), Vector2)
+
+    def test_scalar_multiplication_does_not_repeat_the_tuple(self) -> None:
+        """tuple.__mul__ would turn v * 3 into a 6-element tuple."""
+        assert len(Vector2(1, 2) * 3) == 2
+
+    def test_division_and_negation(self) -> None:
+        assert Vector2(4, 6) / 2 == Vector2(2, 3)
+        assert -Vector2(1, -2) == Vector2(-1, 2)
+
+    def test_addition_accepts_a_plain_tuple(self) -> None:
+        assert Vector2(1, 2) + (3, 4) == Vector2(4, 6)
+
+    def test_vector_is_immutable(self) -> None:
+        import pytest
+
+        with pytest.raises(AttributeError):
+            Vector2(1, 2).x = 5  # type: ignore[misc]
+
+
+class TestVector2Geometry:
+    def test_magnitude_and_sqr_magnitude(self) -> None:
+        assert Vector2(3, 4).magnitude == 5.0
+        assert Vector2(3, 4).sqr_magnitude == 25.0
+
+    def test_normalize_gives_unit_length(self) -> None:
+        assert Vector2(3, 4).normalize() == Vector2(0.6, 0.8)
+
+    def test_normalize_of_zero_vector_does_not_raise(self) -> None:
+        assert Vector2(0, 0).normalize() == Vector2(0, 0)
+
+    def test_dot_and_cross(self) -> None:
+        assert Vector2(1, 0).dot(Vector2(0, 1)) == 0.0
+        assert Vector2(1, 0).cross(Vector2(0, 1)) == 1.0
+
+    def test_distance_to(self) -> None:
+        assert Vector2(0, 0).distance_to(Vector2(3, 4)) == 5.0
+
+    def test_lerp_endpoints_and_midpoint(self) -> None:
+        a, b = Vector2(0, 0), Vector2(10, 20)
+        assert a.lerp(b, 0.0) == a
+        assert a.lerp(b, 1.0) == b
+        assert a.lerp(b, 0.5) == Vector2(5, 10)
+
+    def test_to_tuple_and_to_int_tuple(self) -> None:
+        assert Vector2(1.7, -2.7).to_tuple() == (1.7, -2.7)
+        assert Vector2(1.7, -2.7).to_int_tuple() == (1, -2)
+
+
+class TestVector2Rotation:
+    def test_rotated_takes_radians(self) -> None:
+        import math
+
+        result = Vector2(1, 0).rotated(math.pi / 2)
+        assert abs(result.x) < 1e-9
+        assert abs(result.y - 1.0) < 1e-9
+
+    def test_rotate_degrees_takes_degrees(self) -> None:
+        result = Vector2(1, 0).rotate_degrees(90)
+        assert abs(result.x) < 1e-9
+        assert abs(result.y - 1.0) < 1e-9
+
+    def test_rotate_is_gone_so_the_unit_cannot_be_confused(self) -> None:
+        """`rotate` (degrees) sat next to `rotated` (radians), and
+        Transform.rotate() takes radians. A one-letter difference deciding the
+        angle unit is unreadable at a call site, so the ambiguous name was
+        removed rather than documented."""
+        assert not hasattr(Vector2(1, 0), "rotate")
+
+    def test_rotation_preserves_length(self) -> None:
+        assert abs(Vector2(3, 4).rotate_degrees(37).magnitude - 5.0) < 1e-9
+
+
+class TestVector2Directions:
+    def test_axis_convention_is_y_down(self) -> None:
+        """Y grows downwards (SDL/pygame, and the engine's positive default
+        gravity), so up is negative Y."""
+        assert Vector2.up() == Vector2(0, -1)
+        assert Vector2.down() == Vector2(0, 1)
+        assert Vector2.left() == Vector2(-1, 0)
+        assert Vector2.right() == Vector2(1, 0)
+
+    def test_opposites_cancel(self) -> None:
+        assert Vector2.up() + Vector2.down() == Vector2.zero()
+        assert Vector2.left() + Vector2.right() == Vector2.zero()
+
+    def test_zero_and_one(self) -> None:
+        assert Vector2.zero() == Vector2(0, 0)
+        assert Vector2.one() == Vector2(1, 1)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,309 @@
+"""Behavioural tests for the Transform component.
+
+Transform carries the most intricate logic in `pyguara/common` -- a parent
+hierarchy, lazily rebuilt world caches, and local/world coordinate conversion
+-- and had no dedicated tests before this file. It appeared in ten other test
+modules only as an incidental fixture, so the hierarchy math itself was
+exercised almost entirely by accident.
+"""
+
+import math
+
+import pytest
+
+from pyguara.common.components import ResourceLink, Tag, Transform
+from pyguara.common.types import Vector2
+
+
+def assert_vec(actual: Vector2, expected: tuple[float, float], tol: float = 1e-9):
+    assert abs(actual.x - expected[0]) < tol, f"{actual} != {expected}"
+    assert abs(actual.y - expected[1]) < tol, f"{actual} != {expected}"
+
+
+class TestTransformDefaults:
+    def test_defaults_to_origin_no_rotation_unit_scale(self) -> None:
+        t = Transform()
+        assert t.position == Vector2(0, 0)
+        assert t.rotation == 0.0
+        assert t.scale == Vector2(1, 1)
+        assert t.parent is None
+
+    def test_rotation_degrees_mirrors_rotation(self) -> None:
+        t = Transform()
+        t.rotation_degrees = 180
+        assert abs(t.rotation - math.pi) < 1e-9
+        t.rotation = math.pi / 2
+        assert abs(t.rotation_degrees - 90) < 1e-9
+
+    def test_rotate_takes_radians(self) -> None:
+        """Transform.rotate() is radians while the old Vector2.rotate() was
+        degrees; the unit is asserted here so the two cannot silently swap."""
+        t = Transform()
+        t.rotate(math.pi)
+        assert abs(t.rotation_degrees - 180) < 1e-9
+
+
+class TestTransformDirections:
+    def test_up_is_negative_y_matching_vector2(self) -> None:
+        """Transform.up returned (0, 1) -- pointing *down* on screen, and the
+        exact opposite of Vector2.up(). Gravity defaults positive, so the
+        engine is unambiguously Y-down."""
+        assert_vec(Transform().up, (0, -1))
+        assert Transform().up == Vector2.up()
+
+    def test_all_four_directions_at_rest(self) -> None:
+        t = Transform()
+        assert_vec(t.right, (1, 0))
+        assert_vec(t.left, (-1, 0))
+        assert_vec(t.up, (0, -1))
+        assert_vec(t.down, (0, 1))
+
+    def test_directions_follow_world_rotation(self) -> None:
+        t = Transform(rotation=math.pi / 2)
+        assert_vec(t.right, (0, 1))
+        assert_vec(t.up, (1, 0))
+
+    def test_forward_is_right_and_look_at_agrees(self) -> None:
+        t = Transform(position=Vector2(0, 0))
+        t.look_at(Vector2(10, 0))
+        assert_vec(t.forward, (1, 0))
+        t.look_at(Vector2(0, 10))
+        assert_vec(t.forward, (0, 1))
+
+
+class TestTransformHierarchy:
+    def test_child_world_position_includes_parent_offset(self) -> None:
+        parent = Transform(position=Vector2(100, 50))
+        child = Transform(position=Vector2(10, 5))
+        child.set_parent(parent, keep_world_transform=False)
+        assert_vec(child.world_position, (110, 55))
+
+    def test_child_inherits_parent_rotation_and_scale(self) -> None:
+        parent = Transform(rotation=math.pi / 2, scale=Vector2(2, 2))
+        child = Transform(position=Vector2(1, 0))
+        child.set_parent(parent, keep_world_transform=False)
+
+        assert_vec(child.world_position, (0, 2))
+        assert abs(child.world_rotation - math.pi / 2) < 1e-9
+        assert_vec(child.world_scale, (2, 2))
+
+    def test_keep_world_transform_preserves_world_position(self) -> None:
+        parent = Transform(position=Vector2(100, 100))
+        child = Transform(position=Vector2(10, 10))
+
+        child.set_parent(parent, keep_world_transform=True)
+
+        assert_vec(child.world_position, (10, 10))
+        assert_vec(child.position, (-90, -90))
+
+    def test_detaching_preserves_world_position(self) -> None:
+        parent = Transform(position=Vector2(100, 100))
+        child = Transform(position=Vector2(10, 10))
+        child.set_parent(parent, keep_world_transform=False)
+        assert_vec(child.world_position, (110, 110))
+
+        child.set_parent(None, keep_world_transform=True)
+
+        assert child.parent is None
+        assert_vec(child.world_position, (110, 110))
+
+    def test_reparenting_removes_the_child_from_the_old_parent(self) -> None:
+        a, b = Transform(), Transform()
+        child = Transform()
+        child.set_parent(a)
+        child.set_parent(b)
+
+        assert a.children == []
+        assert b.children == [child]
+
+    def test_children_returns_a_snapshot_not_the_live_list(self) -> None:
+        parent = Transform()
+        Transform().set_parent(parent)
+        snapshot = parent.children
+        snapshot.clear()
+        assert len(parent.children) == 1
+
+    def test_setting_parent_to_the_current_parent_is_a_noop(self) -> None:
+        parent, child = Transform(), Transform()
+        child.set_parent(parent)
+        child.set_parent(parent)
+        assert parent.children == [child]
+
+    def test_three_level_chain_composes(self) -> None:
+        a = Transform(position=Vector2(100, 0))
+        b = Transform(position=Vector2(10, 0))
+        c = Transform(position=Vector2(1, 0))
+        b.set_parent(a, keep_world_transform=False)
+        c.set_parent(b, keep_world_transform=False)
+        assert_vec(c.world_position, (111, 0))
+
+
+class TestTransformCycles:
+    """set_parent() had no cycle guard: any loop turned every later world_*
+    read into unbounded recursion."""
+
+    def test_self_parenting_is_rejected(self) -> None:
+        t = Transform()
+        with pytest.raises(ValueError, match="itself or to one of its own"):
+            t.set_parent(t)
+        assert t.parent is None
+        assert t.children == []
+
+    def test_direct_cycle_is_rejected(self) -> None:
+        a, b = Transform(), Transform()
+        a.set_parent(b)
+        with pytest.raises(ValueError, match="descendants"):
+            b.set_parent(a)
+
+    def test_indirect_cycle_is_rejected(self) -> None:
+        a, b, c = Transform(), Transform(), Transform()
+        b.set_parent(a)
+        c.set_parent(b)
+        with pytest.raises(ValueError, match="descendants"):
+            a.set_parent(c)
+
+    def test_the_hierarchy_survives_a_rejected_cycle(self) -> None:
+        a, b = Transform(), Transform()
+        a.set_parent(b)
+        with pytest.raises(ValueError):
+            b.set_parent(a)
+
+        assert a.parent is b
+        assert b.parent is None
+        assert b.children == [a]
+        assert a.world_position == Vector2(0, 0)
+
+    def test_is_ancestor_of(self) -> None:
+        a, b, unrelated = Transform(), Transform(), Transform()
+        b.set_parent(a)
+        assert a.is_ancestor_of(b)
+        assert a.is_ancestor_of(a)
+        assert not b.is_ancestor_of(a)
+        assert not a.is_ancestor_of(unrelated)
+
+
+class TestTransformDirtyCaching:
+    def test_moving_a_parent_updates_child_world_position(self) -> None:
+        parent = Transform(position=Vector2(0, 0))
+        child = Transform(position=Vector2(10, 0))
+        child.set_parent(parent, keep_world_transform=False)
+        assert_vec(child.world_position, (10, 0))
+
+        parent.position = Vector2(100, 0)
+
+        assert_vec(child.world_position, (110, 0))
+
+    def test_moving_a_parent_updates_a_grandchild(self) -> None:
+        a, b, c = Transform(), Transform(), Transform()
+        b.set_parent(a, keep_world_transform=False)
+        c.set_parent(b, keep_world_transform=False)
+        c.position = Vector2(1, 0)
+        assert_vec(c.world_position, (1, 0))
+
+        a.position = Vector2(50, 0)
+
+        assert_vec(c.world_position, (51, 0))
+
+    def test_repeated_parent_moves_all_propagate(self) -> None:
+        """A dirty node stops _mark_dirty() recursing. That is only sound
+        because cleaning a node also cleans its ancestors, so a dirty node can
+        never have a clean descendant -- this walks that interleaving."""
+        parent, child = Transform(), Transform()
+        child.set_parent(parent, keep_world_transform=False)
+
+        for step in range(1, 4):
+            parent.position = Vector2(step * 10, 0)
+            assert_vec(child.world_position, (step * 10, 0))
+            parent.position = Vector2(step * 10 + 1, 0)
+            assert_vec(parent.world_position, (step * 10 + 1, 0))
+            assert_vec(child.world_position, (step * 10 + 1, 0))
+
+    def test_rotating_a_parent_updates_child_world_rotation(self) -> None:
+        parent, child = Transform(), Transform()
+        child.set_parent(parent, keep_world_transform=False)
+        assert child.world_rotation == 0.0
+
+        parent.rotation = math.pi
+
+        assert abs(child.world_rotation - math.pi) < 1e-9
+
+
+class TestTransformCoordinateConversion:
+    def test_local_to_world_round_trips(self) -> None:
+        t = Transform(position=Vector2(10, 20), rotation=0.7, scale=Vector2(2, 3))
+        point = Vector2(5, -4)
+        assert_vec(t.world_to_local(t.local_to_world(point)), (5, -4), tol=1e-6)
+
+    def test_local_to_world_applies_scale_rotation_then_translation(self) -> None:
+        t = Transform(
+            position=Vector2(10, 0), rotation=math.pi / 2, scale=Vector2(2, 2)
+        )
+        assert_vec(t.local_to_world(Vector2(1, 0)), (10, 2))
+
+    def test_world_to_local_of_a_zero_scaled_transform_returns_origin(self) -> None:
+        """A zero scale is not invertible; the origin is returned rather than
+        raising ZeroDivisionError mid-frame."""
+        t = Transform(scale=Vector2(0, 0))
+        assert t.world_to_local(Vector2(5, 5)) == Vector2(0, 0)
+
+    def test_world_position_setter_accounts_for_the_parent(self) -> None:
+        parent = Transform(position=Vector2(100, 100))
+        child = Transform()
+        child.set_parent(parent, keep_world_transform=False)
+
+        child.world_position = Vector2(150, 150)
+
+        assert_vec(child.position, (50, 50))
+        assert_vec(child.world_position, (150, 150))
+
+    def test_world_rotation_setter_accounts_for_the_parent(self) -> None:
+        parent = Transform(rotation=math.pi / 2)
+        child = Transform()
+        child.set_parent(parent, keep_world_transform=False)
+
+        child.world_rotation = math.pi
+
+        assert abs(child.rotation - math.pi / 2) < 1e-9
+        assert abs(child.world_rotation - math.pi) < 1e-9
+
+    def test_distance_to_uses_world_space(self) -> None:
+        parent = Transform(position=Vector2(100, 0))
+        child = Transform()
+        child.set_parent(parent, keep_world_transform=False)
+        other = Transform(position=Vector2(103, 4))
+        assert child.distance_to(other) == 5.0
+
+
+class TestSharedComponents:
+    def test_tag_and_resource_link_have_no_instance_dict(self) -> None:
+        """slots=True keeps these off a per-instance __dict__, as the ECS docs
+        require of dataclass components."""
+        assert not hasattr(Tag("player"), "__dict__")
+        assert not hasattr(ResourceLink("a/b.json"), "__dict__")
+
+    def test_slotted_components_still_initialise_base_state(self) -> None:
+        """dataclass(slots=True) rebuilds the class, which breaks a zero-arg
+        super() in __post_init__; entity must still be initialised."""
+        assert Tag("player").entity is None
+        assert ResourceLink("a/b.json").entity is None
+
+    def test_tag_defaults_and_equality(self) -> None:
+        assert Tag().name == "Entity"
+        assert Tag("a") == Tag("a")
+        assert Tag("a") != Tag("b")
+
+
+class TestTransformFalsyDefaults:
+    """`position or default` is wrong for Vector2: pymunk's Vec2d is falsy at
+    (0, 0), so an explicitly requested zero was silently replaced."""
+
+    def test_explicit_zero_scale_is_honoured(self) -> None:
+        assert Transform(scale=Vector2(0, 0)).scale == Vector2(0, 0)
+
+    def test_explicit_zero_position_is_honoured(self) -> None:
+        assert Transform(position=Vector2(0, 0)).position == Vector2(0, 0)
+
+    def test_omitted_arguments_still_default(self) -> None:
+        t = Transform()
+        assert t.position == Vector2(0, 0)
+        assert t.scale == Vector2(1, 1)


### PR DESCRIPTION
Second iteration of the incremental subsystem audit. Scope is `pyguara/common` — `Vector2`, `Color`, `Rect`, `Transform`.

> **Stacked on #1.** Base is `refactor/ecs-audit`, not `main`. Merge #1 first and this will retarget cleanly.

## Three real bugs

All reproduced by probe before being fixed.

**`Transform.up` pointed down.** `Vector2.up()` returns `(0, -1)`; `Transform.up` returned `(0, +1)` — the exact opposite, in the same package, with nothing documenting which was intended. Evidence settles it rather than preference: the shipped games set `gravity_y = 900.0`, so **+Y is down** and `Transform.up` was aimed at the floor. Both now agree, and the convention is stated in both module docstrings and the new doc page.

**`Transform.set_parent()` had no cycle guard.** `t.set_parent(t)`, or any loop, made every later `world_*` read recurse until the stack blew — surfacing as a `RecursionError` deep in a render frame, far from the parenting call responsible. Now raises `ValueError`; `is_ancestor_of()` exposes the check.

**`scale or Vector2(1, 1)` silently discarded a zero scale.** `pymunk.Vec2d` defines `__bool__`, so `Vector2(0, 0)` is falsy and an explicitly requested zero scale became unit scale. Worth noting how this surfaced: not by reading the code, but by a test written against the documented behaviour, which failed. Generalised as **CC-7** — the same trap applies to `Color(0,0,0,0)`, an empty `Rect`, and `0.0` defaults.

## ⚠️ Breaking change

`Vector2.rotate(degrees)` → **`Vector2.rotate_degrees(degrees)`**. It sat one letter from `rotated(radians)`, while `Transform.rotate()` *also* takes radians. A one-letter difference deciding an angle unit cannot be read correctly at a call site. All three in-repo call sites (`camera.py` ×2, `particles.py`) were already passing degrees, so this closes a latent trap rather than a live bug. External callers must rename.

## Other changes

`Color` now coerces channels to `int` and clamps to 0–255 — it lost `pygame.Color`'s own validation in the ticket-31 migration and gained no replacement, so `Color.from_hsv(0, 5, 5)` returned `Color(1275, -5100, -5100)`. Clamping over raising: colour arithmetic overshoots legitimately, and saturating beats crashing mid-render.

Added `Vector2.down()/left()` and `Transform.left/down` (the opposites were simply missing), `Color.to_hex()`, `Rect.size`. `Rect.inflate()` now matches `pygame.Rect` for odd negative deltas. `BasicColors` re-exports `Color`'s constants instead of redefining all nine. Deleted `constants.py` — a docstring-only file imported nowhere.

`Tag` and `ResourceLink` became `@dataclass(slots=True)`, as the ECS docs require. That change bit back and is worth knowing about: `slots=True` returns a **new class**, so the zero-arg `super()` in `__post_init__` resolves against the discarded original and raises `TypeError` on every instantiation. Ten failing tests caught it; fixed with an explicit `BaseComponent.__init__(self)` and a comment.

## Tests

**`Vector2` and `Transform` had zero direct tests.** `test_common_types.py` covered only `Color` and `Rect`. `Transform` — the most intricate logic in the package — appeared in ten other test modules purely as an incidental fixture, so its hierarchy math, dirty-cache propagation and coordinate conversion were exercised almost entirely by accident. That gap is precisely what let all three bugs survive.

New `test_transform.py` (36 tests) and `test_common_types.py` grown 24 → 52. **1236 pass** (from 1168), ruff clean, mypy clean.

## Review notes

Four commits, scoped by file so each reviews on its own — `917cb23` (types), `061a2c4` (Transform), `7cc715d` (colour dedup), `e9b57cf` (docs). Each was checked out into an isolated worktree and run independently: 1200 / 1236 / 1236 / 1236 passing, no red intermediate state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
