### PR TITLE
refactor(events): audit pass — break a latent log/events import cycle, fix timestamp sentinel

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -12,7 +12,7 @@ rather than fixed in place.
 
 ## Active Subsystem
 
-`pyguara/common` — **in review (awaiting approval)**
+`pyguara/events` — **in review (awaiting approval)**
 
 ---
 
@@ -21,9 +21,9 @@ rather than fixed in place.
 Ordered roughly by dependency depth: foundations first, leaves last.
 
 ### Tier 1 — Foundations (no intra-engine dependencies)
-- [x] `pyguara/common` — Vector2, Color, Rect, shared components *(active)*
+- [x] `pyguara/common` — Vector2, Color, Rect, shared components *(done)*
 - [ ] `pyguara/log` — logging facade
-- [ ] `pyguara/events` — EventDispatcher, Event protocol
+- [x] `pyguara/events` — EventDispatcher, Event protocol *(active)*
 - [ ] `pyguara/di` — DIContainer, auto-wiring, lifetimes
 
 ### Tier 2 — Core runtime
@@ -59,6 +59,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/common` | 2026-09-06 | Fixed `Transform.up` pointing down, an unguarded parent cycle and a falsy-`Vector2` default; renamed `Vector2.rotate` to `rotate_degrees`; wrote the first tests for `Vector2` and `Transform`. PR #2. |
 | `pyguara/ecs` | 2026-09-06 | Fixed two silent query bugs (`add_entity()` bypassing the query cache; dead-entity resurrection), replaced the private removal hook with a subscribe/unsubscribe API, and modernised the module. PR #1. |
 
 ---
@@ -127,6 +128,16 @@ are audited and the true extent is known, migrate the tree to `StrictComponent`
 and consider making it the default.
 *Discovered in:* `ecs`; offender identified in `common`. *Status:* parked.
 
+### CC-8 — Package `__init__.py` files export nothing
+Most subsystem packages have a docstring-only `__init__.py`, so callers reach
+into submodules (`from pyguara.events.dispatcher import ...`). Beyond the
+ergonomics, it actively hides import cycles: adding re-exports to
+`events/__init__.py` immediately exposed a latent `log` <-> `events` deadlock
+(fixed in that pass). Every package still lacking exports may be hiding the
+same thing. **Fix:** add a curated `__all__` per package as each is audited,
+and treat any cycle it reveals as a finding rather than a reason to revert.
+*Discovered in:* `events`. *Status:* open.
+
 ### CC-7 — `x or default` used with falsy value types
 `pymunk.Vec2d` defines `__bool__`, so `Vector2(0, 0)` is falsy. `Transform
 .__init__` used `scale or Vector2(1, 1)`, which silently rewrote an explicitly
@@ -189,7 +200,7 @@ test modules migrated; 7 further tests added (1168 total, from 1161).
 half of CC-5 (`Entity._components` reached into by `persistence`/`prefabs`).
 
 
-### `pyguara/common` — awaiting approval (2026-09-06)
+### `pyguara/common` — CLOSED 2026-09-06 (PR #2, branch `refactor/common-audit`)
 
 **Verification:** 1236/1236 tests pass (up from 1168); ruff clean; mypy clean
 across 217 files (one fewer: `constants.py` deleted).
@@ -242,3 +253,59 @@ fixture, so the most intricate logic in the package was exercised by accident.
 **Docs:** new `docs/core/common-types.md`, added to the mkdocs nav.
 
 **Deferred:** CC-1 through CC-4, CC-6, CC-7, and the remaining half of CC-5.
+
+
+### `pyguara/events` — awaiting approval (2026-09-06)
+
+**Verification:** 1262/1262 tests pass (up from 1236); ruff clean; mypy clean.
+
+**Correctness fixes (all reproduced by probe before fixing):**
+- Every event dataclass in `input.py`, `lifecycle.py` and `window.py` used
+  `timestamp: float = 0.0` plus a `__post_init__` overwriting zero with
+  `time.time()`. A genuine timestamp of 0.0 was therefore impossible to
+  express, and the idiom was duplicated five times. Replaced with
+  `field(default_factory=time.time)`, which `ecs/events.py` already used --
+  the engine had two idioms for the same thing and the more common one was
+  the broken one.
+- `filter_func` exceptions bypassed `error_strategy` entirely: a raising
+  filter propagated even under IGNORE, because only the handler call was
+  wrapped. A filter is user code too, and now follows the same policy.
+- **Latent `log` <-> `events` import cycle.** `pyguara.log.events` inherits the
+  `Event` protocol at runtime, so `log` depends on `events`; but
+  `events.dispatcher` imported `pyguara.log` at module scope. The cycle was
+  masked only by `events/__init__.py` being empty, and detonated the moment
+  re-exports were added. `events` is the more foundational package, so the
+  fix is on its side: `EngineLogger` is a type-only import and the default
+  logger resolves lazily inside `__init__`. Both import orders are now
+  covered by a subprocess regression test.
+
+**API changes:**
+- `dispatch()` returns `bool` instead of `None` -- True if every handler ran,
+  False if one consumed the event by returning False. The short-circuit
+  already worked but was invisible to callers, which is precisely what
+  UI-over-game input handling needs. No in-repo caller used the return value,
+  so this is additive. `IEventDispatcher` updated to match.
+- `max_history_size` is now a constructor parameter; it was hardcoded at 1000
+  while `enable_history` was configurable.
+- `IEventDispatcher.subscribe` gained the `filter_func` parameter the
+  implementation always had.
+- `events/__init__.py` re-exports the public surface with an `__all__`.
+
+**Performance:** `dispatch()` rebuilt and re-sorted the merged MRO handler
+list on every single call -- in the engine's hottest path. Now memoised per
+concrete event type and invalidated when the subscription set changes.
+Measured on 20 000 dispatches with 50 handlers: 5.7 us -> 3.1 us per dispatch.
+
+**Tests:** 23 -> 49. The dispatcher's existing tests were genuinely good; the
+gaps were the event dataclasses (untested, and where the timestamp bug lived),
+filter error handling, `clear_subscribers`, history filtering and sizing,
+cache invalidation, snapshot-during-dispatch semantics, and real multi-thread
+`queue_event` contention.
+
+**Note:** one existing test caught a regression I introduced -- dropping the
+exception text from the handler error message. Restored.
+
+**Docs:** new `docs/core/events.md`; `architecture.md`'s Event section
+condensed to a summary and link.
+
+**Deferred:** CC-1 through CC-4, CC-6, CC-7, CC-8, and the rest of CC-5.

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -58,22 +58,26 @@ app = container.get(Application)
 
 # Event System
 
-The Event System (`pyguara.events`) provides a decoupled communication channel between subsystems.
+The event system (`pyguara.events`) decouples subsystems: publishers do not
+know their subscribers, and subscription is by event type.
 
-## EventDispatcher
-
-- **Synchronous Dispatch**: `dispatch(event)` executes handlers immediately on the calling thread.
-- **Queued Dispatch**: `queue_event(event)` is thread-safe and processes events at the start of the next frame (useful for Network/Loader threads).
-- **Filtering & Priority**: Handlers can define priority levels and filter logic.
-
-## Protocol
-
-Events are defined using the `Event` protocol, typically implemented as Dataclasses.
+- **Structural events.** `Event` is a Protocol, so any dataclass with
+  `timestamp` and `source` qualifies — no base class required.
+- **Subclass matching.** Dispatch walks the event's MRO, so subscribing to
+  `KeyboardEvent` receives both `KeyDownEvent` and `KeyUpEvent`. Handlers
+  across the hierarchy merge into one priority-ordered pass.
+- **Consumption.** A handler returning `False` stops lower-priority handlers,
+  and `dispatch()` reports it — how a UI layer claims input before the game.
+- **Threading.** `queue_event()` is the only thread-safe entry point;
+  `process_queue()` drains on the main loop, under optional time and count
+  budgets.
 
 ```python
 @dataclass
