### PR TITLE
refactor(di): audit pass — a lock bug that fabricated circular dependencies, plus captive lifetimes

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -12,7 +12,7 @@ rather than fixed in place.
 
 ## Active Subsystem
 
-`pyguara/events` — **in review (awaiting approval)**
+`pyguara/di` — **in review (awaiting approval)**
 
 ---
 
@@ -23,8 +23,8 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 ### Tier 1 — Foundations (no intra-engine dependencies)
 - [x] `pyguara/common` — Vector2, Color, Rect, shared components *(done)*
 - [ ] `pyguara/log` — logging facade
-- [x] `pyguara/events` — EventDispatcher, Event protocol *(active)*
-- [ ] `pyguara/di` — DIContainer, auto-wiring, lifetimes
+- [x] `pyguara/events` — EventDispatcher, Event protocol *(done)*
+- [x] `pyguara/di` — DIContainer, auto-wiring, lifetimes *(active)*
 
 ### Tier 2 — Core runtime
 - [x] `pyguara/ecs` — Entity, Component, EntityManager, QueryCache *(done)*
@@ -59,6 +59,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/events` | 2026-09-06 | Broke a latent `log` <-> `events` import cycle, fixed a timestamp sentinel that made 0.0 inexpressible, brought filter errors under the error strategy, and memoised handler resolution (5.7us -> 3.1us per dispatch). PR #3. |
 | `pyguara/common` | 2026-09-06 | Fixed `Transform.up` pointing down, an unguarded parent cycle and a falsy-`Vector2` default; renamed `Vector2.rotate` to `rotate_degrees`; wrote the first tests for `Vector2` and `Transform`. PR #2. |
 | `pyguara/ecs` | 2026-09-06 | Fixed two silent query bugs (`add_entity()` bypassing the query cache; dead-entity resurrection), replaced the private removal hook with a subscribe/unsubscribe API, and modernised the module. PR #1. |
 
@@ -127,6 +128,16 @@ is deliberately not attempted piecemeal. **Fix:** once `physics`, `ui` and `ai`
 are audited and the true extent is known, migrate the tree to `StrictComponent`
 and consider making it the default.
 *Discovered in:* `ecs`; offender identified in `common`. *Status:* parked.
+
+### CC-9 — `ErrorHandlingStrategy` is defined twice
+`pyguara/di/types.py` and `pyguara/events/types.py` each declare their own enum
+of the same name with identical members (LOG / RAISE / IGNORE) and identical
+semantics. They are not interchangeable -- `di.RAISE != events.RAISE` -- so
+passing one where the other is expected fails a comparison silently rather than
+loudly. **Fix:** hoist a single definition to a shared home once more
+subsystems are audited and the full set of consumers is known; `di` must not
+import `events` (see CC-8) so it cannot simply re-export.
+*Discovered in:* `di`. *Status:* open.
 
 ### CC-8 — Package `__init__.py` files export nothing
 Most subsystem packages have a docstring-only `__init__.py`, so callers reach
@@ -255,7 +266,7 @@ fixture, so the most intricate logic in the package was exercised by accident.
 **Deferred:** CC-1 through CC-4, CC-6, CC-7, and the remaining half of CC-5.
 
 
-### `pyguara/events` — awaiting approval (2026-09-06)
+### `pyguara/events` — CLOSED 2026-09-06 (PR #3, branch `refactor/events-audit`)
 
 **Verification:** 1262/1262 tests pass (up from 1236); ruff clean; mypy clean.
 
@@ -309,3 +320,53 @@ exception text from the handler error message. Restored.
 condensed to a summary and link.
 
 **Deferred:** CC-1 through CC-4, CC-6, CC-7, CC-8, and the rest of CC-5.
+
+
+### `pyguara/di` — awaiting approval (2026-09-06)
+
+**Verification:** 1286/1286 tests pass (up from 1262); ruff clean; mypy clean.
+
+**Correctness fixes (all reproduced by probe before fixing):**
+- **`DIScope.get()` resolved without taking the container lock**, so parallel
+  resolutions through scopes shared one mutable cycle-detection stack and saw
+  each other's partial chains. With constructors that take a couple of
+  milliseconds this reported **140 spurious CircularDependencyExceptions out
+  of 160 resolutions**. It hid because every constructor in the test suite is
+  instant. Fixed twice over, deliberately: the scope now takes the lock like
+  the container does, and the resolution stack is thread-local, so the
+  invariant holds structurally rather than by remembering to lock -- which is
+  exactly the discipline that failed here.
+- **Captive dependency.** A singleton resolved inside a scope captured the
+  scoped instance; the scope disposed it and the singleton kept handing out
+  the dead object forever. Singletons are now built with `scope=None`, so the
+  attempt raises with a message explaining why.
+- **A disposed scope still resolved**, tracking new disposables in a list it
+  had already emptied -- they would never be cleaned up. Now raises.
+- **Re-registering an already-resolved singleton silently did nothing.** The
+  registration was replaced but the cached instance was not, so `get()` kept
+  returning the old implementation. The cached instance is now evicted.
+- **`*args`/`**kwargs` were treated as injection points.** `*args: int` was
+  read as a dependency named "args" of type `int`, making any class that
+  declares varargs unresolvable. Only POSITIONAL_OR_KEYWORD and KEYWORD_ONLY
+  parameters are considered now.
+- **`DIScope.dispose()` swallowed every exception** with a bare
+  `except Exception: pass`. Failures are logged, and the remaining services
+  are still disposed.
+
+**API additions:** `DIContainer.is_registered()` and `DIScope.disposed`, both
+needed to write the tests above without reaching into privates.
+
+**Also:** `_create_instance` could fall off the end and return None for a
+malformed registration; it now raises. Modern typing, Google-style docstrings,
+P2-003 ticket references removed from public docstrings (CC-3).
+
+**Tests:** 26 -> 40. The existing tests were reasonable but entirely
+single-threaded and single-scope, which is why the lock bug survived. Added
+lifetime-capture rules, disposal semantics, re-registration, signature edge
+cases, and three genuine concurrency tests.
+
+**Docs:** new `docs/core/dependency-injection.md`; `architecture.md`'s DI
+section condensed to a summary and link. That file's three original sections
+(ECS, DI, Events) are now all summaries pointing at dedicated pages.
+
+**Deferred:** CC-1 through CC-4, CC-6 through CC-9, and the rest of CC-5.

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -33,26 +33,25 @@ See **[Entity Component System](ecs.md)** for the full reference.
 
 # Dependency Injection (DI)
 
-PyGuara features a native, reflection-based Dependency Injection container (`pyguara.di`).
-
-## Features
-
-- **Auto-Wiring**: Uses Python type hints (`typing.get_type_hints`) and `inspect` to automatically resolve constructor dependencies.
-- **Cycle Detection**: Detects and reports circular dependencies at runtime.
-- **Scopes**:
-    - `SINGLETON`: Shared across the entire application.
-    - `TRANSIENT`: Created new every time requested.
-    - `SCOPED`: Shared within a specific context (e.g., a Scene).
-
-## Usage
+The container (`pyguara.di`) resolves constructor dependencies from type hints.
+Three lifetimes: `SINGLETON` (one per container), `SCOPED` (one per `DIScope`)
+and `TRANSIENT` (one per request).
 
 ```python
 container = DIContainer()
 container.register_singleton(IPhysicsEngine, PymunkEngine)