-class PlayerDiedEvent:
+class PlayerDied:
     player_id: str
     timestamp: float = field(default_factory=time.time)
     source: Any = None
 ```
+
+See **[Event System](events.md)** for the full reference.

--- a/docs/core/events.md
+++ b/docs/core/events.md
@@ -1,0 +1,152 @@
+# Event System
+
+`pyguara.events` is the decoupled communication channel between subsystems.
+Publishers do not know their subscribers, and subscription is by event type.
+
+## Defining an event
+
+An event is any object with `timestamp` and `source`. `Event` is a
+**Protocol**, not a required base class, so a plain dataclass qualifies:
+
+```python
+from dataclasses import dataclass, field
+import time
+from typing import Any
+
+@dataclass
+class PlayerDied:
+    player_id: str
+    timestamp: float = field(default_factory=time.time)
+    source: Any = None
+```
+
+!!! warning "Use `field(default_factory=time.time)`"
+    Not `timestamp: float = 0.0` with a `__post_init__` that overwrites zero.
+    That sentinel pattern makes a genuine timestamp of `0.0` impossible to
+    express — passing it silently yields the current time instead.
+
+## Subscribing
+
+```python
+dispatcher.subscribe(PlayerDied, on_player_died)
+dispatcher.subscribe(PlayerDied, on_player_died, priority=100)
+dispatcher.subscribe(PlayerDied, on_boss_died, filter_func=lambda e: e.is_boss)
+dispatcher.unsubscribe(PlayerDied, on_player_died)
+```
+
+- **Higher priority runs first.** Ties keep subscription order.
+- **`filter_func`** gates the handler. It is user code, and its exceptions
+  follow the same error strategy as a handler's.
+- **`unsubscribe` removes every registration** of that callable for the type,
+  and must name the same class used to subscribe — not a subclass.
+- **The same callable may be subscribed more than once**, at different
+  priorities or with different filters. Each registration runs.
+
+### Subscribing to a base class
+
+Dispatch walks the event's MRO, so a handler on a base class receives every
+subclass:
+
+```python
+dispatcher.subscribe(KeyboardEvent, on_key)   # KeyDownEvent and KeyUpEvent
+dispatcher.subscribe(object, log_everything)  # every event, a catch-all
+```
+
+Handlers from the whole hierarchy merge into **one** priority-ordered pass, so
+priority decides call order whether a handler subscribed to the exact type or
+to a base. Ties break in MRO order, subclass handlers first.
+
+## Dispatching
+
+```python
+delivered = dispatcher.dispatch(PlayerDied(player_id="p1"))
+```
+
+`dispatch()` returns **`True`** if every applicable handler ran, and **`False`**
+if one consumed the event by returning `False`, stopping lower-priority
+handlers. That is how a UI layer claims an input event before the game sees it:
+
+```python
+def on_click(event) -> bool | None:
+    if not self.rect.contains_point(event.position):
+        return None          # not mine; let it through
+    self.activate()
+    return False             # consumed
+```
+
+The handler list is **snapshotted** before the pass begins. A handler that
+subscribes or unsubscribes affects the *next* dispatch, not the one in flight.
+
+## Threading
+
+Only `queue_event()` is thread-safe. `dispatch()`, `subscribe()`,
+`unsubscribe()` and `clear_subscribers()` must run on the main thread.
+
+Background work — resource loaders, network callbacks — queues, and the main
+loop drains:
+
+```python
+dispatcher.queue_event(TextureLoaded(path=path))   # any thread
+
+dispatcher.process_queue()                          # main loop, once per frame
+dispatcher.process_queue(max_events=100)            # count budget
+dispatcher.process_queue(max_time_ms=2.0)           # time budget
+```
+
+`process_queue()` only considers events already queued when the call began.
+Anything a handler queues waits for the next frame, as does anything left over
+when a budget runs out — that is what stops a self-feeding event storm from
+locking up a frame. It logs a warning past `queue_warning_threshold` (10 000 by
+default) as an early signal of exactly that spiral.
+
+## Error strategy
+
+Handler and filter exceptions are governed by one policy, chosen at
+construction:
+
+| Strategy | Behaviour |
+| --- | --- |
+| `RAISE` *(default)* | Log, then re-raise. Fail fast in development. |
+| `LOG` | Log and continue with the next handler. Graceful in production. |
+| `IGNORE` | Swallow silently. Tests and narrow edge cases only. |
+
+```python
+EventDispatcher(error_strategy=ErrorHandlingStrategy.LOG)
+```
+
+## History
+
+A debug and test aid, off by default so the dispatch path never pays for it:
+
+```python
+dispatcher = EventDispatcher(enable_history=True, max_history_size=500)
+dispatcher.get_history()             # everything retained, oldest first
+dispatcher.get_history(PlayerDied)   # that type and its subclasses
+```
+
+Backed by a bounded deque, so enabling it cannot grow without bound.
+
+## Performance
+
+`dispatch()` memoises the resolved handler list per concrete event type, so a
+dispatch is a lookup plus a walk rather than an MRO scan and a re-sort every
+time. The cache is dropped whenever the subscription set changes, which is why
+`subscribe`/`unsubscribe`/`clear_subscribers` belong in setup rather than in a
+per-frame loop.
+
+## Dependency direction
+
+`log` depends on `events` — `OnLogEvent` and `OnExceptionEvent` implement the
+`Event` protocol — so **`events` must never import `log` at module scope**. The
+dispatcher's default logger is resolved lazily inside `__init__` and
+`EngineLogger` is a type-only import. Reintroducing a module-level
+`from pyguara.log import ...` here deadlocks both packages on first import.
+
+## Rules of thumb
+
+1. `field(default_factory=time.time)`, never a `0.0` sentinel.
+2. `queue_event()` off the main thread; everything else on it.
+3. Return `False` to consume an event, and check `dispatch()`'s result if you
+   care whether someone did.
+4. Subscribe in setup, not per frame — it invalidates the handler cache.
+5. `RAISE` in development. Reach for `IGNORE` only in tests.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - Architecture: core/architecture.md
       - Entity Component System: core/ecs.md
       - Core Types: core/common-types.md
+      - Event System: core/events.md
       - Application & Lifecycle: core/application.md
       - Logging: core/logging.md
   - Graphics:

--- a/pyguara/events/__init__.py
+++ b/pyguara/events/__init__.py
@@ -1,1 +1,33 @@
-"""Event management package containing dispatcher, protocols, and standard event types."""
+"""Event system: the dispatcher, its contracts, and the engine's own events.
+
+Subscription is by type and matches subclasses, so subscribing to
+`KeyboardEvent` receives both `KeyDownEvent` and `KeyUpEvent`.
+"""
+
+from pyguara.events.dispatcher import EventDispatcher, HandlerRecord
+from pyguara.events.input import (
+    KeyboardEvent,
+    KeyDownEvent,
+    KeyUpEvent,
+    MouseMotionEvent,
+)
+from pyguara.events.lifecycle import ApplicationStartEvent, QuitEvent
+from pyguara.events.protocols import Event, IEventDispatcher
+from pyguara.events.types import ErrorHandlingStrategy, EventHandler
+from pyguara.events.window import WindowResizeEvent
+
+__all__ = [
+    "ApplicationStartEvent",
+    "ErrorHandlingStrategy",
+    "Event",
+    "EventDispatcher",
+    "EventHandler",
+    "HandlerRecord",
+    "IEventDispatcher",
+    "KeyDownEvent",
+    "KeyUpEvent",
+    "KeyboardEvent",
+    "MouseMotionEvent",
+    "QuitEvent",
+    "WindowResizeEvent",
+]

--- a/pyguara/events/dispatcher.py
+++ b/pyguara/events/dispatcher.py
@@ -1,217 +1,334 @@
-"""Concrete implementation of the Event Dispatcher."""
+"""Concrete implementation of the event dispatcher."""
+
+from __future__ import annotations
 
 import queue
 import time
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from typing import Any, Callable, Deque, DefaultDict, List, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from pyguara.events.protocols import Event
-from pyguara.events.types import EventHandler, ErrorHandlingStrategy
-from pyguara.log import EngineLogger, get_logger
+from pyguara.events.types import ErrorHandlingStrategy, EventHandler
+
+if TYPE_CHECKING:
+    from pyguara.log import EngineLogger
+
+# `pyguara.log` imports this package at runtime -- its OnLogEvent and
+# OnExceptionEvent inherit the Event protocol -- so `events` must not import
+# `log` at module scope or the two packages deadlock on first import. Events
+# are the more foundational of the two: log depends on events, and the
+# dispatcher merely happens to log. The default logger is therefore resolved
+# lazily, inside __init__, and EngineLogger is a type-only import.
 
 E = TypeVar("E", bound=Event)
 
-# Default safety thresholds
 DEFAULT_QUEUE_WARNING_THRESHOLD = 10000
+DEFAULT_MAX_HISTORY_SIZE = 1000
 
 
 @dataclass
 class HandlerRecord:
-    """DTO with information to handle the event call."""
+    """One subscription: the callback plus how and when it should run.
 
-    callback: Callable[[Any], Optional[bool]]
+    Attributes:
+        callback: Receives the event. Returning False stops propagation.
+        priority: Higher runs first.
+        filter_func: Optional predicate; the callback runs only if it passes.
+    """
+
+    callback: Callable[[Any], bool | None]
     priority: int
-    filter_func: Optional[Callable[[Any], bool]]
+    filter_func: Callable[[Any], bool] | None
 
 
 class EventDispatcher:
-    """Advanced event dispatcher with filtering, priority, and thread-safety support."""
+    """Routes events to subscribers, with priority, filtering and queueing.
+
+    Subscription is by type, and dispatch walks the event's MRO: a handler
+    subscribed to a base class receives every subclass too. Handlers from the
+    whole MRO merge into one priority-ordered pass, so priority governs call
+    order regardless of which class in the hierarchy a handler subscribed to.
+    Subscribing to `object` therefore receives everything.
+
+    Thread safety:
+        `queue_event()` is safe to call from any thread. Everything else --
+        `dispatch()`, `subscribe()`, `unsubscribe()`, `clear_subscribers()` --
+        must run on the main thread. Background threads queue; the main loop
+        drains via `process_queue()`.
+    """
 
     def __init__(
         self,
-        logger: Optional[EngineLogger] = None,
+        logger: "EngineLogger | None" = None,
         error_strategy: ErrorHandlingStrategy = ErrorHandlingStrategy.RAISE,
         queue_warning_threshold: int = DEFAULT_QUEUE_WARNING_THRESHOLD,
         enable_history: bool = False,
+        max_history_size: int = DEFAULT_MAX_HISTORY_SIZE,
     ) -> None:
-        """Initialize the Event Dispatcher.
+        """Initialise a dispatcher with no subscribers.
 
         Args:
-            logger: Optional logger for error reporting. Defaults to the shared
-                logging accessor so the dispatcher always logs somewhere, even
-                when constructed before bootstrap wires anything explicitly.
-            error_strategy: How to handle errors in event handlers. Defaults to RAISE
-                for fail-fast behavior in development. Use LOG for production
-                graceful degradation.
-            queue_warning_threshold: Queue size threshold for warning logs.
-                Defaults to 10000 events.
-            enable_history: Whether to record dispatched events for `get_history()`.
-                A debug/devtool/test feature, not a production one -- defaults off
-                so the hot path never pays for it. Backed by a bounded deque
-                regardless, so turning it on doesn't reintroduce O(n) eviction.
+            logger: Where handler errors and queue warnings go. Defaults to
+                the shared logging accessor, so the dispatcher always logs
+                somewhere even when built before bootstrap wires anything.
+            error_strategy: What to do when a handler or filter raises.
+                RAISE fails fast in development; LOG degrades gracefully in
+                production.
+            queue_warning_threshold: Queue depth that triggers a warning,
+                as an early signal of an event death spiral.
+            enable_history: Record dispatched events for `get_history()`. A
+                devtool and test feature; off by default so the hot path
+                never pays for it.
+            max_history_size: How many events history retains. Backed by a
+                bounded deque, so enabling history cannot grow without bound.
         """
-        self._listeners: DefaultDict[Type[Event], List[HandlerRecord]] = defaultdict(
+        self._listeners: defaultdict[type[Event], list[HandlerRecord]] = defaultdict(
             list
         )
+        # type(event) -> its MRO's handlers, merged and priority-sorted.
+        # dispatch() is the engine's hottest path; without this it rebuilt and
+        # re-sorted that list on every single call. Dropped whenever the
+        # subscription set changes.
+        self._resolved: dict[type[Event], list[HandlerRecord]] = {}
 
-        # Thread-safe queue
         self._event_queue: queue.Queue[Event] = queue.Queue()
 
         self._enable_history = enable_history
-        self._max_history_size: int = 1000
-        self._event_history: Deque[Event] = deque(maxlen=self._max_history_size)
-        self._logger = logger or get_logger(__name__)
+        self._max_history_size = max_history_size
+        self._event_history: deque[Event] = deque(maxlen=max_history_size)
+        if logger is None:
+            from pyguara.log import get_logger
+
+            logger = get_logger(__name__)
+        self._logger = logger
         self._error_strategy = error_strategy
         self._queue_warning_threshold = queue_warning_threshold
 
     def subscribe(
         self,
-        event_type: Type[E],
+        event_type: type[E],
         handler: EventHandler[E],
         priority: int = 0,
-        filter_func: Optional[Callable[[E], bool]] = None,
+        filter_func: Callable[[E], bool] | None = None,
     ) -> None:
-        """Subscribe a handler to a specific event type."""
+        """Register a handler for an event type and its subclasses.
+
+        The same callable may be subscribed more than once -- with different
+        priorities or filters, say -- and will then run once per subscription.
+
+        Args:
+            event_type: The class to listen for. Subclasses match too.
+            handler: Receives the event. Returning False stops propagation to
+                lower-priority handlers.
+            priority: Higher runs first. Ties keep subscription order.
+            filter_func: Optional predicate; the handler runs only if it
+                returns True.
+        """
         record = HandlerRecord(
             callback=handler, priority=priority, filter_func=filter_func
         )
-        target_list = self._listeners[event_type]
-        target_list.append(record)
-        target_list.sort(key=lambda r: r.priority, reverse=True)
+        self._listeners[event_type].append(record)
+        self._resolved.clear()
 
-    def dispatch(self, event: Event) -> None:
+    def unsubscribe(self, event_type: type[E], handler: EventHandler[E]) -> None:
+        """Remove every subscription of a handler for an event type.
+
+        Removes all of them if the handler was subscribed more than once.
+        Unsubscribing something that was never subscribed is a no-op.
+
+        Args:
+            event_type: The class the handler was registered against. Must be
+                the same class used to subscribe, not a subclass.
+            handler: The callable to remove.
         """
-        Dispatch an event immediately to all subscribers (Synchronous).
+        records = self._listeners.get(event_type)
+        if records is None:
+            return
+        self._listeners[event_type] = [r for r in records if r.callback != handler]
+        self._resolved.clear()
 
-        Handlers subscribed to any class in `type(event).__mro__` all fire --
-        not just exact-type subscribers -- merged into one priority-sorted
-        pass, so priority governs call order (and short-circuit-on-False)
-        regardless of whether a handler subscribed to the exact type or a
-        base class.
+    def clear_subscribers(self, event_type: type[Event] | None = None) -> None:
+        """Remove subscribers for one event type, or all of them.
 
-        WARNING: This runs on the calling thread. For background threads,
-        use queue_event() instead.
+        Args:
+            event_type: The class to clear. If None, clears everything.
+        """
+        if event_type is not None:
+            self._listeners.pop(event_type, None)
+        else:
+            self._listeners.clear()
+        self._resolved.clear()
+
+    def dispatch(self, event: Event) -> bool:
+        """Deliver an event to its subscribers immediately, on this thread.
+
+        Handlers run in priority order, merged across the event's whole MRO.
+        The handler list is snapshotted first, so a handler that subscribes or
+        unsubscribes affects the next dispatch, not this one.
+
+        Args:
+            event: The event to deliver.
+
+        Returns:
+            True if every applicable handler ran; False if one returned False
+            and consumed the event, stopping lower-priority handlers.
+
+        Warning:
+            Runs on the calling thread. Use `queue_event()` from background
+            threads.
         """
         self._record_history(event)
-
-        handlers: List[HandlerRecord] = []
-        for cls in type(event).__mro__:
-            handlers.extend(self._listeners.get(cls, []))
-        handlers.sort(key=lambda r: r.priority, reverse=True)
-
-        self._process_handlers(handlers, event)
+        return self._process_handlers(self._resolve_handlers(type(event)), event)
 
     def queue_event(self, event: Event) -> None:
-        """Queue event for next frame (Thread-Safe)."""
+        """Queue an event for the next `process_queue()`. Thread-safe.
+
+        Args:
+            event: The event to queue.
+        """
         self._event_queue.put(event)
 
     def process_queue(
-        self, max_time_ms: Optional[float] = None, max_events: Optional[int] = None
+        self, max_time_ms: float | None = None, max_events: int | None = None
     ) -> int:
-        """Safely process currently queued events with time and count budgets.
+        """Drain queued events, within optional time and count budgets.
+
+        Call once per frame from the main loop. Only events already queued
+        when the call began are considered; anything a handler queues waits
+        for the next frame, as does anything left over when a budget runs out.
 
         Args:
-            max_time_ms: Maximum time budget in milliseconds. If None, no time limit.
-            max_events: Maximum number of events to process. If None, no count limit.
+            max_time_ms: Time budget in milliseconds. None means no limit.
+            max_events: Maximum events to process. None means no limit.
 
         Returns:
-            Number of events processed.
-
-        Note:
-            Unprocessed events remain in queue for next frame.
-            Logs warning if queue size exceeds threshold.
+            The number of events dispatched.
         """
         queue_size = self._event_queue.qsize()
 
-        # Log warning if queue is getting too large
         if queue_size > self._queue_warning_threshold and self._logger:
             self._logger.warning(
                 f"Event queue size ({queue_size}) exceeds threshold "
                 f"({self._queue_warning_threshold}). Possible event death spiral."
             )
 
-        # Determine how many events to process
-        if max_events is not None:
-            count = min(queue_size, max_events)
-        else:
-            count = queue_size
-
+        count = queue_size if max_events is None else min(queue_size, max_events)
         start_time = time.perf_counter() if max_time_ms is not None else None
         processed = 0
 
         for _ in range(count):
-            # Check time budget before processing each event
-            if start_time is not None:
+            if start_time is not None and max_time_ms is not None:
                 elapsed_ms = (time.perf_counter() - start_time) * 1000.0
-                if elapsed_ms >= max_time_ms:  # type: ignore
+                if elapsed_ms >= max_time_ms:
                     break
 
             try:
                 event = self._event_queue.get_nowait()
-                self.dispatch(event)
-                processed += 1
             except queue.Empty:
                 break
+            self.dispatch(event)
+            processed += 1
 
         return processed
 
-    def _process_handlers(self, records: List[HandlerRecord], event: Event) -> bool:
+    def get_history(self, event_type: type[Event] | None = None) -> list[Event]:
+        """Return recorded events, oldest first.
+
+        Empty unless the dispatcher was built with `enable_history=True`.
+
+        Args:
+            event_type: If given, return only events of this type or a
+                subclass of it.
+
+        Returns:
+            A snapshot list of the retained events.
+        """
+        if event_type is not None:
+            return [e for e in self._event_history if isinstance(e, event_type)]
+        return list(self._event_history)
+
+    def _resolve_handlers(self, event_type: type[Event]) -> list[HandlerRecord]:
+        """Return the priority-ordered handlers for an event type, memoised.
+
+        Args:
+            event_type: The concrete class of the event being dispatched.
+
+        Returns:
+            Handlers from every class in the MRO, highest priority first.
+            Ties keep MRO order, so a subclass handler precedes a base one.
+        """
+        cached = self._resolved.get(event_type)
+        if cached is not None:
+            return cached
+
+        handlers: list[HandlerRecord] = []
+        for cls in event_type.__mro__:
+            handlers.extend(self._listeners.get(cls, ()))
+        handlers.sort(key=lambda r: r.priority, reverse=True)
+
+        self._resolved[event_type] = handlers
+        return handlers
+
+    def _process_handlers(self, records: list[HandlerRecord], event: Event) -> bool:
+        """Run handlers in order until one consumes the event.
+
+        Args:
+            records: Handlers to run, already in priority order.
+            event: The event to pass to each handler.
+
+        Returns:
+            True if the pass completed; False if a handler returned False.
+
+        Raises:
+            Exception: Whatever a handler or filter raised, if the error
+                strategy is RAISE.
+        """
         for record in records:
-            if record.filter_func and not record.filter_func(event):
-                continue
             try:
-                result = record.callback(event)
-                if result is False:
+                if record.filter_func is not None and not record.filter_func(event):
+                    continue
+                if record.callback(event) is False:
                     return False
-            except Exception as e:
-                # Handle error based on configured strategy
-                event_type = type(event).__name__
-                handler_name = getattr(
-                    record.callback, "__name__", str(record.callback)
-                )
-
-                error_msg = (
-                    f"Error in event handler '{handler_name}' "
-                    f"for event type '{event_type}': {e}"
-                )
-
-                if self._error_strategy == ErrorHandlingStrategy.IGNORE:
-                    # Silently ignore (not recommended)
-                    pass
-                elif self._error_strategy == ErrorHandlingStrategy.LOG:
-                    # Log and continue
-                    if self._logger:
-                        self._logger.error(error_msg, exc_info=True)
-                else:  # ErrorHandlingStrategy.RAISE
-                    # Log and re-raise
-                    if self._logger:
-                        self._logger.error(error_msg, exc_info=True)
+            except Exception as error:
+                # Filters are user code too, so they get the same treatment as
+                # handlers rather than escaping the configured strategy.
+                if not self._handle_error(record, event, error):
                     raise
         return True
 
-    def unsubscribe(self, event_type: Type[E], handler: EventHandler[E]) -> None:
-        """Remove a handler of an event type listeners."""
-        if event_type in self._listeners:
-            self._listeners[event_type] = [
-                r for r in self._listeners[event_type] if r.callback != handler
-            ]
+    def _handle_error(
+        self, record: HandlerRecord, event: Event, error: Exception
+    ) -> bool:
+        """Apply the configured error strategy to a failed handler or filter.
 
-    def clear_subscribers(self, event_type: Optional[Type[Event]] = None) -> None:
-        """Clear all listeners or all listeners of a specific event type."""
-        if event_type:
-            if event_type in self._listeners:
-                del self._listeners[event_type]
-        else:
-            self._listeners.clear()
+        Args:
+            record: The subscription that raised.
+            event: The event being dispatched.
+            error: The exception that was raised.
+
+        Returns:
+            True if dispatch should continue with the next handler, False if
+            the exception should propagate.
+        """
+        if self._error_strategy is ErrorHandlingStrategy.IGNORE:
+            return True
+
+        handler_name = getattr(record.callback, "__name__", str(record.callback))
+        error_msg = (
+            f"Error in event handler '{handler_name}' "
+            f"for event type '{type(event).__name__}': {error}"
+        )
+        if self._logger:
+            self._logger.error(error_msg, exc_info=True)
+
+        return self._error_strategy is ErrorHandlingStrategy.LOG
 
     def _record_history(self, event: Event) -> None:
-        """Register an event in history, if `enable_history` is set."""
+        """Append an event to history when history is enabled.
+
+        Args:
+            event: The event being dispatched.
+        """
         if self._enable_history:
             self._event_history.append(event)
-
-    def get_history(self, event_type: Optional[Type[Event]] = None) -> List[Event]:
-        """Return all history records or all history records of an event type."""
-        if event_type:
-            return [e for e in self._event_history if isinstance(e, event_type)]
-        return list(self._event_history)

--- a/pyguara/events/input.py
+++ b/pyguara/events/input.py
@@ -1,50 +1,55 @@
-"""Input events for keyboard and mouse interactions."""
+"""Keyboard and mouse input events.
 
-from dataclasses import dataclass
+`KeyDownEvent` and `KeyUpEvent` share the `KeyboardEvent` base, so a handler
+subscribed to `KeyboardEvent` receives both -- see `EventDispatcher.dispatch`.
+"""
+
 import time
+from dataclasses import dataclass, field
 from typing import Any
 
 
 @dataclass
 class KeyboardEvent:
-    """Base class for key interactions."""
+    """Base for key press and release events.
 
-    key_code: int  # The integer scan code (e.g., pygame.K_SPACE)
-    timestamp: float = 0.0
+    Attributes:
+        key_code: Backend scan code for the key, e.g. `pygame.K_SPACE`.
+        timestamp: Unix time the event was created.
+        source: Whatever raised the event, if it identified itself.
+    """
+
+    key_code: int
+    timestamp: float = field(default_factory=time.time)
     source: Any = None
-
-    def __post_init__(self) -> None:
-        """Initialize timestamp if not provided."""
-        if self.timestamp == 0.0:
-            self.timestamp = time.time()
 
 
 @dataclass
 class KeyDownEvent(KeyboardEvent):
     """Fired when a key is pressed."""
 
-    pass
-
 
 @dataclass
 class KeyUpEvent(KeyboardEvent):
     """Fired when a key is released."""
 
-    pass
-
 
 @dataclass
 class MouseMotionEvent:
-    """Fired when the mouse moves."""
+    """Fired when the mouse moves.
+
+    Attributes:
+        x: Cursor X position in window pixels.
+        y: Cursor Y position in window pixels.
+        rel_x: Horizontal movement since the previous motion event.
+        rel_y: Vertical movement since the previous motion event.
+        timestamp: Unix time the event was created.
+        source: Whatever raised the event, if it identified itself.
+    """
 
     x: int
     y: int
     rel_x: int
     rel_y: int
-    timestamp: float = 0.0
+    timestamp: float = field(default_factory=time.time)
     source: Any = None
-
-    def __post_init__(self) -> None:
-        """Initialize timestamp if not provided."""
-        if self.timestamp == 0.0:
-            self.timestamp = time.time()

--- a/pyguara/events/lifecycle.py
+++ b/pyguara/events/lifecycle.py
@@ -1,31 +1,31 @@
-"""Standard lifecycle events for application state."""
+"""Application lifecycle events."""
 
-from dataclasses import dataclass
-from typing import Any
 import time
+from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
 class QuitEvent:
-    """Fired when the user requests the application to close."""
+    """Fired when the user asks the application to close.
 
-    timestamp: float = 0.0
+    Attributes:
+        timestamp: Unix time the event was created.
+        source: Whatever raised the event, if it identified itself.
+    """
+
+    timestamp: float = field(default_factory=time.time)
     source: Any = None
-
-    def __post_init__(self) -> None:
-        """Initialize timestamp if not provided."""
-        if self.timestamp == 0.0:
-            self.timestamp = time.time()
 
 
 @dataclass
 class ApplicationStartEvent:
-    """Fired when the engine loop begins."""
+    """Fired once when the engine loop begins.
 
-    timestamp: float = 0.0
+    Attributes:
+        timestamp: Unix time the event was created.
+        source: Whatever raised the event, if it identified itself.
+    """
+
+    timestamp: float = field(default_factory=time.time)
     source: Any = None
-
-    def __post_init__(self) -> None:
-        """Initialize timestamp if not provided."""
-        if self.timestamp == 0.0:
-            self.timestamp = time.time()

--- a/pyguara/events/protocols.py
+++ b/pyguara/events/protocols.py
@@ -1,18 +1,26 @@
 """Core protocols defining the contracts for the Event System."""
 
-from typing import Any, Protocol, Optional, Type, TypeVar, runtime_checkable
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol, TypeVar, runtime_checkable
+
 from pyguara.events.types import EventHandler
 
-# Define a generic type variable bound to the Event protocol
 E = TypeVar("E", bound="Event")
 
 
 @runtime_checkable
 class Event(Protocol):
-    """Core event protocol for type checking.
+    """Structural contract every event satisfies.
 
-    All concrete events should implement these fields.
-    Using a Protocol allows events to be simple dataclasses or complex objects.
+    A Protocol rather than a base class, so an event can be a plain dataclass
+    without inheriting anything. Prefer `field(default_factory=time.time)` for
+    the timestamp over a sentinel checked in `__post_init__`, which cannot
+    express a genuine timestamp of 0.0.
+
+    Attributes:
+        timestamp: Unix time the event was created.
+        source: Whatever raised the event, if it identified itself.
     """
 
     timestamp: float
@@ -26,11 +34,15 @@ class IEventDispatcher(Protocol):
     Responsible for routing events to registered handlers based on type.
     """
 
-    def dispatch(self, event: Event) -> None:
-        """Dispatch an event to all subscribers immediately (Synchronous).
+    def dispatch(self, event: Event) -> bool:
+        """Deliver an event to its subscribers immediately, on this thread.
 
         Args:
-            event: The event instance to broadcast.
+            event: The event to broadcast.
+
+        Returns:
+            True if every applicable handler ran; False if one consumed the
+            event by returning False.
         """
         ...
 
@@ -47,7 +59,7 @@ class IEventDispatcher(Protocol):
         ...
 
     def process_queue(
-        self, max_time_ms: Optional[float] = None, max_events: Optional[int] = None
+        self, max_time_ms: float | None = None, max_events: int | None = None
     ) -> int:
         """
         Flush the event queue and dispatch pending events with optional limits.
@@ -64,18 +76,24 @@ class IEventDispatcher(Protocol):
         ...
 
     def subscribe(
-        self, event_type: Type[E], handler: EventHandler[E], priority: int = 0
+        self,
+        event_type: type[E],
+        handler: EventHandler[E],
+        priority: int = 0,
+        filter_func: Callable[[E], bool] | None = None,
     ) -> None:
-        """Subscribe to an event type.
+        """Subscribe to an event type and its subclasses.
 
         Args:
-            event_type: The class of the event to listen for.
-            handler: A callable that will receive the event.
-            priority: Execution order (Higher runs first). Defaults to 0.
+            event_type: The class to listen for. Subclasses match too.
+            handler: Receives the event. Returning False stops propagation.
+            priority: Higher runs first. Ties keep subscription order.
+            filter_func: Optional predicate; the handler runs only if it
+                returns True.
         """
         ...
 
-    def unsubscribe(self, event_type: Type[E], handler: EventHandler[E]) -> None:
+    def unsubscribe(self, event_type: type[E], handler: EventHandler[E]) -> None:
         """Unsubscribe from an event type.
 
         Args:
@@ -84,7 +102,7 @@ class IEventDispatcher(Protocol):
         """
         ...
 
-    def clear_subscribers(self, event_type: Optional[Type[Event]] = None) -> None:
+    def clear_subscribers(self, event_type: type[Event] | None = None) -> None:
         """Clear subscribers for an event type or all events.
 
         Args:

--- a/pyguara/events/window.py
+++ b/pyguara/events/window.py
@@ -1,20 +1,22 @@
 """Window management events."""
 
-from dataclasses import dataclass
 import time
+from dataclasses import dataclass, field
 from typing import Any
 
 
 @dataclass
 class WindowResizeEvent:
-    """Fired when the OS window dimensions change."""
+    """Fired when the OS window dimensions change.
+
+    Attributes:
+        width: New window width in pixels.
+        height: New window height in pixels.
+        timestamp: Unix time the event was created.
+        source: Whatever raised the event, if it identified itself.
+    """
 
     width: int
     height: int
-    timestamp: float = 0.0
+    timestamp: float = field(default_factory=time.time)
     source: Any = None
-
-    def __post_init__(self) -> None:
-        """Initialize timestamp if not provided."""
-        if self.timestamp == 0.0:
-            self.timestamp = time.time()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,6 +1,11 @@
 from dataclasses import dataclass
 from typing import Any
+
+import pytest
+
+from pyguara.events.dispatcher import EventDispatcher
 from pyguara.events.protocols import Event
+from pyguara.events.types import ErrorHandlingStrategy
 
 
 @dataclass
@@ -506,3 +511,369 @@ def test_history_enabled_records_bounded_deque():
 
     assert dispatcher.get_history() == events
     assert dispatcher.get_history(CustomEvent) == events
+
+
+# -- Package import order (regression) --
+
+
+def test_events_package_imports_before_log() -> None:
+    """`pyguara.log` inherits the Event protocol at runtime, so log depends on
+    events. If events also imported log at module scope the two would deadlock
+    on first import -- which is exactly what happened the moment
+    events/__init__.py started re-exporting the dispatcher. Import each
+    package first in a clean interpreter to prove neither order breaks.
+    """
+    import subprocess
+    import sys
+
+    for first, second in (
+        ("pyguara.events", "pyguara.log"),
+        ("pyguara.log", "pyguara.events"),
+    ):
+        result = subprocess.run(
+            [sys.executable, "-c", f"import {first}; import {second}"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"{first} then {second} failed:\n{result.stderr}"
+
+
+def test_package_reexports_the_public_surface() -> None:
+    import pyguara.events as events
+
+    for name in ("EventDispatcher", "Event", "IEventDispatcher", "KeyDownEvent"):
+        assert hasattr(events, name), name
+
+
+# -- Event dataclasses --
+
+
+def test_event_timestamps_default_to_now() -> None:
+    import time as _time
+
+    from pyguara.events.input import KeyDownEvent, MouseMotionEvent
+    from pyguara.events.lifecycle import ApplicationStartEvent, QuitEvent
+    from pyguara.events.window import WindowResizeEvent
+
+    before = _time.time()
+    events = [
+        KeyDownEvent(key_code=32),
+        MouseMotionEvent(1, 2, 3, 4),
+        QuitEvent(),
+        ApplicationStartEvent(),
+        WindowResizeEvent(800, 600),
+    ]
+    after = _time.time()
+
+    for event in events:
+        assert before <= event.timestamp <= after, type(event).__name__
+
+
+def test_an_explicit_zero_timestamp_is_honoured() -> None:
+    """Every event class used `if self.timestamp == 0.0: self.timestamp =
+    time.time()`, which made 0.0 impossible to express -- a real value was
+    silently overwritten. field(default_factory=time.time) has no sentinel."""
+    from pyguara.events.input import KeyDownEvent
+    from pyguara.events.window import WindowResizeEvent
+
+    assert KeyDownEvent(key_code=32, timestamp=0.0).timestamp == 0.0
+    assert WindowResizeEvent(800, 600, timestamp=0.0).timestamp == 0.0
+
+
+def test_key_events_share_a_base_so_one_handler_catches_both(event_dispatcher) -> None:
+    from pyguara.events.input import KeyboardEvent, KeyDownEvent, KeyUpEvent
+
+    seen = []
+    event_dispatcher.subscribe(KeyboardEvent, lambda e: seen.append(type(e).__name__))
+
+    event_dispatcher.dispatch(KeyDownEvent(key_code=1))
+    event_dispatcher.dispatch(KeyUpEvent(key_code=1))
+
+    assert seen == ["KeyDownEvent", "KeyUpEvent"]
+
+
+# -- Filter errors follow the configured strategy --
+
+
+def test_filter_exception_is_raised_under_raise_strategy() -> None:
+    from unittest.mock import MagicMock
+
+    dispatcher = EventDispatcher(
+        logger=MagicMock(), error_strategy=ErrorHandlingStrategy.RAISE
+    )
+
+    def exploding_filter(_e):
+        raise ValueError("filter blew up")
+
+    dispatcher.subscribe(CustomEvent, lambda _e: None, filter_func=exploding_filter)
+
+    with pytest.raises(ValueError, match="filter blew up"):
+        dispatcher.dispatch(CustomEvent(data="x"))
+
+
+def test_filter_exception_is_swallowed_under_ignore_strategy() -> None:
+    """A filter is user code just like a handler, but its exceptions used to
+    escape the error strategy entirely -- IGNORE still propagated them."""
+    dispatcher = EventDispatcher(error_strategy=ErrorHandlingStrategy.IGNORE)
+
+    def exploding_filter(_e):
+        raise ValueError("filter blew up")
+
+    ran = []
+    dispatcher.subscribe(CustomEvent, lambda _e: None, filter_func=exploding_filter)
+    dispatcher.subscribe(CustomEvent, lambda _e: ran.append(1))
+
+    dispatcher.dispatch(CustomEvent(data="x"))
+
+    assert ran == [1], "a failing filter must not stop later handlers"
+
+
+def test_filter_exception_is_logged_and_skipped_under_log_strategy() -> None:
+    from unittest.mock import MagicMock
+
+    logger = MagicMock()
+    dispatcher = EventDispatcher(
+        logger=logger, error_strategy=ErrorHandlingStrategy.LOG
+    )
+
+    def exploding_filter(_e):
+        raise ValueError("filter blew up")
+
+    dispatcher.subscribe(CustomEvent, lambda _e: None, filter_func=exploding_filter)
+    dispatcher.dispatch(CustomEvent(data="x"))
+
+    logger.error.assert_called_once()
+    assert "filter blew up" in logger.error.call_args[0][0]
+
+
+# -- dispatch() reports consumption --
+
+
+def test_dispatch_returns_true_when_every_handler_runs(event_dispatcher) -> None:
+    event_dispatcher.subscribe(CustomEvent, lambda _e: None)
+    assert event_dispatcher.dispatch(CustomEvent(data="x")) is True
+
+
+def test_dispatch_returns_false_when_a_handler_consumes_the_event(
+    event_dispatcher,
+) -> None:
+    """Returning False already stopped lower-priority handlers, but dispatch()
+    returned None, so a caller could not tell a consumed event from a
+    delivered one -- the case UI-over-game input handling needs."""
+    event_dispatcher.subscribe(CustomEvent, lambda _e: False, priority=10)
+    event_dispatcher.subscribe(CustomEvent, lambda _e: None, priority=0)
+
+    assert event_dispatcher.dispatch(CustomEvent(data="x")) is False
+
+
+def test_dispatch_returns_true_with_no_subscribers(event_dispatcher) -> None:
+    assert event_dispatcher.dispatch(CustomEvent(data="x")) is True
+
+
+def test_a_filtered_out_handler_does_not_count_as_consuming(event_dispatcher) -> None:
+    event_dispatcher.subscribe(
+        CustomEvent, lambda _e: False, filter_func=lambda _e: False
+    )
+    assert event_dispatcher.dispatch(CustomEvent(data="x")) is True
+
+
+# -- Subscription bookkeeping --
+
+
+def test_handler_cache_reflects_a_subscription_added_later(event_dispatcher) -> None:
+    """dispatch() memoises the resolved handler list per event type; the cache
+    must be dropped whenever the subscription set changes."""
+    seen = []
+    event_dispatcher.dispatch(CustomEvent(data="first"))
+
+    event_dispatcher.subscribe(CustomEvent, lambda e: seen.append(e.data))
+    event_dispatcher.dispatch(CustomEvent(data="second"))
+
+    assert seen == ["second"]
+
+
+def test_handler_cache_reflects_an_unsubscription(event_dispatcher) -> None:
+    seen = []
+
+    def handler(e):
+        seen.append(e.data)
+
+    event_dispatcher.subscribe(CustomEvent, handler)
+    event_dispatcher.dispatch(CustomEvent(data="first"))
+
+    event_dispatcher.unsubscribe(CustomEvent, handler)
+    event_dispatcher.dispatch(CustomEvent(data="second"))
+
+    assert seen == ["first"]
+
+
+def test_handler_cache_reflects_a_base_class_subscription(event_dispatcher) -> None:
+    """A later subscription on a *base* class must invalidate the cache for
+    already-dispatched subclasses too."""
+    from pyguara.events.input import KeyboardEvent, KeyDownEvent
+
+    seen = []
+    event_dispatcher.dispatch(KeyDownEvent(key_code=1))
+
+    event_dispatcher.subscribe(KeyboardEvent, lambda _e: seen.append(1))
+    event_dispatcher.dispatch(KeyDownEvent(key_code=1))
+
+    assert seen == [1]
+
+
+def test_clear_subscribers_for_one_type_leaves_others(event_dispatcher) -> None:
+    from pyguara.events.lifecycle import QuitEvent
+
+    seen = []
+    event_dispatcher.subscribe(CustomEvent, lambda _e: seen.append("custom"))
+    event_dispatcher.subscribe(QuitEvent, lambda _e: seen.append("quit"))
+
+    event_dispatcher.clear_subscribers(CustomEvent)
+    event_dispatcher.dispatch(CustomEvent(data="x"))
+    event_dispatcher.dispatch(QuitEvent())
+
+    assert seen == ["quit"]
+
+
+def test_clear_subscribers_with_no_argument_clears_everything(event_dispatcher) -> None:
+    seen = []
+    event_dispatcher.subscribe(CustomEvent, lambda _e: seen.append(1))
+
+    event_dispatcher.clear_subscribers()
+    event_dispatcher.dispatch(CustomEvent(data="x"))
+
+    assert seen == []
+
+
+def test_unsubscribing_an_unknown_handler_is_a_noop(event_dispatcher) -> None:
+    event_dispatcher.unsubscribe(CustomEvent, lambda _e: None)
+
+
+def test_the_same_handler_subscribed_twice_runs_twice(event_dispatcher) -> None:
+    """Deliberate: a callable may be registered at two priorities or with two
+    filters, so subscriptions are distinct records, not deduplicated by
+    callback the way EntityManager's removal hook is."""
+    calls = []
+
+    def handler(_e):
+        calls.append(1)
+
+    event_dispatcher.subscribe(CustomEvent, handler, priority=10)
+    event_dispatcher.subscribe(CustomEvent, handler, priority=0)
+    event_dispatcher.dispatch(CustomEvent(data="x"))
+
+    assert len(calls) == 2
+
+
+def test_unsubscribe_removes_every_registration_of_a_handler(event_dispatcher) -> None:
+    calls = []
+
+    def handler(_e):
+        calls.append(1)
+
+    event_dispatcher.subscribe(CustomEvent, handler, priority=10)
+    event_dispatcher.subscribe(CustomEvent, handler, priority=0)
+    event_dispatcher.unsubscribe(CustomEvent, handler)
+    event_dispatcher.dispatch(CustomEvent(data="x"))
+
+    assert calls == []
+
+
+def test_the_handler_list_is_snapshotted_for_the_duration_of_a_dispatch(
+    event_dispatcher,
+) -> None:
+    """A handler that unsubscribes another still lets that one run for the
+    dispatch already in flight; the change takes effect on the next one."""
+    order = []
+
+    def second(_e):
+        order.append("second")
+
+    def first(_e):
+        order.append("first")
+        event_dispatcher.unsubscribe(CustomEvent, second)
+
+    event_dispatcher.subscribe(CustomEvent, first, priority=10)
+    event_dispatcher.subscribe(CustomEvent, second, priority=0)
+
+    event_dispatcher.dispatch(CustomEvent(data="x"))
+    event_dispatcher.dispatch(CustomEvent(data="y"))
+
+    assert order == ["first", "second", "first"]
+
+
+# -- Queue --
+
+
+def test_queue_event_is_safe_from_background_threads() -> None:
+    """queue_event() is the documented thread-safe entry point; prove it under
+    real contention rather than trusting queue.Queue by inspection."""
+    import threading
+
+    dispatcher = EventDispatcher()
+    received = []
+    dispatcher.subscribe(CustomEvent, lambda e: received.append(e.data))
+
+    def producer(worker: int) -> None:
+        for i in range(50):
+            dispatcher.queue_event(CustomEvent(data=f"{worker}-{i}"))
+
+    threads = [threading.Thread(target=producer, args=(w,)) for w in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert dispatcher.process_queue() == 200
+    assert len(set(received)) == 200
+
+
+def test_events_queued_by_a_handler_wait_for_the_next_drain() -> None:
+    dispatcher = EventDispatcher()
+    seen = []
+
+    def handler(e):
+        seen.append(e.data)
+        if e.data == "first":
+            dispatcher.queue_event(CustomEvent(data="second"))
+
+    dispatcher.subscribe(CustomEvent, handler)
+    dispatcher.queue_event(CustomEvent(data="first"))
+
+    assert dispatcher.process_queue() == 1
+    assert seen == ["first"]
+    assert dispatcher.process_queue() == 1
+    assert seen == ["first", "second"]
+
+
+# -- History --
+
+
+def test_history_can_be_filtered_by_type() -> None:
+    from pyguara.events.lifecycle import QuitEvent
+
+    dispatcher = EventDispatcher(enable_history=True)
+    dispatcher.dispatch(CustomEvent(data="x"))
+    dispatcher.dispatch(QuitEvent())
+
+    assert len(dispatcher.get_history()) == 2
+    assert len(dispatcher.get_history(QuitEvent)) == 1
+
+
+def test_history_size_is_configurable() -> None:
+    dispatcher = EventDispatcher(enable_history=True, max_history_size=3)
+    for i in range(10):
+        dispatcher.dispatch(CustomEvent(data=str(i)))
+
+    history = dispatcher.get_history()
+    assert len(history) == 3
+    assert [e.data for e in history] == ["7", "8", "9"]
+
+
+def test_get_history_returns_a_snapshot_not_the_live_deque() -> None:
+    dispatcher = EventDispatcher(enable_history=True)
+    dispatcher.dispatch(CustomEvent(data="x"))
+
+    dispatcher.get_history().clear()
+
+    assert len(dispatcher.get_history()) == 1


### PR DESCRIPTION
Third iteration of the incremental subsystem audit. Scope is `pyguara/events`.

> **Stacked on #2**, which is stacked on #1. Base is `refactor/common-audit`. Merge in order and each retargets cleanly.

## A latent `log` ⇄ `events` import cycle

`pyguara.log.events` inherits the `Event` protocol at runtime, so **log depends on events**. But `events.dispatcher` imported `pyguara.log` at module scope. Nothing ever failed — because `events/__init__.py` was empty.

I found it by adding re-exports to that `__init__.py`, an ordinary ergonomic change, which detonated both packages on first import. Anyone doing the same thing later would have hit it cold.

`events` is the more foundational package, so the fix belongs on its side: `EngineLogger` becomes a type-only import and the default logger resolves lazily inside `__init__`. A subprocess test now imports each package first in a clean interpreter, so neither order can regress. Generalised as **CC-8** — docstring-only `__init__.py` files don't just cost ergonomics, they *hide* cycles, and other packages may be concealing the same thing.

## 🐞 An explicit timestamp of `0.0` was silently overwritten

Every event dataclass in `input.py`, `lifecycle.py` and `window.py` used `timestamp: float = 0.0` plus a `__post_init__` replacing zero with `time.time()`. The sentinel is indistinguishable from a real value, so a fixed clock in a test, a replay origin, or a deliberately epoch-stamped event silently became "now".

`ecs/events.py` already used `field(default_factory=time.time)` correctly — the engine had two idioms for one thing and the more widely copied one was the broken one. The fix also deletes five copies of the same three-line hook.

## 🐞 `filter_func` exceptions bypassed the error strategy

Only the handler call sat inside the `try`, so a raising filter propagated even under `IGNORE`. A filter is user code exactly as a handler is; it now follows the same policy.

## `dispatch()` now returns `bool`

A handler returning `False` already stopped lower-priority handlers, but `dispatch()` returned `None`, so callers could not tell a consumed event from a delivered one — the exact case UI-over-game input handling needs. No in-repo caller used the return value, so this is additive. `IEventDispatcher` updated to match.

## Performance

`dispatch()` rebuilt and re-sorted the merged MRO handler list **on every call**, in the engine's hottest path. Now memoised per concrete event type, invalidated when the subscription set changes.

Measured over 20,000 dispatches with 50 handlers: **5.7 µs → 3.1 µs** per dispatch.

## Also

`max_history_size` is now a constructor parameter (it was hardcoded at 1000 while `enable_history` was configurable). `IEventDispatcher.subscribe` gained the `filter_func` parameter the implementation always had. `events/__init__.py` re-exports the public surface. Thread-safety boundaries, subclass matching, snapshot-during-dispatch and duplicate-subscription semantics are now documented rather than left to be discovered by probing.

## Tests

23 → 49. The existing dispatcher tests were genuinely good — behavioural, not mock-chasing — so this fills gaps rather than replacing anything: the event dataclasses (untested, and where the timestamp bug lived), filter error handling, `clear_subscribers`, history filtering and sizing, cache invalidation, and real multi-thread `queue_event` contention.

**1262 pass** (from 1236), ruff clean, mypy clean.

Worth noting: an existing test caught a regression I introduced — I dropped the exception text from the handler error message while restructuring. Restored. The suite did its job.

## Review notes

Three commits — `4d9411e` (timestamps), `40e9fa5` (dispatcher), `0ecd5ed` (docs). Each was checked out into an isolated worktree and run independently: 1236 / 1262 / 1262 passing, no red intermediate state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