-
-# Application is auto-wired with IPhysicsEngine
-app = container.get(Application)
+app = container.get(Application)   # dependencies injected recursively
 ```
+
+Two rules are load-bearing:
+
+- **Lifetimes cannot be captured downwards.** A singleton may not depend on a
+  scoped service; it would outlive the scope and keep a disposed object. The
+  container builds singletons without a scope so the attempt fails loudly.
+- **Cycles raise.** `CircularDependencyException` names the chain, and
+  detection state is thread-local so parallel resolutions cannot cross.
+
+See **[Dependency Injection](dependency-injection.md)** for the full reference.
 
 ---
 

--- a/docs/core/dependency-injection.md
+++ b/docs/core/dependency-injection.md
@@ -1,0 +1,168 @@
+# Dependency Injection
+
+`pyguara.di` is a reflection-based container. Services are registered against
+an interface type and constructed by reading their constructor's type hints —
+no attributes, no registration DSL.
+
+```python
+container = DIContainer()
+container.register_singleton(IPhysicsEngine, PymunkEngine)
+container.register_transient(IProjectile, Bullet)
+
+engine = container.get(IPhysicsEngine)
+```
+
+Anything the constructor annotates is resolved recursively:
+
+```python
+class PhysicsSystem:
+    def __init__(self, engine: IPhysicsEngine, dispatcher: EventDispatcher) -> None:
+        ...
+
+container.get(PhysicsSystem)   # both arguments injected
+```
+
+## Lifetimes
+
+| Lifetime | Instances | Use for |
+| --- | --- | --- |
+| `SINGLETON` | One per container | Engine services: renderer, physics, audio |
+| `SCOPED` | One per `DIScope` | Per-scene or per-request resources |
+| `TRANSIENT` | One per request | Stateless helpers, short-lived objects |
+
+```python
+container.register_singleton(IRenderer, PygameBackend)
+container.register_scoped(ILevelCache, LevelCache)
+container.register_transient(IPathfinder, AStarPathfinder)
+container.register_instance(IConfig, loaded_config)   # pre-built object
+```
+
+`register_instance()` validates the object against the interface when that
+interface is a `@runtime_checkable` Protocol — the only registration that can
+check anything up front, since the others have a class and no instance yet.
+
+Re-registering a type replaces it, **including any singleton already handed
+out**. A later `get()` returns the new implementation.
+
+### Lifetimes must not be captured downwards
+
+A singleton may depend on singletons and transients. It may **not** depend on
+a scoped service:
+
+```python
+container.register_scoped(ILevelCache, LevelCache)
+container.register_singleton(IWorld, World)   # World(cache: ILevelCache)
+
+with container.create_scope() as scope:
+    scope.get(IWorld)     # DIException
+```
+
+This is the captive-dependency problem. The singleton outlives the scope, so
+it would keep holding a `LevelCache` the scope had already disposed. Singletons
+are therefore always constructed **without** a scope, and the attempt fails
+loudly rather than producing an object that silently rots.
+
+The safe directions:
+
+| Consumer | May depend on |
+| --- | --- |
+| Singleton | Singleton, Transient |
+| Scoped | Singleton, Scoped, Transient |
+| Transient | Singleton, Scoped, Transient |
+
+## Scopes
+
+A scope owns one instance of each scoped service and disposes them when it
+closes. Always use it as a context manager:
+
+```python
+with container.create_scope() as scope:
+    cache = scope.get(ILevelCache)
+    assert scope.get(ILevelCache) is cache
+# scope disposed
+```
+
+On disposal, each scoped instance is torn down newest-first via `dispose()`,
+or `close()` if it has no `dispose()`. A teardown that raises is **logged and
+skipped**, so one broken object cannot strand the rest.
+
+A disposed scope refuses to resolve — anything created afterwards would never
+be cleaned up:
+
+```python
+scope.dispose()
+scope.get(ILevelCache)     # DIException
+```
+
+## Optional dependencies
+
+`Optional[X]` and `X | None` resolve to `X`. A wider union takes its first
+non-`None` member.
+
+A dependency that is not registered raises `ServiceNotFoundException` — unless
+the parameter declares a default, in which case it is skipped and Python
+supplies the default:
+
+```python
+class Renderer:
+    def __init__(self, profiler: IProfiler | None = None) -> None:
+        ...   # profiler is None when IProfiler was never registered
+```
+
+`*args` and `**kwargs` are never injection points and are skipped entirely.
+
+## Cycle detection
+
+A dependency cycle raises `CircularDependencyException` naming the chain:
+
+```
+Circular dependency detected: ServiceA -> ServiceB -> ServiceA
+```
+
+Detection state is **thread-local**, so a resolution on one thread never sees
+another's partial chain.
+
+## Threading
+
+Registration and resolution are guarded by a reentrant lock, so a singleton is
+constructed at most once even under contention, and resolving through a
+`DIScope` takes the same lock as resolving through the container.
+
+The lock is held for the whole resolution, constructors included, so a slow
+constructor blocks other threads for its duration. Build the container during
+bootstrap rather than resolving on hot paths from several threads.
+
+## Decorators
+
+Classes may carry their own registration metadata:
+
+```python
+@singleton(IPhysicsEngine)
+class PymunkEngine: ...
+
+@scoped(ILevelCache)
+class LevelCache: ...
+
+auto_register(container, PymunkEngine, LevelCache)
+```
+
+## Error strategy
+
+Controls what happens when the container cannot read a constructor's hints —
+an unresolvable forward reference, say:
+
+| Strategy | Behaviour |
+| --- | --- |
+| `RAISE` *(default)* | Log, then raise `DIException`. Fail fast. |
+| `LOG` | Log and register with no dependencies. |
+| `IGNORE` | Register with no dependencies, silently. |
+
+## Rules of thumb
+
+1. Register everything during bootstrap; resolve, don't re-register, later.
+2. Singletons never depend on scoped services. Push shared state up, or make
+   the consumer scoped too.
+3. Scopes belong in `with` blocks.
+4. Annotate constructors. An unannotated parameter is invisible to injection.
+5. Give a parameter a default when the dependency is genuinely optional; that
+   is the only thing that makes a missing registration non-fatal.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
       - Entity Component System: core/ecs.md
       - Core Types: core/common-types.md
       - Event System: core/events.md
+      - Dependency Injection: core/dependency-injection.md
       - Application & Lifecycle: core/application.md
       - Logging: core/logging.md
   - Graphics:

--- a/pyguara/di/container.py
+++ b/pyguara/di/container.py
@@ -1,18 +1,13 @@
-"""Core container and scope logic."""
+"""Dependency injection container and scopes."""
 
 from __future__ import annotations
 
 import inspect
-from pyguara.log import get_logger
 import threading
 import types
 from typing import (
     Any,
     Callable,
-    Dict,
-    List,
-    Optional,
-    Type,
     TypeVar,
     Union,
     cast,
@@ -26,7 +21,8 @@ from pyguara.di.exceptions import (
     DIException,
     ServiceNotFoundException,
 )
-from pyguara.di.types import ServiceLifetime, ServiceRegistration, ErrorHandlingStrategy
+from pyguara.di.types import ErrorHandlingStrategy, ServiceLifetime, ServiceRegistration
+from pyguara.log import get_logger
 
 logger = get_logger(__name__)
 
@@ -34,65 +30,126 @@ T = TypeVar("T")
 TInterface = TypeVar("TInterface")
 TImplementation = TypeVar("TImplementation")
 
+_INJECTABLE_KINDS = frozenset(
+    {
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    }
+)
+
 
 class DIContainer:
-    """Lightweight dependency injection container with lifecycle management."""
+    """Reflection-based dependency injection container.
+
+    Services are registered against an interface type and constructed by
+    reading their constructor's type hints. Three lifetimes are supported:
+    SINGLETON (one per container), SCOPED (one per `DIScope`) and TRANSIENT
+    (a fresh instance per request).
+
+    Thread safety:
+        Registration and resolution are guarded by a reentrant lock, so a
+        service is constructed at most once even under contention. Cycle
+        detection state is thread-local, so concurrent resolutions on
+        different threads cannot see each other's partial chains.
+    """
 
     def __init__(
         self, error_strategy: ErrorHandlingStrategy = ErrorHandlingStrategy.RAISE
     ) -> None:
-        """Initialize an empty container.
+        """Initialise an empty container.
 
         Args:
-            error_strategy: How to handle errors during dependency resolution.
-                Defaults to RAISE for fail-fast behavior in development.
-                Use LOG for production graceful degradation.
+            error_strategy: What to do when dependency extraction fails.
+                RAISE fails fast in development; LOG degrades gracefully.
         """
-        self._services: Dict[Type[Any], ServiceRegistration] = {}
-        self._singletons: Dict[Type[Any], Any] = {}
+        self._services: dict[type[Any], ServiceRegistration] = {}
+        self._singletons: dict[type[Any], Any] = {}
         self._lock = threading.RLock()
-        self._resolution_stack: List[Type] = []
         self._error_strategy = error_strategy
 
+        # Thread-local, not shared: this tracks one in-flight resolution chain.
+        # A single shared list made concurrent resolutions see each other's
+        # partial chains and raise CircularDependencyException at random.
+        self._local = threading.local()
+
+    @property
+    def _resolution_stack(self) -> list[type[Any]]:
+        """The current thread's in-flight resolution chain."""
+        stack: list[type[Any]] | None = getattr(self._local, "stack", None)
+        if stack is None:
+            stack = []
+            self._local.stack = stack
+        return stack
+
     def register_singleton(
-        self, interface: Type[TInterface], implementation: Type[TImplementation]
+        self, interface: type[TInterface], implementation: type[TImplementation]
     ) -> DIContainer:
-        """Register a service as a singleton (shared instance)."""
+        """Register a service constructed once and shared container-wide.
+
+        Args:
+            interface: The type callers will request.
+            implementation: The concrete class to construct.
+
+        Returns:
+            This container, for chaining.
+        """
         return self._register_service(
             interface, implementation=implementation, lifetime=ServiceLifetime.SINGLETON
         )
 
     def register_transient(
-        self, interface: Type[TInterface], implementation: Type[TImplementation]
+        self, interface: type[TInterface], implementation: type[TImplementation]
     ) -> DIContainer:
-        """Register a service as transient (fresh instance every time)."""
+        """Register a service constructed fresh on every request.
+
+        Args:
+            interface: The type callers will request.
+            implementation: The concrete class to construct.
+
+        Returns:
+            This container, for chaining.
+        """
         return self._register_service(
             interface, implementation=implementation, lifetime=ServiceLifetime.TRANSIENT
         )
 
     def register_scoped(
-        self, interface: Type[TInterface], implementation: Type[TImplementation]
+        self, interface: type[TInterface], implementation: type[TImplementation]
     ) -> DIContainer:
-        """Register a service as scoped (shared within a scope)."""
+        """Register a service constructed once per `DIScope`.
+
+        Args:
+            interface: The type callers will request.
+            implementation: The concrete class to construct.
+
+        Returns:
+            This container, for chaining.
+        """
         return self._register_service(
             interface, implementation=implementation, lifetime=ServiceLifetime.SCOPED
         )
 
     def register_instance(
-        self, interface: Type[TInterface], instance: TInterface
+        self, interface: type[TInterface], instance: TInterface
     ) -> DIContainer:
-        """Register an existing object as a singleton.
+        """Register an already-built object as the singleton for a type.
+
+        Args:
+            interface: The type callers will request.
+            instance: The object to hand out.
+
+        Returns:
+            This container, for chaining.
 
         Raises:
             DIException: If `interface` is a `@runtime_checkable` Protocol and
-                `instance` doesn't structurally satisfy it. Only checked for
-                Protocols -- concrete-class interfaces are left alone, since at
-                least one deliberately registers an instance that is *not* a
-                real subclass (BOOT-1's Pygame `RenderGraph` stub, branched on
-                by identity elsewhere rather than treated as a real one). This
-                is also the only registration method that can check anything at
-                registration time at all -- the others only have a class, not
-                yet an instance.
+                `instance` does not structurally satisfy it. Only Protocols are
+                checked; concrete-class interfaces are left alone, since at
+                least one registration deliberately supplies an instance that
+                is not a real subclass (the Pygame `RenderGraph` stub, branched
+                on by identity elsewhere). This is also the only registration
+                that can validate anything up front -- the others have a class
+                and no instance yet.
         """
         with self._lock:
             if getattr(interface, "_is_protocol", False) and not isinstance(
@@ -113,40 +170,84 @@ class DIContainer:
             self._singletons[interface] = instance
             return self
 
-    def get(self, service_type: Type[T]) -> T:
-        """Resolve and retrieve an instance of the requested service."""
+    def is_registered(self, service_type: type[Any]) -> bool:
+        """Report whether a type has a registration.
+
+        Args:
+            service_type: The type to check.
+
+        Returns:
+            True if the type can be resolved.
+        """
+        with self._lock:
+            return service_type in self._services
+
+    def get(self, service_type: type[T]) -> T:
+        """Resolve a service, constructing it and its dependencies as needed.
+
+        Args:
+            service_type: The registered interface type to resolve.
+
+        Returns:
+            An instance of the requested service.
+
+        Raises:
+            ServiceNotFoundException: If the type was never registered.
+            CircularDependencyException: If the dependency graph has a cycle.
+            DIException: If a scoped service is requested without a scope.
+        """
         with self._lock:
             return self._resolve_service(service_type)
 
     def create_scope(self) -> DIScope:
-        """Create a new resource scope."""
+        """Create a scope for resolving scoped services.
+
+        Returns:
+            A new scope. Use it as a context manager so it disposes.
+        """
         return DIScope(self)
 
     def _register_service(
         self,
-        interface: Type[TInterface],
-        implementation: Optional[Type[TImplementation]] = None,
-        factory: Optional[Callable[..., TInterface]] = None,
-        instance: Optional[TInterface] = None,
+        interface: type[TInterface],
+        implementation: type[TImplementation] | None = None,
+        factory: Callable[..., TInterface] | None = None,
+        instance: TInterface | None = None,
         lifetime: ServiceLifetime = ServiceLifetime.TRANSIENT,
     ) -> DIContainer:
+        """Record a registration and pre-compute its constructor dependencies.
+
+        Args:
+            interface: The type callers will request.
+            implementation: Concrete class to construct, if any.
+            factory: Callable producing the instance, if any.
+            instance: Pre-built object, if any.
+            lifetime: The lifecycle strategy.
+
+        Returns:
+            This container, for chaining.
+
+        Raises:
+            DIException: Unless exactly one provider is given.
+        """
         with self._lock:
             providers = [implementation, factory, instance]
             if sum(p is not None for p in providers) != 1:
                 raise DIException(
-                    "Exactly one of implementation, factory, or instance must be provided"
+                    "Exactly one of implementation, factory, or instance "
+                    "must be provided"
                 )
 
-            dependencies: Dict[str, Type] = {}
+            dependencies: dict[str, type[Any]] = {}
             param_defaults: set[str] = set()
-            if implementation:
+            if implementation is not None:
                 dependencies, param_defaults = self._extract_dependencies(
                     implementation
                 )
-            elif factory:
+            elif factory is not None:
                 dependencies, param_defaults = self._extract_dependencies(factory)
 
-            registration = ServiceRegistration(
+            self._services[interface] = ServiceRegistration(
                 interface=interface,
                 implementation=implementation,
                 factory=factory,
@@ -155,233 +256,305 @@ class DIContainer:
                 dependencies=dependencies,
                 param_defaults=param_defaults,
             )
-
-            self._services[interface] = registration
+            # Drop any instance cached under a previous registration; otherwise
+            # re-registering a type that had already been resolved silently
+            # kept handing out the old object.
+            self._singletons.pop(interface, None)
             return self
 
     def _resolve_service(
-        self, service_type: Type[T], scope: Optional[DIScope] = None
+        self, service_type: type[T], scope: DIScope | None = None
     ) -> T:
-        # 1. Cycle Detection
-        if service_type in self._resolution_stack:
-            raise CircularDependencyException(self._resolution_stack + [service_type])
+        """Resolve one service, recursing through its dependencies.
 
-        # 2. Lookup
-        if service_type not in self._services:
+        Args:
+            service_type: The interface type to resolve.
+            scope: The active scope, if resolution started from one.
+
+        Returns:
+            The resolved instance.
+
+        Raises:
+            CircularDependencyException: If this type is already being built
+                further up this thread's chain.
+            ServiceNotFoundException: If the type was never registered.
+            DIException: If a scoped service is reached without a scope.
+        """
+        stack = self._resolution_stack
+        if service_type in stack:
+            raise CircularDependencyException([*stack, service_type])
+
+        registration = self._services.get(service_type)
+        if registration is None:
             raise ServiceNotFoundException(service_type)
 
-        registration = self._services[service_type]
-
-        # 3. Strategy Execution
-        if registration.lifetime == ServiceLifetime.SINGLETON:
-            if service_type in self._singletons:
-                return cast(T, self._singletons[service_type])
-
-            self._resolution_stack.append(service_type)
-            try:
-                instance = self._create_instance(registration, scope)
+        stack.append(service_type)
+        try:
+            if registration.lifetime is ServiceLifetime.SINGLETON:
+                if service_type in self._singletons:
+                    return cast(T, self._singletons[service_type])
+                # Deliberately scope=None: a container-lived singleton must not
+                # capture a scope-lived dependency, which would outlive its
+                # owner and be disposed out from under it.
+                instance = self._create_instance(registration, None)
                 self._singletons[service_type] = instance
                 return cast(T, instance)
-            finally:
-                self._resolution_stack.pop()
 
-        elif registration.lifetime == ServiceLifetime.SCOPED:
-            if scope is None:
-                raise DIException(
-                    f"Scoped service {service_type.__name__} requires an active scope"
-                )
-            self._resolution_stack.append(service_type)
-            try:
+            if registration.lifetime is ServiceLifetime.SCOPED:
+                if scope is None:
+                    raise DIException(
+                        f"Scoped service {service_type.__name__!r} requires an "
+                        f"active scope. Either resolve it through "
+                        f"DIContainer.create_scope(), or -- if it is being "
+                        f"pulled in as a dependency of a singleton -- note that "
+                        f"singletons are resolved without a scope on purpose, "
+                        f"since a container-lived object must not capture a "
+                        f"scope-lived one."
+                    )
                 return scope._get_scoped_service(service_type, registration)
-            finally:
-                self._resolution_stack.pop()
 
-        else:  # TRANSIENT
-            self._resolution_stack.append(service_type)
-            try:
-                return cast(T, self._create_instance(registration, scope))
-            finally:
-                self._resolution_stack.pop()
+            return cast(T, self._create_instance(registration, scope))
+        finally:
+            stack.pop()
 
     def _create_instance(
-        self, registration: ServiceRegistration, scope: Optional[DIScope] = None
+        self, registration: ServiceRegistration, scope: DIScope | None = None
     ) -> Any:
+        """Construct an instance for a registration.
+
+        Args:
+            registration: The registration to build.
+            scope: The active scope, if any.
+
+        Returns:
+            The constructed object.
+
+        Raises:
+            DIException: If the registration has no usable provider.
+        """
         if registration.instance is not None:
             return registration.instance
 
-        target = registration.implementation or registration.factory
-        if target is None:
-            raise DIException("Invalid registration state")
-
-        # P2-003: Pass cached param_defaults instead of target
         kwargs = self._resolve_dependencies(
             registration.dependencies or {},
             registration.param_defaults or set(),
             scope,
         )
 
-        if registration.factory:
+        if registration.factory is not None:
             return registration.factory(**kwargs)
-
-        if registration.implementation:
+        if registration.implementation is not None:
             return registration.implementation(**kwargs)
+
+        raise DIException(
+            f"Registration for {registration.interface.__name__!r} has no "
+            f"implementation, factory or instance."
+        )
 
     def _resolve_dependencies(
         self,
-        dependencies: Dict[str, Type],
+        dependencies: dict[str, type[Any]],
         param_defaults: set[str],
-        scope: Optional[DIScope],
-    ) -> Dict[str, Any]:
-        """Resolve dependencies recursively, respecting default arguments.
+        scope: DIScope | None,
+    ) -> dict[str, Any]:
+        """Resolve constructor arguments, skipping ones that have defaults.
 
         Args:
-            dependencies: Map of parameter names to types.
-            param_defaults: Set of parameter names with default values
-                (cached during registration to avoid inspect at runtime).
-            scope: Optional scope for scoped services.
+            dependencies: Parameter name to required type.
+            param_defaults: Parameter names that declare a default, computed at
+                registration so resolution never calls `inspect` at runtime.
+            scope: The active scope, if any.
 
         Returns:
-            Dict of resolved parameter name to instance.
+            Keyword arguments for the constructor. A parameter whose service is
+            unregistered is omitted when it has a default, so Python supplies
+            it.
 
-        Note:
-            P2-003: This method no longer uses inspect.signature() at runtime.
-            Default parameters are cached during registration.
+        Raises:
+            ServiceNotFoundException: If a dependency without a default is
+                unregistered.
         """
         resolved_kwargs = {}
 
         for param_name, dep_type in dependencies.items():
             try:
-                instance = self._resolve_service(dep_type, scope)
-                resolved_kwargs[param_name] = instance
+                resolved_kwargs[param_name] = self._resolve_service(dep_type, scope)
             except ServiceNotFoundException:
-                # P2-003: Use cached default info instead of inspect.signature
                 if param_name in param_defaults:
-                    continue  # Let Python use the default value
+                    continue
                 raise
 
         return resolved_kwargs
 
     def _extract_dependencies(
-        self, target: Union[Type, Callable]
-    ) -> tuple[Dict[str, Type], set[str]]:
-        """Extract type hints and default parameters at registration time.
+        self, target: type[Any] | Callable[..., Any]
+    ) -> tuple[dict[str, type[Any]], set[str]]:
+        """Read a constructor's injectable parameters, once, at registration.
+
+        `*args` and `**kwargs` are skipped: they are not injection points, and
+        treating them as such made any class declaring them unresolvable.
+        `Optional[X]` and `X | None` resolve to `X`; a wider union takes its
+        first non-None member.
+
+        Args:
+            target: The class or factory to inspect.
 
         Returns:
-            Tuple of (dependencies dict, param_defaults set)
+            A `(dependencies, param_defaults)` pair.
+
+        Raises:
+            DIException: If inspection fails and the error strategy is RAISE.
         """
         try:
-            # We still need explicit check here for get_type_hints
-            # But we wrap it safely or assume inspect.isclass handles it.
-            func = target
+            func: Any = target
             if inspect.isclass(target):
-                # Safe access for Class types
                 func = getattr(target, "__init__", target)
 
             hints = get_type_hints(func)
-            sig = inspect.signature(func)
+            signature = inspect.signature(func)
 
-            dependencies = {}
-            param_defaults = set()
-            for param_name, param in sig.parameters.items():
-                if param_name == "self":
+            dependencies: dict[str, type[Any]] = {}
+            param_defaults: set[str] = set()
+            for param_name, param in signature.parameters.items():
+                if param_name == "self" or param.kind not in _INJECTABLE_KINDS:
                     continue
 
-                # Cache which parameters have defaults (P2-003: avoid runtime inspect)
-                if param.default != inspect.Parameter.empty:
+                if param.default is not inspect.Parameter.empty:
                     param_defaults.add(param_name)
 
-                if param_name in hints:
-                    param_type = hints[param_name]
-                    origin = get_origin(param_type)
-                    if origin is Union or origin is types.UnionType:
-                        args = get_args(param_type)
-                        valid_args = [arg for arg in args if arg is not type(None)]
-                        if valid_args:
-                            param_type = valid_args[0]
+                if param_name not in hints:
+                    continue
 
-                    dependencies[param_name] = param_type
+                param_type = hints[param_name]
+                if get_origin(param_type) in (Union, types.UnionType):
+                    non_none = [a for a in get_args(param_type) if a is not type(None)]
+                    if non_none:
+                        param_type = non_none[0]
+                dependencies[param_name] = param_type
+
             return dependencies, param_defaults
-        except Exception as e:
-            # Handle error based on configured strategy
+        except Exception as error:
             target_name = getattr(target, "__name__", str(target))
             error_msg = (
-                f"[DI] Dependency extraction failed for '{target_name}': {e}. "
+                f"[DI] Dependency extraction failed for {target_name!r}: {error}. "
                 f"This may cause injection failures if the service is requested."
             )
 
-            if self._error_strategy == ErrorHandlingStrategy.IGNORE:
-                # Silently ignore (not recommended)
+            if self._error_strategy is ErrorHandlingStrategy.IGNORE:
                 return {}, set()
-            elif self._error_strategy == ErrorHandlingStrategy.LOG:
-                # Log and return empty dict/set (graceful degradation)
-                logger.error(error_msg)
+
+            logger.error(error_msg)
+            if self._error_strategy is ErrorHandlingStrategy.LOG:
                 return {}, set()
-            else:  # ErrorHandlingStrategy.RAISE
-                # Log and re-raise
-                logger.error(error_msg)
-                raise DIException(
-                    f"Failed to extract dependencies from {target_name}: {e}"
-                ) from e
+
+            raise DIException(
+                f"Failed to extract dependencies from {target_name}: {error}"
+            ) from error
 
 
 class DIScope:
-    """Service scope for managing scoped lifetimes and cleanup.
+    """A resolution context owning one instance of each scoped service.
 
-    Scopes are used to manage the lifetime of scoped services. Services
-    registered as scoped will have one instance per scope, shared across
-    all requests within that scope.
+    Scoped services are created once per scope and disposed when it closes.
+    Singletons and transients resolve as usual through the container.
 
-    Example:
-        >>> container = DIContainer()
-        >>> container.register_scoped(IDatabase, DatabaseConnection)
-        >>>
-        >>> with container.create_scope() as scope:
-        ...     db1 = scope.get(IDatabase)  # Creates new instance
-        ...     db2 = scope.get(IDatabase)  # Returns same instance
-        ...     assert db1 is db2
-        >>> # Scope disposed, resources cleaned up
+    Use it as a context manager so disposal always runs:
+
+    ```python
+    container.register_scoped(IDatabase, DatabaseConnection)
+
+    with container.create_scope() as scope:
+        db = scope.get(IDatabase)
+        assert scope.get(IDatabase) is db
+    # scope disposed; db.dispose() called
+    ```
     """
 
     def __init__(self, container: DIContainer) -> None:
-        """Initialize a new scope."""
-        self._container = container
-        self._scoped_services: Dict[Type[Any], Any] = {}
-        self._disposed = False
-        self._disposables: List[Any] = []
-        self._lock = threading.RLock()
-
-    def get(self, service_type: Type[T]) -> T:
-        """Resolve and retrieve a service instance within this scope.
-
-        This is the primary public API for resolving services within a scope.
-        Scoped services will be shared within this scope, while singletons
-        will return the global instance, and transients will create new instances.
+        """Initialise an empty scope.
 
         Args:
-            service_type: The type of service to resolve.
+            container: The container this scope resolves against.
+        """
+        self._container = container
+        self._scoped_services: dict[type[Any], Any] = {}
+        self._disposed = False
+        self._disposables: list[Any] = []
+        self._lock = threading.RLock()
+
+    @property
+    def disposed(self) -> bool:
+        """Whether this scope has been disposed."""
+        return self._disposed
+
+    def get(self, service_type: type[T]) -> T:
+        """Resolve a service within this scope.
+
+        Args:
+            service_type: The registered interface type to resolve.
 
         Returns:
-            An instance of the requested service.
+            An instance. Scoped services are shared within this scope;
+            singletons come from the container; transients are fresh.
 
         Raises:
+            DIException: If this scope has already been disposed. Anything
+                created afterwards would never be cleaned up.
             ServiceNotFoundException: If the service is not registered.
-            CircularDependencyException: If a circular dependency is detected.
-            DIException: If attempting to resolve a scoped service without a scope.
-
-        Example:
-            >>> container = DIContainer()
-            >>> container.register_scoped(ILogger, FileLogger)
-            >>> container.register_singleton(IConfig, AppConfig)
-            >>>
-            >>> with container.create_scope() as scope:
-            ...     logger = scope.get(ILogger)  # Scoped instance
-            ...     config = scope.get(IConfig)  # Singleton instance
+            CircularDependencyException: If the dependency graph has a cycle.
         """
-        return self._container._resolve_service(service_type, scope=self)
+        if self._disposed:
+            raise DIException(
+                "Cannot resolve from a disposed DIScope; anything created now "
+                "would never be disposed. Create a new scope instead."
+            )
+        # Take the container lock, as DIContainer.get() does. Without it,
+        # resolutions through a scope raced registry and singleton access.
+        with self._container._lock:
+            return self._container._resolve_service(service_type, scope=self)
+
+    def dispose(self) -> None:
+        """Dispose every scoped service this scope created, newest first.
+
+        Calls `dispose()` if present, otherwise `close()`. A failure is logged
+        and the remaining objects are still disposed. Calling this twice is a
+        no-op.
+        """
+        with self._lock:
+            if self._disposed:
+                return
+            # Set first: a disposal callback that reaches back into this scope
+            # gets the clear "disposed" error rather than a half-torn-down one.
+            self._disposed = True
+
+            for disposable in reversed(self._disposables):
+                try:
+                    if hasattr(disposable, "dispose"):
+                        disposable.dispose()
+                    elif hasattr(disposable, "close"):
+                        disposable.close()
+                except Exception:
+                    logger.error(
+                        f"Error disposing {type(disposable).__name__!r} in "
+                        f"DIScope; continuing with the remaining services.",
+                        exc_info=True,
+                    )
+
+            self._scoped_services.clear()
+            self._disposables.clear()
 
     def _get_scoped_service(
-        self, service_type: Type[T], registration: ServiceRegistration
+        self, service_type: type[T], registration: ServiceRegistration
     ) -> T:
+        """Return this scope's instance of a service, creating it if needed.
+
+        Args:
+            service_type: The interface being resolved.
+            registration: Its registration.
+
+        Returns:
+            The scope-local instance.
+        """
         with self._lock:
             if service_type in self._scoped_services:
                 return cast(T, self._scoped_services[service_type])
@@ -394,29 +567,14 @@ class DIScope:
 
             return cast(T, instance)
 
-    def dispose(self) -> None:
-        """Cleanup all resources tracked by this scope."""
-        with self._lock:
-            if self._disposed:
-                return
-
-            for disposable in reversed(self._disposables):
-                try:
-                    if hasattr(disposable, "dispose"):
-                        disposable.dispose()
-                    elif hasattr(disposable, "close"):
-                        disposable.close()
-                except Exception:
-                    pass
-
-            self._scoped_services.clear()
-            self._disposables.clear()
-            self._disposed = True
-
     def __enter__(self) -> DIScope:
-        """Enter the context manager, returning this scope."""
+        """Enter the context manager.
+
+        Returns:
+            This scope.
+        """
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """Exit the context manager, disposing resources."""
+        """Leave the context manager, disposing the scope."""
         self.dispose()

--- a/tests/test_di.py
+++ b/tests/test_di.py
@@ -275,3 +275,414 @@ def test_default_error_strategy_is_raise():
     container = DIContainer()
 
     assert container._error_strategy == ErrorHandlingStrategy.RAISE
+
+
+# -- Lifetime boundaries: singletons must not capture scoped services --
+
+
+class ScopedResource:
+    def __init__(self) -> None:
+        self.disposed = False
+
+    def dispose(self) -> None:
+        self.disposed = True
+
+
+class SingletonNeedingScope:
+    def __init__(self, resource: ScopedResource) -> None:
+        self.resource = resource
+
+
+def test_a_singleton_cannot_capture_a_scoped_dependency(container) -> None:
+    """A container-lived object holding a scope-lived one is the classic
+    captive-dependency bug: the scope disposes its instance and the singleton
+    keeps handing out the dead object forever. Singletons are therefore built
+    with no scope, so the attempt fails loudly instead."""
+    container.register_scoped(ScopedResource, ScopedResource)
+    container.register_singleton(SingletonNeedingScope, SingletonNeedingScope)
+
+    with container.create_scope() as scope:
+        with pytest.raises(DIException, match="requires an active scope"):
+            scope.get(SingletonNeedingScope)
+
+
+def test_the_captive_dependency_error_explains_the_singleton_case(container) -> None:
+    container.register_scoped(ScopedResource, ScopedResource)
+    container.register_singleton(SingletonNeedingScope, SingletonNeedingScope)
+
+    with container.create_scope() as scope:
+        with pytest.raises(DIException) as excinfo:
+            scope.get(SingletonNeedingScope)
+
+    assert "singleton" in str(excinfo.value).lower()
+
+
+def test_a_transient_may_still_take_a_scoped_dependency(container) -> None:
+    """Transients live no longer than the call that asked for them, so they
+    are free to depend on scoped services."""
+
+    class TransientUser:
+        def __init__(self, resource: ScopedResource) -> None:
+            self.resource = resource
+
+    container.register_scoped(ScopedResource, ScopedResource)
+    container.register_transient(TransientUser, TransientUser)
+
+    with container.create_scope() as scope:
+        assert scope.get(TransientUser).resource is scope.get(ScopedResource)
+
+
+def test_a_scoped_service_may_depend_on_a_singleton(container) -> None:
+    class Config:
+        pass
+
+    class ScopedUser:
+        def __init__(self, config: Config) -> None:
+            self.config = config
+
+    container.register_singleton(Config, Config)
+    container.register_scoped(ScopedUser, ScopedUser)
+
+    with container.create_scope() as scope:
+        assert scope.get(ScopedUser).config is container.get(Config)
+
+
+# -- Scope disposal --
+
+
+def test_a_disposed_scope_refuses_to_resolve(container) -> None:
+    """Resolving after disposal produced instances that would never be
+    cleaned up -- the scope had already emptied its disposables list."""
+    container.register_scoped(ScopedResource, ScopedResource)
+    scope = container.create_scope()
+    scope.dispose()
+
+    with pytest.raises(DIException, match="disposed"):
+        scope.get(ScopedResource)
+
+
+def test_disposing_twice_is_a_noop(container) -> None:
+    class CountingDispose:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def dispose(self) -> None:
+            self.calls += 1
+
+    container.register_scoped(CountingDispose, CountingDispose)
+    scope = container.create_scope()
+    instance = scope.get(CountingDispose)
+
+    scope.dispose()
+    scope.dispose()
+
+    assert instance.calls == 1
+
+
+def test_a_failing_dispose_does_not_abort_the_rest(container) -> None:
+    """dispose() swallowed every exception with a bare `except: pass`, so a
+    broken teardown was invisible. It is logged now, and the remaining
+    services are still disposed."""
+
+    class FailingDispose:
+        def dispose(self) -> None:
+            raise RuntimeError("cleanup failed")
+
+    class WorkingDispose:
+        def __init__(self, other: FailingDispose) -> None:
+            self.disposed = False
+
+        def dispose(self) -> None:
+            self.disposed = True
+
+    container.register_scoped(FailingDispose, FailingDispose)
+    container.register_scoped(WorkingDispose, WorkingDispose)
+
+    with container.create_scope() as scope:
+        working = scope.get(WorkingDispose)
+
+    assert working.disposed
+
+
+def test_a_failing_dispose_is_logged(container, caplog) -> None:
+    import logging
+
+    class FailingDispose:
+        def dispose(self) -> None:
+            raise RuntimeError("cleanup failed")
+
+    container.register_scoped(FailingDispose, FailingDispose)
+    with caplog.at_level(logging.ERROR):
+        with container.create_scope() as scope:
+            scope.get(FailingDispose)
+
+    assert "Error disposing" in caplog.text
+
+
+def test_close_is_used_when_dispose_is_absent(container) -> None:
+    class Closeable:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    container.register_scoped(Closeable, Closeable)
+    with container.create_scope() as scope:
+        instance = scope.get(Closeable)
+
+    assert instance.closed
+
+
+def test_disposed_flag_is_observable(container) -> None:
+    scope = container.create_scope()
+    assert scope.disposed is False
+    scope.dispose()
+    assert scope.disposed is True
+
+
+# -- Re-registration --
+
+
+def test_re_registering_replaces_an_already_resolved_singleton(container) -> None:
+    """The registration dict was overwritten but the cached instance was not,
+    so a re-registered singleton silently kept handing out the old object."""
+
+    class Original:
+        pass
+
+    class Replacement:
+        pass
+
+    container.register_singleton(Original, Original)
+    first = container.get(Original)
+
+    container.register_singleton(Original, Replacement)
+    second = container.get(Original)
+
+    assert isinstance(first, Original)
+    assert isinstance(second, Replacement)
+
+
+def test_re_registering_replaces_a_registered_instance(container) -> None:
+    class Thing:
+        pass
+
+    first, second = Thing(), Thing()
+    container.register_instance(Thing, first)
+    container.register_singleton(Thing, Thing)
+
+    assert container.get(Thing) is not first
+    assert container.get(Thing) is not second
+
+
+def test_is_registered(container) -> None:
+    class Known:
+        pass
+
+    class Unknown:
+        pass
+
+    container.register_singleton(Known, Known)
+    assert container.is_registered(Known)
+    assert not container.is_registered(Unknown)
+
+
+# -- Constructor signature handling --
+
+
+def test_varargs_are_not_treated_as_injection_points(container) -> None:
+    """`*args: int` was read as a dependency named "args" of type int, so any
+    class declaring varargs failed to resolve with ServiceNotFoundException."""
+
+    class Varargs:
+        def __init__(self, *args: int, **kwargs: str) -> None:
+            self.built = True
+
+    container.register_transient(Varargs, Varargs)
+
+    assert container._services[Varargs].dependencies == {}
+    assert container.get(Varargs).built
+
+
+def test_varargs_alongside_a_real_dependency(container) -> None:
+    class Dep:
+        pass
+
+    class Mixed:
+        def __init__(self, dep: Dep, *args: int) -> None:
+            self.dep = dep
+
+    container.register_singleton(Dep, Dep)
+    container.register_transient(Mixed, Mixed)
+
+    assert container.get(Mixed).dep is container.get(Dep)
+
+
+def test_an_unregistered_dependency_with_a_default_is_skipped(container) -> None:
+    class Missing:
+        pass
+
+    class HasDefault:
+        def __init__(self, missing: Missing | None = None) -> None:
+            self.missing = missing
+
+    container.register_transient(HasDefault, HasDefault)
+
+    assert container.get(HasDefault).missing is None
+
+
+def test_an_unregistered_dependency_without_a_default_raises(container) -> None:
+    class Missing:
+        pass
+
+    class NeedsIt:
+        def __init__(self, missing: Missing) -> None: ...
+
+    container.register_transient(NeedsIt, NeedsIt)
+
+    with pytest.raises(ServiceNotFoundException):
+        container.get(NeedsIt)
+
+
+def test_a_class_with_no_constructor_resolves(container) -> None:
+    class Bare:
+        pass
+
+    container.register_singleton(Bare, Bare)
+    assert isinstance(container.get(Bare), Bare)
+
+
+def test_a_factory_registration_receives_injected_arguments(container) -> None:
+    class Dep:
+        pass
+
+    class Product:
+        def __init__(self, dep: Dep) -> None:
+            self.dep = dep
+
+    def build(dep: Dep) -> Product:
+        return Product(dep)
+
+    container.register_singleton(Dep, Dep)
+    container._register_service(Product, factory=build)
+
+    assert container.get(Product).dep is container.get(Dep)
+
+
+def test_registering_two_providers_at_once_is_rejected(container) -> None:
+    class Thing:
+        pass
+
+    with pytest.raises(DIException, match="Exactly one"):
+        container._register_service(Thing, implementation=Thing, instance=Thing())
+
+
+# -- Thread safety --
+
+
+def test_concurrent_scoped_resolution_does_not_report_false_cycles(container) -> None:
+    """DIScope.get() resolved without taking the container lock, so parallel
+    resolutions shared one mutable cycle-detection stack and saw each other's
+    partial chains. With a slow constructor this reported a circular
+    dependency on roughly 90% of resolutions.
+    """
+    import threading
+    import time
+
+    class Slow:
+        def __init__(self) -> None:
+            time.sleep(0.002)
+
+    class Root:
+        def __init__(self, slow: Slow) -> None: ...
+
+    container.register_transient(Slow, Slow)
+    container.register_transient(Root, Root)
+
+    errors: list[Exception] = []
+
+    def worker() -> None:
+        for _ in range(10):
+            try:
+                with container.create_scope() as scope:
+                    scope.get(Root)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+
+
+def test_a_singleton_is_constructed_once_under_contention(container) -> None:
+    import threading
+    import time
+
+    class SlowSingleton:
+        instances = 0
+
+        def __init__(self) -> None:
+            time.sleep(0.002)
+            SlowSingleton.instances += 1
+
+    container.register_singleton(SlowSingleton, SlowSingleton)
+    resolved = []
+
+    def worker() -> None:
+        resolved.append(container.get(SlowSingleton))
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert SlowSingleton.instances == 1
+    assert len({id(r) for r in resolved}) == 1
+
+
+def test_cycle_detection_state_does_not_leak_between_threads(container) -> None:
+    """The resolution stack is thread-local, so one thread's in-flight chain is
+    invisible to another even without the lock held."""
+    import threading
+
+    class Leaf:
+        pass
+
+    container.register_transient(Leaf, Leaf)
+    stacks: list[list] = []
+
+    def worker() -> None:
+        container.get(Leaf)
+        stacks.append(container._resolution_stack)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert all(s == [] for s in stacks)
+    assert len({id(s) for s in stacks}) == 4
+
+
+def test_the_resolution_stack_is_unwound_after_a_failed_resolution(container) -> None:
+    class Missing:
+        pass
+
+    class NeedsIt:
+        def __init__(self, missing: Missing) -> None: ...
+
+    container.register_transient(NeedsIt, NeedsIt)
+
+    with pytest.raises(ServiceNotFoundException):
+        container.get(NeedsIt)
+
+    assert container._resolution_stack == []
+    container.register_singleton(Missing, Missing)
+    assert container.get(NeedsIt) is not None


### PR DESCRIPTION
Fourth iteration of the incremental subsystem audit. Scope is `pyguara/di`.

> **Stacked on #3 → #2 → #1.** Base is `refactor/events-audit`. Merge in order and each retargets cleanly.

## 🐞 `DIScope.get()` never took the container lock

`DIContainer.get()` holds a reentrant lock for the whole resolution. `DIScope.get()` called straight into `_resolve_service` without it. Parallel resolutions through scopes therefore shared one mutable cycle-detection stack and saw each other's partial chains.

With constructors that take a couple of milliseconds, eight threads resolving a two-level graph produced:

```
errors: 140 / 160
  CircularDependencyException: 140
  example: Circular dependency detected: Top -> Slow -> Top
```

There is no cycle. The graph is `Top -> Slow`. This is the container inventing one under concurrency, and it would surface as a baffling startup failure in any threaded resource-loading or scene-prep path.

It stayed hidden because **every constructor in the test suite is instant** — the race window is nanoseconds wide with trivial `__init__`s. My first probe found 0 errors too; it only appeared once I made a constructor take 2 ms, which is what a real one does.

Fixed twice over, deliberately: the scope now takes the lock, **and** the resolution stack becomes thread-local. The lock is the fix; the thread-local makes the invariant hold structurally rather than by remembering to lock on every path — which is exactly the discipline that failed here. Errors: **140 → 0**.

## 🐞 Captive dependency — singletons capturing scoped services

A singleton resolved inside a scope captured the scoped instance. The scope disposed it on exit, and the singleton went on handing out the dead object for the container's lifetime:

```
after scope exit, captured dep disposed: True
singleton still hands out the dead instance: True
```

Singletons are now built with `scope=None`, so the attempt raises with a message explaining that a container-lived object must not capture a scope-lived one.

## Four more

- **A disposed scope still resolved**, appending to a disposables list it had already emptied — those objects would never be cleaned up.
- **Re-registering an already-resolved singleton silently did nothing.** The registration was replaced; the cached instance was not. `get()` kept returning the old implementation.
- **`*args`/`**kwargs` were treated as injection points.** `*args: int` was read as a dependency named `args` of type `int`, so any class declaring varargs failed with `ServiceNotFoundException: Service not registered: int`.
- **`DIScope.dispose()` swallowed every exception** with a bare `except Exception: pass`. Now logged, and the remaining services still dispose.

## Tests

26 → 40. The existing tests were reasonable but **entirely single-threaded and single-scope**, which is precisely why the lock bug survived them. Added lifetime-capture rules, disposal semantics, re-registration, constructor-signature edge cases, and three real concurrency tests — including one that reproduces the 140-failure scenario and asserts zero.

Two small API additions, `DIContainer.is_registered()` and `DIScope.disposed`, so those tests don't reach into privates.

**1286 pass** (from 1262), ruff clean, mypy clean.

## Docs

New `docs/core/dependency-injection.md`, leading with the lifetime-capture rules and stating the threading contract explicitly: the lock is held across constructors, so build the container at bootstrap rather than resolving on hot paths from several threads.

`architecture.md`'s DI section is condensed to a summary and link — all three of its original sections (ECS, DI, Events) are now summaries pointing at dedicated pages.

**CC-9** added: `ErrorHandlingStrategy` is declared separately in `di/types.py` and `events/types.py` with identical members and semantics, and they are *not* interchangeable (`di.RAISE != events.RAISE`), so passing one where the other is expected fails a comparison silently.

## Review notes

Two commits — `3871840` (container), `676c048` (docs). Each verified green in an isolated worktree: 1286 / 1286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
