### PR TITLE
refactor(log): audit pass — every record reported the wrong source line; docs described a nonexistent API

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -12,7 +12,7 @@ rather than fixed in place.
 
 ## Active Subsystem
 
-`pyguara/di` — **in review (awaiting approval)**
+`pyguara/log` — **in review (awaiting approval)**
 
 ---
 
@@ -22,9 +22,9 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 ### Tier 1 — Foundations (no intra-engine dependencies)
 - [x] `pyguara/common` — Vector2, Color, Rect, shared components *(done)*
-- [ ] `pyguara/log` — logging facade
+- [x] `pyguara/log` — logging facade *(active)*
 - [x] `pyguara/events` — EventDispatcher, Event protocol *(done)*
-- [x] `pyguara/di` — DIContainer, auto-wiring, lifetimes *(active)*
+- [x] `pyguara/di` — DIContainer, auto-wiring, lifetimes *(done)*
 
 ### Tier 2 — Core runtime
 - [x] `pyguara/ecs` — Entity, Component, EntityManager, QueryCache *(done)*
@@ -59,6 +59,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/di` | 2026-09-06 | Fixed a missing lock in `DIScope.get()` that fabricated circular dependencies under concurrency (140/160 resolutions), plus captive lifetimes, dead-scope resolution, silent re-registration and varargs injection. PR #4. |
 | `pyguara/events` | 2026-09-06 | Broke a latent `log` <-> `events` import cycle, fixed a timestamp sentinel that made 0.0 inexpressible, brought filter errors under the error strategy, and memoised handler resolution (5.7us -> 3.1us per dispatch). PR #3. |
 | `pyguara/common` | 2026-09-06 | Fixed `Transform.up` pointing down, an unguarded parent cycle and a falsy-`Vector2` default; renamed `Vector2.rotate` to `rotate_degrees`; wrote the first tests for `Vector2` and `Transform`. PR #2. |
 | `pyguara/ecs` | 2026-09-06 | Fixed two silent query bugs (`add_entity()` bypassing the query cache; dead-entity resurrection), replaced the private removal hook with a subscribe/unsubscribe API, and modernised the module. PR #1. |
@@ -128,6 +129,17 @@ is deliberately not attempted piecemeal. **Fix:** once `physics`, `ui` and `ai`
 are audited and the true extent is known, migrate the tree to `StrictComponent`
 and consider making it the default.
 *Discovered in:* `ecs`; offender identified in `common`. *Status:* parked.
+
+### CC-10 — Documentation can describe APIs that do not exist
+`docs/core/logging.md` documented `pyguara.log.config.setup_logging()` and
+`pyguara.log.config.get_logger()`. Neither the module nor the function exists
+anywhere in the tree; every code sample on the page raised
+`ModuleNotFoundError`. Nothing catches this, because docs are never executed.
+**Fix:** enable `pytest --doctest-glob='*.md'` over `docs/`, or add a smoke
+test that imports every symbol the docs reference. Until then, treat "verify
+the documented API actually exists" as an explicit Phase C step in every
+iteration.
+*Discovered in:* `log`. *Status:* open.
 
 ### CC-9 — `ErrorHandlingStrategy` is defined twice
 `pyguara/di/types.py` and `pyguara/events/types.py` each declare their own enum
@@ -322,7 +334,7 @@ condensed to a summary and link.
 **Deferred:** CC-1 through CC-4, CC-6, CC-7, CC-8, and the rest of CC-5.
 
 
-### `pyguara/di` — awaiting approval (2026-09-06)
+### `pyguara/di` — CLOSED 2026-09-06 (PR #4, branch `refactor/di-audit`)
 
 **Verification:** 1286/1286 tests pass (up from 1262); ruff clean; mypy clean.
 
@@ -370,3 +382,55 @@ section condensed to a summary and link. That file's three original sections
 (ECS, DI, Events) are now all summaries pointing at dedicated pages.
 
 **Deferred:** CC-1 through CC-4, CC-6 through CC-9, and the rest of CC-5.
+
+
+### `pyguara/log` — awaiting approval (2026-09-06)
+
+**Verification:** 1303/1303 tests pass (up from 1286); ruff clean; mypy clean.
+
+**Correctness fixes (all reproduced by probe before fixing):**
+- **Every log record in the engine reported `logger.py:138` as its source.**
+  `EngineLogger._log()` called `self._logger.log()` without a `stacklevel`, so
+  the two wrapper frames were never skipped and every record attributed itself
+  to the same line inside the wrapper. The file formatter's `%(lineno)d`, and
+  the `module`/`line` fields carried into `OnLogEvent`, were that same constant
+  for every message ever logged. A caller-supplied `stacklevel` is now offset
+  rather than ignored.
+- **`reconfigure()` cleared the whole handler list of a process-global stdlib
+  logger**, silently tearing down handlers installed by the application, by a
+  test, or by a second `LogManager` using the same name. Each logger now tracks
+  and removes only the handlers it installed.
+- **`shutdown()` closed handlers but left them attached**, and a closed
+  `FileHandler` silently reopens its file on the next record -- so shutdown
+  did not actually stop logging. It detaches now, and a test asserts nothing
+  is written afterwards. (My first probe of this claimed data loss; checking
+  the file showed the opposite. The defect is that shutdown is a no-op, not
+  that it drops records.)
+- **`configure(dispatcher=None)` could not detach a dispatcher**, because
+  `if dispatcher:` cannot tell None from unspecified. A sentinel default now
+  distinguishes them.
+
+**Also:**
+- `EventIntegratedHandler.emit()` built a throwaway `LogRecord` on **every**
+  record, purely to compute a constant set of key names. Hoisted to a
+  module-level frozenset.
+- `propagate` is now configurable. Engine loggers install their own handlers
+  *and* propagate, so an application that also configures root logging sees
+  every record twice. Default left at True -- propagation is what lets an app
+  capture engine output, and the duplication only occurs when the app prints
+  too -- but the choice is now explicit and documented rather than implicit.
+- Removed a leftover `# FIX:` comment; documented `LogCategory` as orthogonal
+  to `LogLevel`. Modern typing, Google-style docstrings.
+
+**Tests:** 9 -> 26. Source attribution, handler ownership, shutdown semantics,
+`configure()` dispatcher handling, propagation, and the path from structured
+keyword arguments through to `OnLogEvent.context`.
+
+**Docs:** `docs/core/logging.md` **rewritten from scratch** -- see CC-10. It
+documented `pyguara.log.config.setup_logging()`, a module and function that
+have never existed in this tree; every code sample on the page raised
+`ModuleNotFoundError`.
+
+**Tier 1 is now complete:** `common`, `log`, `events`, `di`.
+
+**Deferred:** CC-1 through CC-4, CC-6 through CC-10, and the rest of CC-5.

--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -1,45 +1,163 @@
 # Logging System
 
-PyGuara provides a centralized logging configuration (`pyguara.log`) wrapping Python's standard `logging` module. This ensures consistent log formatting, levels, and output destinations.
+`pyguara.log` wraps Python's `logging` with three additions: a **category** on
+every record, arbitrary **structured fields**, and optional republishing of
+records as engine **events**.
 
-## Setup
-
-Logging is initialized via `setup_logging` in `bootstrap.py`.
-
-```python
-from pyguara.log.config import setup_logging
-import logging
-
-# Configure console output and optional file output
-setup_logging(
-    level=logging.INFO,
-    log_file="game.log",
-    file_level=logging.DEBUG
-)
-```
-
-## Usage
-
-In any module, retrieve a namespaced logger:
+## Getting a logger
 
 ```python
-from pyguara.log.config import get_logger
+from pyguara.log import get_logger
 
 logger = get_logger(__name__)
 
-def my_function():
-    logger.info("Function started")
-    try:
-        # ... logic ...
-    except Exception:
-        logger.error("Critical failure", exc_info=True)
+logger.info("Scene loaded")
+logger.warning("Texture missing, using fallback")
+logger.error("Failed to load '%s': %s", path, reason)
 ```
 
-## Best Practices
+`get_logger()` is backed by a shared `default_log_manager`, so a module can
+take a logger at import time and still pick up configuration applied later.
 
-*   **Avoid `print()`**: Always use the logger.
-*   **Levels**:
-    *   `DEBUG`: High-frequency data (resource loads, events).
-    *   `INFO`: Lifecycle events (startup, scene switch).
-    *   `WARNING`: Recoverable issues (missing texture fallback).
-    *   `ERROR`: Exceptions and failures.
+## Configuring
+
+```python
+from pathlib import Path
+from pyguara.log import LogLevel, default_log_manager
+
+default_log_manager.configure(
+    level=LogLevel.DEBUG,
+    log_file=Path("logs/game.log"),
+    console=True,
+)
+```
+
+`configure()` rebuilds the handlers of every logger already handed out — not
+just their levels. Most engine modules build a logger at import time, long
+before configuration runs, so without that rebuild file and event output would
+silently never reach them.
+
+`dispatcher` is the one parameter that distinguishes "unspecified" from
+"None": omit it to keep the current dispatcher, pass `None` explicitly to
+detach it.
+
+## Categories and structured fields
+
+Every record carries a `LogCategory` saying which subsystem it came from.
+Categories are orthogonal to levels — a category says *where*, a level says
+*how severe*.
+
+```python
+from pyguara.log import LogCategory
+
+logger.warning("Body count high", category=LogCategory.PHYSICS)
+```
+
+Any other keyword becomes a structured field on the record, reachable by
+handlers and carried into `OnLogEvent`:
+
+```python
+logger.info("Loading asset", asset="hero.png", retries=2)
+```
+
+A field whose name collides with a real `LogRecord` attribute is renamed with a
+trailing underscore rather than dropped — `module="mine"` arrives as
+`module_`.
+
+`exc_info`, `stack_info` and `stacklevel` are passed through to the standard
+library instead of being treated as fields.
+
+## Exceptions
+
+```python
+try:
+    load(path)
+except OSError as error:
+    logger.exception(error, "Could not load level")
+```
+
+Unlike `logging.Logger.exception`, this takes the exception object rather than
+reading the ambient one, so it works outside an `except` block. It also
+dispatches `OnExceptionEvent` when a dispatcher is configured.
+
+## Event integration
+
+With a dispatcher configured, every record is also republished as `OnLogEvent`
+— which is how an in-game console or the editor's log panel subscribes to
+engine output:
+
+```python
+default_log_manager.configure(dispatcher=event_dispatcher)
+
+event_dispatcher.subscribe(OnLogEvent, console_panel.append)
+```
+
+`OnLogEvent.context` carries the structured fields plus the record's origin:
+logger name, module, line and thread.
+
+!!! note "`log` depends on `events`, never the reverse"
+    `OnLogEvent` and `OnExceptionEvent` implement the `Event` protocol at
+    runtime. `pyguara.events` therefore must not import `pyguara.log` at
+    module scope — see [Event System](events.md).
+
+## Propagation
+
+Engine loggers install their own handlers **and** propagate to ancestor
+loggers by default. Propagation is what lets an application capture engine
+output through its own `logging` configuration.
+
+The cost is that if that configuration *also* prints, every record appears
+twice. Two ways out:
+
+```python
+# Let the application own all output
+default_log_manager.configure(console=False)
+
+# Or keep the engine's console output and stop propagating
+default_log_manager.configure(console=True, propagate=False)
+```
+
+## Shutdown
+
+```python
+default_log_manager.shutdown()
+```
+
+Closes **and detaches** every handler the manager installed. Detaching is the
+part that matters: a closed `FileHandler` that is still attached silently
+reopens its file on the next record, so closing alone would leave logging
+running.
+
+Handlers installed by anyone else — the application, a test — are left alone,
+by `shutdown()` and by `configure()` alike.
+
+## A note on shared state
+
+`EngineLogger` wraps `logging.getLogger(name)`, which is process-global. Two
+`LogManager` instances using the same name share one underlying logger. Each
+removes only the handlers it installed, so they no longer tear down each
+other's, but level and propagation are shared and the last writer wins.
+
+Prefer the single `default_log_manager`. Construct a second `LogManager` only
+in tests, with distinct logger names.
+
+## Levels
+
+| Level | Use for |
+| --- | --- |
+| `DEBUG` | High-frequency detail: resource loads, per-frame events |
+| `INFO` | Lifecycle: startup, scene switches, shutdown |
+| `WARNING` | Recoverable problems: a missing texture falling back |
+| `ERROR` | Failures and exceptions |
+| `CRITICAL` | Unrecoverable failures |
+
+## Rules of thumb
+
+1. `get_logger(__name__)` at module scope; configure once at bootstrap.
+2. Never `print()`.
+3. Pass printf-style arguments rather than pre-formatting, so a filtered-out
+   record costs nothing to build.
+4. Put facts in structured fields, not in the message string — they survive
+   into `OnLogEvent` where the message text does not parse.
+5. Categorise anything a subsystem emits; the default `SYSTEM` is for the
+   engine core.

--- a/pyguara/log/handlers.py
+++ b/pyguara/log/handlers.py
@@ -1,7 +1,9 @@
-"""Custom logging handlers."""
+"""Logging handlers that bridge into the engine's event system."""
+
+from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pyguara.log.events import OnLogEvent
 from pyguara.log.types import LogCategory, LogLevel
@@ -9,54 +11,59 @@ from pyguara.log.types import LogCategory, LogLevel
 if TYPE_CHECKING:
     from pyguara.events.dispatcher import EventDispatcher
 
+# Attributes every LogRecord carries, so `emit` can tell caller-supplied extras
+# apart from stdlib ones. Computed once from a throwaway record rather than
+# hand-listed (which would drift) -- and once at import, not per record.
+_STANDARD_RECORD_KEYS: frozenset[str] = frozenset(
+    logging.LogRecord("", 0, "", 0, "", (), None).__dict__
+)
+
 
 class EventIntegratedHandler(logging.Handler):
-    """Log handler that dispatches log records as engine events."""
+    """Republishes log records as `OnLogEvent` on the engine's dispatcher."""
 
-    def __init__(self, event_dispatcher: "EventDispatcher") -> None:
-        """Initialize with a target dispatcher."""
+    def __init__(self, event_dispatcher: EventDispatcher) -> None:
+        """Initialise the handler.
+
+        Args:
+            event_dispatcher: Where records are dispatched.
+        """
         super().__init__()
         self._dispatcher = event_dispatcher
 
     def emit(self, record: logging.LogRecord) -> None:
-        """Emit log record as an event."""
+        """Convert a record to an `OnLogEvent` and dispatch it.
+
+        Structured fields attached via the logger's keyword arguments are
+        merged into the event context alongside the record's own location.
+
+        Args:
+            record: The record to republish.
+        """
         try:
-            # Safe conversion of level
             try:
                 level = LogLevel(record.levelno)
             except ValueError:
                 level = LogLevel.INFO
 
-            # Infer Category (defaulting to SYSTEM if not present)
-            category = getattr(record, "category", LogCategory.SYSTEM)
-
-            # Build Context from record attributes
-            context = {
+            context: dict[str, Any] = {
                 "logger": record.name,
                 "module": record.module,
                 "line": record.lineno,
                 "thread": record.threadName,
             }
-
-            # Merge extra attributes (filtering out standard LogRecord attrs)
-            # We create a dummy record to get the standard keys efficiently
-            standard_keys = logging.LogRecord(
-                "", 0, "", 0, "", (), None
-            ).__dict__.keys()
-
             for key, value in record.__dict__.items():
-                if key not in standard_keys and key not in context:
+                if key not in _STANDARD_RECORD_KEYS and key not in context:
                     context[key] = value
 
-            # Dispatch
-            event = OnLogEvent(
-                level=level,
-                category=category,
-                message=record.getMessage(),
-                context=context,
-                timestamp=record.created,
+            self._dispatcher.dispatch(
+                OnLogEvent(
+                    level=level,
+                    category=getattr(record, "category", LogCategory.SYSTEM),
+                    message=record.getMessage(),
+                    context=context,
+                    timestamp=record.created,
+                )
             )
-            self._dispatcher.dispatch(event)
-
         except Exception:
             self.handleError(record)

--- a/pyguara/log/logger.py
+++ b/pyguara/log/logger.py
@@ -1,9 +1,11 @@
-"""Core logger wrapper implementation."""
+"""Engine logger: a structured wrapper around `logging.Logger`."""
+
+from __future__ import annotations
 
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any
 
 from pyguara.log.events import OnExceptionEvent
 from pyguara.log.handlers import EventIntegratedHandler
@@ -45,99 +47,130 @@ _RESERVED_LOG_RECORD_ATTRS = frozenset(
 # Names that are real keyword arguments of `Logger.log()` rather than `extra` data.
 _LOG_CALL_KWARGS = frozenset({"exc_info", "stack_info", "stacklevel"})
 
+# Frames between the caller and `Logger.log()`: the level method (info, error,
+# ...) and `_log`. Without this every record would attribute itself to the
+# `self._logger.log(...)` line in this module, making %(lineno)d, %(module)s and
+# %(funcName)s useless everywhere they appear.
+_WRAPPER_FRAMES = 2
+
 
 class EngineLogger:
-    """Enhanced logger with event system integration.
+    """A `logging.Logger` wrapper adding categories, context and event output.
 
-    Wraps the standard python logging.Logger to provide structured logging
-    and seamless event system integration.
+    Level methods accept a `category` and arbitrary keyword arguments; the
+    keywords become structured fields on the record, reachable by handlers and
+    carried into `OnLogEvent`.
+
+    Note:
+        This wraps `logging.getLogger(name)`, which is process-global. Two
+        `LogManager` instances asking for the same name therefore share one
+        underlying logger. Each instance only removes the handlers it installed
+        itself, so they no longer silently tear down each other's -- but
+        settings still apply to the shared logger, last writer winning. Prefer
+        the single `default_log_manager`.
     """
 
     def __init__(
         self,
         name: str,
         level: LogLevel,
-        event_dispatcher: Optional["EventDispatcher"],
-        log_file: Optional[Path],
+        event_dispatcher: EventDispatcher | None,
+        log_file: Path | None,
         console_output: bool,
+        propagate: bool = True,
     ) -> None:
-        """Initialize the logger wrapper."""
+        """Create a logger and install its handlers.
+
+        Args:
+            name: Logger name, conventionally the module's `__name__`.
+            level: Minimum level to emit.
+            event_dispatcher: If given, records are also dispatched as
+                `OnLogEvent`.
+            log_file: If given, records are written there. Parent directories
+                are created.
+            console_output: Write records to stdout.
+            propagate: Let records reach ancestor loggers, including root.
+                Leave enabled so an application's own logging configuration
+                can capture engine output; disable it if that configuration
+                also prints, to avoid every record appearing twice.
+        """
         self.name = name
         self._logger = logging.getLogger(name)
+        # Only handlers in here are removed on reconfigure, so a handler added
+        # by the application -- or by another LogManager sharing this stdlib
+        # logger -- survives.
+        self._own_handlers: list[logging.Handler] = []
+        self._event_dispatcher: EventDispatcher | None = None
         self.reconfigure(
             level=level,
             event_dispatcher=event_dispatcher,
             log_file=log_file,
             console_output=console_output,
+            propagate=propagate,
         )
 
     def reconfigure(
         self,
         level: LogLevel,
-        event_dispatcher: Optional["EventDispatcher"],
-        log_file: Optional[Path],
+        event_dispatcher: EventDispatcher | None,
+        log_file: Path | None,
         console_output: bool,
+        propagate: bool = True,
     ) -> None:
-        """Rebuild this logger's handler set for new settings.
+        """Rebuild this logger's own handlers for new settings.
 
-        Closes and replaces every existing handler so repeated calls (e.g. from
-        `LogManager.configure()`) don't leak file descriptors or double-log.
+        Closes and detaches the handlers this logger installed previously, so
+        repeated calls neither leak file descriptors nor double-log. Handlers
+        installed by anyone else are left alone.
+
+        Args:
+            level: Minimum level to emit.
+            event_dispatcher: If given, records are also dispatched as
+                `OnLogEvent`.
+            log_file: If given, records are written there.
+            console_output: Write records to stdout.
+            propagate: Let records reach ancestor loggers.
         """
         self._event_dispatcher = event_dispatcher
 
-        for h in self._logger.handlers:
-            h.close()
-        self._logger.handlers.clear()
+        self.detach_handlers()
         self._logger.setLevel(level.value)
+        self._logger.propagate = propagate
 
-        # 1. Console Handler
         if console_output:
-            c_handler = logging.StreamHandler(sys.stdout)
-            c_fmt = logging.Formatter(
-                "%(asctime)s [%(levelname)8s] %(name)s: %(message)s", datefmt="%H:%M:%S"
+            console_handler = logging.StreamHandler(sys.stdout)
+            console_handler.setFormatter(
+                logging.Formatter(
+                    "%(asctime)s [%(levelname)8s] %(name)s: %(message)s",
+                    datefmt="%H:%M:%S",
+                )
             )
-            c_handler.setFormatter(c_fmt)
-            self._logger.addHandler(c_handler)
+            self._add_own_handler(console_handler)
 
-        # 2. File Handler
         if log_file:
             log_file.parent.mkdir(parents=True, exist_ok=True)
-            f_handler = logging.FileHandler(log_file)
-            f_fmt = logging.Formatter(
-                "%(asctime)s [%(levelname)8s] %(name)s:%(lineno)d: %(message)s"
+            file_handler = logging.FileHandler(log_file)
+            file_handler.setFormatter(
+                logging.Formatter(
+                    "%(asctime)s [%(levelname)8s] %(name)s:%(lineno)d: %(message)s"
+                )
             )
-            f_handler.setFormatter(f_fmt)
-            self._logger.addHandler(f_handler)
+            self._add_own_handler(file_handler)
 
-        # 3. Event Handler
         if event_dispatcher:
-            self._logger.addHandler(EventIntegratedHandler(event_dispatcher))
+            self._add_own_handler(EventIntegratedHandler(event_dispatcher))
 
-    def _log(
-        self,
-        level: LogLevel,
-        message: str,
-        category: LogCategory,
-        *args: Any,
-        **kwargs: Any,
-    ) -> None:
-        """Perform internal logging operations."""
-        log_kwargs = {key: kwargs.pop(key) for key in _LOG_CALL_KWARGS if key in kwargs}
+    def detach_handlers(self) -> None:
+        """Close and remove every handler this logger installed.
 
-        extra: Dict[str, Any] = {"category": category}
-        extra.update(kwargs)
-
-        # A caller-supplied key that shadows a real LogRecord attribute would
-        # otherwise raise KeyError inside logging's makeRecord(); rename it
-        # instead of dropping the data.
-        safe_extra = {
-            (f"{key}_" if key in _RESERVED_LOG_RECORD_ATTRS else key): value
-            for key, value in extra.items()
-        }
-
-        self._logger.log(level.value, message, *args, extra=safe_extra, **log_kwargs)
-
-    # --- Public API ---
+        Detaching as well as closing is what makes teardown stick: a closed
+        `FileHandler` that is still attached silently reopens its file on the
+        next record, so closing alone does not stop logging.
+        """
+        for handler in self._own_handlers:
+            self._logger.removeHandler(handler)
+            handler.close()
+        self._own_handlers.clear()
 
     def debug(
         self,
@@ -146,7 +179,15 @@ class EngineLogger:
         category: LogCategory = LogCategory.DEBUG,
         **kwargs: Any,
     ) -> None:
-        """Log a debug message."""
+        """Log at DEBUG.
+
+        Args:
+            msg: Message, optionally printf-style.
+            *args: Printf-style arguments for `msg`.
+            category: Log category for filtering and routing.
+            **kwargs: `exc_info`, `stack_info` and `stacklevel` are passed to
+                the stdlib logger; anything else becomes a structured field.
+        """
         self._log(LogLevel.DEBUG, msg, category, *args, **kwargs)
 
     def info(
@@ -156,7 +197,14 @@ class EngineLogger:
         category: LogCategory = LogCategory.SYSTEM,
         **kwargs: Any,
     ) -> None:
-        """Log an info message."""
+        """Log at INFO.
+
+        Args:
+            msg: Message, optionally printf-style.
+            *args: Printf-style arguments for `msg`.
+            category: Log category for filtering and routing.
+            **kwargs: Stdlib log keywords, or structured fields.
+        """
         self._log(LogLevel.INFO, msg, category, *args, **kwargs)
 
     def warning(
@@ -166,7 +214,14 @@ class EngineLogger:
         category: LogCategory = LogCategory.SYSTEM,
         **kwargs: Any,
     ) -> None:
-        """Log a warning message."""
+        """Log at WARNING.
+
+        Args:
+            msg: Message, optionally printf-style.
+            *args: Printf-style arguments for `msg`.
+            category: Log category for filtering and routing.
+            **kwargs: Stdlib log keywords, or structured fields.
+        """
         self._log(LogLevel.WARNING, msg, category, *args, **kwargs)
 
     def error(
@@ -176,7 +231,14 @@ class EngineLogger:
         category: LogCategory = LogCategory.SYSTEM,
         **kwargs: Any,
     ) -> None:
-        """Log an error message."""
+        """Log at ERROR.
+
+        Args:
+            msg: Message, optionally printf-style.
+            *args: Printf-style arguments for `msg`.
+            category: Log category for filtering and routing.
+            **kwargs: Stdlib log keywords, or structured fields.
+        """
         self._log(LogLevel.ERROR, msg, category, *args, **kwargs)
 
     def critical(
@@ -186,13 +248,28 @@ class EngineLogger:
         category: LogCategory = LogCategory.SYSTEM,
         **kwargs: Any,
     ) -> None:
-        """Log a critical message."""
+        """Log at CRITICAL.
+
+        Args:
+            msg: Message, optionally printf-style.
+            *args: Printf-style arguments for `msg`.
+            category: Log category for filtering and routing.
+            **kwargs: Stdlib log keywords, or structured fields.
+        """
         self._log(LogLevel.CRITICAL, msg, category, *args, **kwargs)
 
-    def exception(
-        self, ex: Exception, msg: Optional[str] = None, **kwargs: Any
-    ) -> None:
-        """Log an exception with traceback."""
+    def exception(self, ex: Exception, msg: str | None = None, **kwargs: Any) -> None:
+        """Log an exception with its traceback, and dispatch `OnExceptionEvent`.
+
+        Unlike `logging.Logger.exception`, this takes the exception itself
+        rather than reading the ambient one, so it works outside an `except`
+        block.
+
+        Args:
+            ex: The exception to report.
+            msg: Message to log. Defaults to a summary of `ex`.
+            **kwargs: Structured fields, also carried as the event's context.
+        """
         if msg is None:
             msg = f"Exception occurred: {ex}"
 
@@ -206,19 +283,71 @@ class EngineLogger:
         )
 
         if self._event_dispatcher:
-            evt = OnExceptionEvent(
-                exception=ex, context=kwargs, category=LogCategory.SYSTEM
+            self._event_dispatcher.dispatch(
+                OnExceptionEvent(
+                    exception=ex, context=kwargs, category=LogCategory.SYSTEM
+                )
             )
-            self._event_dispatcher.dispatch(evt)
 
     def performance(self, operation: str, duration: float, **context: Any) -> None:
-        """Log a performance metric."""
-        msg = f"Operation '{operation}' completed in {duration:.3f}s"
+        """Log a timing measurement under the PERFORMANCE category.
+
+        Args:
+            operation: What was measured.
+            duration: Elapsed time in seconds.
+            **context: Extra structured fields.
+        """
         self._log(
             LogLevel.INFO,
-            msg,
+            f"Operation '{operation}' completed in {duration:.3f}s",
             LogCategory.PERFORMANCE,
             operation=operation,
             duration=duration,
             **context,
         )
+
+    def _log(
+        self,
+        level: LogLevel,
+        message: str,
+        category: LogCategory,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        """Emit one record, splitting stdlib keywords from structured fields.
+
+        Args:
+            level: Level to emit at.
+            message: Message, optionally printf-style.
+            category: Log category, attached as a record attribute.
+            *args: Printf-style arguments for `message`.
+            **kwargs: `exc_info`, `stack_info` and `stacklevel` are forwarded
+                to the stdlib logger; everything else becomes `extra`.
+        """
+        log_kwargs = {key: kwargs.pop(key) for key in _LOG_CALL_KWARGS if key in kwargs}
+        # Skip past this method and the level method, so the record points at
+        # the code that actually logged rather than at this module.
+        log_kwargs["stacklevel"] = (
+            int(log_kwargs.get("stacklevel", 1)) + _WRAPPER_FRAMES
+        )
+
+        extra: dict[str, Any] = {"category": category, **kwargs}
+
+        # A caller-supplied key that shadows a real LogRecord attribute would
+        # otherwise raise KeyError inside logging's makeRecord(); rename it
+        # instead of dropping the data.
+        safe_extra = {
+            (f"{key}_" if key in _RESERVED_LOG_RECORD_ATTRS else key): value
+            for key, value in extra.items()
+        }
+
+        self._logger.log(level.value, message, *args, extra=safe_extra, **log_kwargs)
+
+    def _add_own_handler(self, handler: logging.Handler) -> None:
+        """Attach a handler and record it as this logger's to remove later.
+
+        Args:
+            handler: The handler to install.
+        """
+        self._logger.addHandler(handler)
+        self._own_handlers.append(handler)

--- a/pyguara/log/manager.py
+++ b/pyguara/log/manager.py
@@ -1,8 +1,10 @@
-"""Central management for application loggers."""
+"""Factory and registry for engine loggers."""
+
+from __future__ import annotations
 
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Final
 
 from pyguara.log.logger import EngineLogger
 from pyguara.log.types import LogLevel
@@ -10,66 +12,114 @@ from pyguara.log.types import LogLevel
 if TYPE_CHECKING:
     from pyguara.events.dispatcher import EventDispatcher
 
+# Distinguishes "leave the dispatcher alone" from "detach the dispatcher",
+# which a plain None default cannot express.
+_UNCHANGED: Final[Any] = object()
+
 
 class LogManager:
-    """Factory and registry for EngineLogger instances."""
+    """Creates and configures `EngineLogger` instances from shared settings.
 
-    def __init__(self, event_dispatcher: Optional["EventDispatcher"] = None) -> None:
-        """Initialize the manager."""
-        self._loggers: Dict[str, EngineLogger] = {}
+    Settings apply to every logger the manager has handed out, including ones
+    created before `configure()` was called.
+
+    Note:
+        Loggers wrap `logging.getLogger(name)`, which is process-global, so two
+        managers using the same name share one underlying logger. Each removes
+        only the handlers it installed, but level and propagation are shared,
+        last writer winning. Prefer the single `default_log_manager`.
+    """
+
+    def __init__(self, event_dispatcher: EventDispatcher | None = None) -> None:
+        """Initialise a manager with default settings.
+
+        Args:
+            event_dispatcher: If given, every logger also dispatches records as
+                `OnLogEvent`.
+        """
+        self._loggers: dict[str, EngineLogger] = {}
         self._event_dispatcher = event_dispatcher
         self._level = LogLevel.INFO
-        self._log_file: Optional[Path] = None
+        self._log_file: Path | None = None
         self._console = True
+        self._propagate = True
         self._lock = threading.RLock()
 
     def configure(
         self,
         level: LogLevel = LogLevel.INFO,
-        log_file: Optional[Union[str, Path]] = None,
+        log_file: str | Path | None = None,
         console: bool = True,
-        dispatcher: Optional["EventDispatcher"] = None,
+        dispatcher: EventDispatcher | None = _UNCHANGED,
+        propagate: bool = True,
     ) -> None:
-        """Update global logging settings and rebuild existing loggers' handlers."""
+        """Apply settings to this manager and every logger it has created.
+
+        Args:
+            level: Minimum level to emit.
+            log_file: Write records here. None disables file logging.
+            console: Write records to stdout.
+            dispatcher: Dispatch records as `OnLogEvent`. Omit to keep the
+                current dispatcher; pass None explicitly to detach it.
+            propagate: Let records reach ancestor loggers, including root.
+                Leave enabled so an application's logging configuration can
+                capture engine output; disable it if that configuration also
+                prints, to avoid every record appearing twice.
+        """
         with self._lock:
             self._level = level
             self._log_file = Path(log_file) if log_file else None
             self._console = console
-            if dispatcher:
+            self._propagate = propagate
+            if dispatcher is not _UNCHANGED:
                 self._event_dispatcher = dispatcher
 
-            # Rebuild handlers on every already-constructed logger. Most of the
-            # 31 leaf modules build their EngineLogger eagerly at import time via
-            # get_logger(), before this is ever called — without rebuilding
-            # handlers here (not just setLevel()), file/event logging configured
-            # afterward would silently never reach them.
+            # Rebuild handlers on every already-constructed logger, not merely
+            # setLevel(): most leaf modules build theirs eagerly at import time
+            # via get_logger(), long before this runs, so file and event output
+            # configured afterwards would otherwise never reach them.
             for logger in self._loggers.values():
                 logger.reconfigure(
                     level=self._level,
                     event_dispatcher=self._event_dispatcher,
                     log_file=self._log_file,
                     console_output=self._console,
+                    propagate=self._propagate,
                 )
 
     def get_logger(self, name: str) -> EngineLogger:
-        """Get or create a named logger instance."""
+        """Return the logger for a name, creating it on first request.
+
+        Args:
+            name: Logger name, conventionally the module's `__name__`.
+
+        Returns:
+            The logger, configured with this manager's current settings.
+        """
         with self._lock:
-            if name not in self._loggers:
-                self._loggers[name] = EngineLogger(
+            logger = self._loggers.get(name)
+            if logger is None:
+                logger = EngineLogger(
                     name=name,
                     level=self._level,
                     event_dispatcher=self._event_dispatcher,
                     log_file=self._log_file,
                     console_output=self._console,
+                    propagate=self._propagate,
                 )
-            return self._loggers[name]
+                self._loggers[name] = logger
+            return logger
 
     def shutdown(self) -> None:
-        """Close all logger handlers."""
+        """Close and detach the handlers of every logger this manager created.
+
+        Detaching matters as much as closing: a closed `FileHandler` that is
+        still attached silently reopens its file on the next record, so closing
+        alone leaves logging running.
+        """
         with self._lock:
             for logger in self._loggers.values():
-                for h in logger._logger.handlers:
-                    h.close()
+                logger.detach_handlers()
             self._loggers.clear()
 
 
@@ -80,5 +130,12 @@ default_log_manager = LogManager()
 
 
 def get_logger(name: str) -> EngineLogger:
-    """Get or create a named logger from the shared default LogManager."""
+    """Return a logger from the shared default manager.
+
+    Args:
+        name: Logger name, conventionally the module's `__name__`.
+
+    Returns:
+        The logger for that name.
+    """
     return default_log_manager.get_logger(name)

--- a/pyguara/log/types.py
+++ b/pyguara/log/types.py
@@ -5,7 +5,7 @@ import logging
 
 
 class LogLevel(IntEnum):
-    """Maps standard Python logging levels to our system."""
+    """Engine log levels, numerically identical to the stdlib's."""
 
     DEBUG = logging.DEBUG
     INFO = logging.INFO
@@ -15,10 +15,15 @@ class LogLevel(IntEnum):
 
 
 class LogCategory(str, Enum):
-    """Categories for organizing log streams."""
+    """Subsystem tag carried on every record, for filtering and routing.
+
+    Orthogonal to `LogLevel`: a category says *where* a message came from,
+    a level says how severe it is. DEBUG is the exception -- it is the default
+    category for `EngineLogger.debug()`, for messages that belong to no
+    particular subsystem.
+    """
 
     SYSTEM = "system"
-    # FIX: Added DEBUG category to resolve 'attr-defined' error
     DEBUG = "debug"
     GRAPHICS = "graphics"
     AUDIO = "audio"

--- a/tests/test_log_manager.py
+++ b/tests/test_log_manager.py
@@ -105,3 +105,323 @@ def test_module_level_get_logger_is_backed_by_shared_default_manager():
     second = log_module.default_log_manager.get_logger(name)
 
     assert first is second
+
+
+# -- Source attribution --
+
+
+class _Capture(logging.Handler):
+    """Collects records so their attributes can be asserted directly."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@pytest.fixture
+def captured():
+    manager = LogManager()
+    manager.configure(level=LogLevel.DEBUG, console=False)
+    log = manager.get_logger("test.source")
+    handler = _Capture()
+    log._logger.addHandler(handler)
+    yield log, handler
+    log._logger.removeHandler(handler)
+    manager.shutdown()
+
+
+@pytest.mark.unit
+def test_records_point_at_the_calling_code_not_the_wrapper(captured):
+    """Every record used to report logger.py and the line of the internal
+    `self._logger.log(...)` call, because the two wrapper frames were never
+    skipped. %(lineno)d in the file format, and the module/line carried into
+    OnLogEvent, were therefore the same useless value for every message in
+    the engine."""
+    log, handler = captured
+
+    log.info("from the test")
+    record = handler.records[-1]
+
+    assert record.module == "test_log_manager"
+    assert record.funcName == "test_records_point_at_the_calling_code_not_the_wrapper"
+    assert record.pathname.endswith("test_log_manager.py")
+
+
+@pytest.mark.unit
+def test_every_level_method_attributes_correctly(captured):
+    log, handler = captured
+
+    log.debug("d")
+    log.info("i")
+    log.warning("w")
+    log.error("e")
+    log.critical("c")
+
+    assert {r.module for r in handler.records} == {"test_log_manager"}
+    assert all(
+        r.funcName == "test_every_level_method_attributes_correctly"
+        for r in handler.records
+    )
+
+
+@pytest.mark.unit
+def test_performance_and_exception_also_attribute_correctly(captured):
+    log, handler = captured
+
+    log.performance("load", 1.5)
+    log.exception(ValueError("boom"))
+
+    assert {r.module for r in handler.records} == {"test_log_manager"}
+
+
+@pytest.mark.unit
+def test_a_caller_supplied_stacklevel_still_skips_the_wrapper(captured):
+    """stacklevel=2 must mean "two frames above my caller", counted from user
+    code, not from inside the wrapper."""
+    log, handler = captured
+
+    def helper() -> None:
+        log.info("logged via a helper", stacklevel=2)
+
+    helper()
+
+    assert handler.records[-1].funcName == (
+        "test_a_caller_supplied_stacklevel_still_skips_the_wrapper"
+    )
+
+
+# -- Handler ownership --
+
+
+@pytest.mark.unit
+def test_reconfigure_leaves_foreign_handlers_attached(captured):
+    """reconfigure() cleared the whole handler list of a process-global stdlib
+    logger, so it silently tore down handlers installed by the application --
+    or by a second LogManager sharing the same name."""
+    log, handler = captured
+
+    log.reconfigure(
+        level=LogLevel.DEBUG, event_dispatcher=None, log_file=None, console_output=False
+    )
+
+    assert handler in log._logger.handlers
+
+
+@pytest.mark.unit
+def test_two_managers_do_not_tear_down_each_others_handlers():
+    name = "test.two_managers"
+    first, second = LogManager(), LogManager()
+
+    log_a = first.get_logger(name)
+    handlers_after_a = list(log_a._logger.handlers)
+    log_b = second.get_logger(name)
+
+    assert log_a is not log_b
+    assert log_a._logger is log_b._logger, "stdlib loggers are process-global"
+    for handler in handlers_after_a:
+        assert handler in log_a._logger.handlers
+
+    first.shutdown()
+    second.shutdown()
+
+
+@pytest.mark.unit
+def test_reconfigure_does_not_accumulate_its_own_handlers(tmp_path):
+    manager = LogManager()
+    manager.configure(level=LogLevel.INFO, console=True, log_file=tmp_path / "a.log")
+    log = manager.get_logger("test.no_accumulate")
+    first_count = len(log._logger.handlers)
+
+    for index in range(3):
+        manager.configure(
+            level=LogLevel.INFO, console=True, log_file=tmp_path / f"{index}.log"
+        )
+
+    assert len(log._logger.handlers) == first_count
+    manager.shutdown()
+
+
+# -- Shutdown --
+
+
+@pytest.mark.unit
+def test_shutdown_detaches_handlers_not_just_closes_them(tmp_path):
+    """A closed FileHandler that is still attached silently reopens its file on
+    the next record, so closing alone left logging running after shutdown."""
+    manager = LogManager()
+    manager.configure(level=LogLevel.INFO, console=False, log_file=tmp_path / "e.log")
+    log = manager.get_logger("test.detach")
+    log.info("before")
+
+    manager.shutdown()
+
+    assert log._logger.handlers == []
+
+
+@pytest.mark.unit
+def test_nothing_is_written_after_shutdown(tmp_path):
+    log_file = tmp_path / "engine.log"
+    manager = LogManager()
+    manager.configure(level=LogLevel.INFO, console=False, log_file=log_file)
+    log = manager.get_logger("test.after_shutdown")
+    log.info("before shutdown")
+    manager.shutdown()
+
+    log.info("after shutdown")
+
+    contents = log_file.read_text()
+    assert "before shutdown" in contents
+    assert "after shutdown" not in contents
+
+
+@pytest.mark.unit
+def test_shutdown_is_idempotent(tmp_path):
+    manager = LogManager()
+    manager.configure(level=LogLevel.INFO, console=False, log_file=tmp_path / "e.log")
+    manager.get_logger("test.double_shutdown")
+
+    manager.shutdown()
+    manager.shutdown()
+
+
+# -- configure() --
+
+
+@pytest.mark.unit
+def test_configure_can_detach_the_dispatcher():
+    """`if dispatcher:` meant None was indistinguishable from "unspecified",
+    so event integration could be switched on but never off."""
+
+    class FakeDispatcher:
+        def dispatch(self, event) -> None: ...
+
+    manager = LogManager()
+    manager.configure(console=False, dispatcher=FakeDispatcher())
+    assert manager._event_dispatcher is not None
+
+    manager.configure(console=False, dispatcher=None)
+
+    assert manager._event_dispatcher is None
+    manager.shutdown()
+
+
+@pytest.mark.unit
+def test_configure_without_a_dispatcher_argument_keeps_the_current_one():
+    class FakeDispatcher:
+        def dispatch(self, event) -> None: ...
+
+    dispatcher = FakeDispatcher()
+    manager = LogManager()
+    manager.configure(console=False, dispatcher=dispatcher)
+
+    manager.configure(level=LogLevel.DEBUG, console=False)
+
+    assert manager._event_dispatcher is dispatcher
+    manager.shutdown()
+
+
+@pytest.mark.unit
+def test_propagation_can_be_disabled(captured):
+    """Engine loggers install their own console handler, so an application
+    that also configures root logging sees every record twice. Propagation is
+    left on by default -- it is what lets an app capture engine output -- but
+    must be switchable."""
+    log, _ = captured
+    assert log._logger.propagate is True
+
+    log.reconfigure(
+        level=LogLevel.INFO,
+        event_dispatcher=None,
+        log_file=None,
+        console_output=True,
+        propagate=False,
+    )
+
+    assert log._logger.propagate is False
+
+
+# -- Structured context reaches events --
+
+
+@pytest.mark.unit
+def test_structured_fields_reach_the_dispatched_event():
+    from pyguara.events.dispatcher import EventDispatcher
+    from pyguara.log.events import OnLogEvent
+
+    dispatcher = EventDispatcher()
+    seen: list[OnLogEvent] = []
+    dispatcher.subscribe(OnLogEvent, lambda e: seen.append(e))
+
+    manager = LogManager()
+    manager.configure(level=LogLevel.INFO, console=False, dispatcher=dispatcher)
+    manager.get_logger("test.context").info("loading", asset="hero.png", retries=2)
+
+    assert seen[-1].context["asset"] == "hero.png"
+    assert seen[-1].context["retries"] == 2
+    manager.shutdown()
+
+
+@pytest.mark.unit
+def test_event_context_reports_the_real_call_site():
+    from pyguara.events.dispatcher import EventDispatcher
+    from pyguara.log.events import OnLogEvent
+
+    dispatcher = EventDispatcher()
+    seen: list[OnLogEvent] = []
+    dispatcher.subscribe(OnLogEvent, lambda e: seen.append(e))
+
+    manager = LogManager()
+    manager.configure(level=LogLevel.INFO, console=False, dispatcher=dispatcher)
+    manager.get_logger("test.event_site").info("hello")
+
+    assert seen[-1].context["module"] == "test_log_manager"
+    manager.shutdown()
+
+
+@pytest.mark.unit
+def test_a_reserved_attribute_name_is_renamed_rather_than_dropped():
+    from pyguara.events.dispatcher import EventDispatcher
+    from pyguara.log.events import OnLogEvent
+
+    dispatcher = EventDispatcher()
+    seen: list[OnLogEvent] = []
+    dispatcher.subscribe(OnLogEvent, lambda e: seen.append(e))
+
+    manager = LogManager()
+    manager.configure(level=LogLevel.INFO, console=False, dispatcher=dispatcher)
+    manager.get_logger("test.reserved").info("m", module="mine", filename="x.py")
+
+    assert seen[-1].context["module_"] == "mine"
+    assert seen[-1].context["filename_"] == "x.py"
+    manager.shutdown()
+
+
+@pytest.mark.unit
+def test_the_category_defaults_per_level():
+    from pyguara.events.dispatcher import EventDispatcher
+    from pyguara.log.events import OnLogEvent
+    from pyguara.log.types import LogCategory
+
+    dispatcher = EventDispatcher()
+    seen: list[OnLogEvent] = []
+    dispatcher.subscribe(OnLogEvent, lambda e: seen.append(e))
+
+    manager = LogManager()
+    manager.configure(level=LogLevel.DEBUG, console=False, dispatcher=dispatcher)
+    log = manager.get_logger("test.categories")
+
+    log.debug("d")
+    log.info("i")
+    log.performance("op", 0.5)
+    log.warning("w", category=LogCategory.PHYSICS)
+
+    assert [e.category for e in seen] == [
+        LogCategory.DEBUG,
+        LogCategory.SYSTEM,
+        LogCategory.PERFORMANCE,
+        LogCategory.PHYSICS,
+    ]
+    manager.shutdown()


### PR DESCRIPTION
Fifth iteration of the incremental subsystem audit. Scope is `pyguara/log`. **This completes Tier 1** — `common`, `log`, `events`, `di`.

> **Stacked on #4 → #3 → #2 → #1.** Base is `refactor/di-audit`.

## 🐞 Every log record in the engine reported the wrong source

`EngineLogger._log()` called `self._logger.log()` without a `stacklevel`, so the two wrapper frames — the level method and `_log` itself — were never skipped. Every record attributed itself to the same line inside the wrapper:

```
record says: logger.py:138  funcName=_log
truth is   : probe_log.py:20  funcName=<module>
```

That constant is what the file formatter's `%(lineno)d` printed, and what the `module`/`line` fields carried into every `OnLogEvent`. Visible in a real log file:

```
2026-09-06 04:49:14 [    INFO] probe:138: before shutdown
2026-09-06 04:49:14 [    INFO] probe:138: AFTER shutdown
```

Source attribution was broken for every message the engine has ever logged. A caller-supplied `stacklevel` is now offset rather than ignored.

## 🐞 `shutdown()` didn't stop logging

It closed handlers but left them attached — and a closed `FileHandler` **silently reopens its file** on the next record. Shutdown was effectively a no-op.

Worth flagging how I got this one wrong first: my initial probe asserted the post-shutdown message was dropped. Reading the file showed the opposite — it was written. The defect is that shutdown doesn't shut down, not that it loses records. Corrected before writing the fix.

## 🐞 `reconfigure()` tore down other people's handlers

It cleared the entire handler list of `logging.getLogger(name)`, which is **process-global**. That silently removed handlers installed by the application, by a test, or by a second `LogManager` using the same name. Each logger now tracks and removes only what it installed.

## 🐞 `configure(dispatcher=None)` couldn't detach a dispatcher

`if dispatcher:` cannot tell `None` from unspecified, so event integration could be switched on but never off. A sentinel default separates them.

## 📄 The docs described an API that has never existed

`docs/core/logging.md` documented `pyguara.log.config.setup_logging()` and `pyguara.log.config.get_logger()`. There is no `config` module and no `setup_logging` function anywhere in the tree:

```
$ grep -rn "setup_logging" .
setup_logging: DOES NOT EXIST ANYWHERE
$ python -c "from pyguara.log.config import setup_logging"
ModuleNotFoundError: No module named 'pyguara.log.config'
```

Every code sample on that page raised `ModuleNotFoundError`. Rewritten against the API that exists. Filed as **CC-10** — nothing catches this because docs are never executed, so "verify the documented API actually exists" is now an explicit Phase C step until docs are covered by a smoke test.

## Also

`EventIntegratedHandler.emit()` constructed a throwaway `LogRecord` on **every** record, purely to compute a constant set of key names — hoisted to a module-level frozenset. `propagate` is now an explicit parameter: engine loggers install their own handlers *and* propagate, so an app that also configures root logging sees everything twice. Default stays `True` (propagation is what lets an app capture engine output, and duplication only occurs when the app prints too), but the trade-off is documented rather than accidental.

## Tests

9 → 26. Source attribution across every level method, handler ownership, shutdown semantics, dispatcher detachment, propagation, and the path from structured keyword arguments through to `OnLogEvent.context`.

**1303 pass** (from 1286), ruff clean, mypy clean. Two commits, each verified green in an isolated worktree.

## Tier 1 complete

| | | |
| --- | --- | --- |
| #1 | `ecs` | Query-cache bypass, dead-entity resurrection, subscription API |
| #2 | `common` | `Transform.up` pointing down, parent cycles, falsy-`Vector2` default |
| #3 | `events` | Latent `log`⇄`events` import cycle, timestamp sentinel, dispatch memoisation |
| #4 | `di` | Missing lock fabricating circular dependencies, captive lifetimes |
| #5 | `log` | Broken source attribution, no-op shutdown, fictional docs |

Ten cross-cutting concerns are parked in `REFACTOR_STATE.md`. **CC-1** (ruff pinned to `py39` against a 3.12+ floor, so pyupgrade/bugbear/pydocstyle never run) is the one I'd take before the large Tier 3 subsystems, where the hand-fixing churn would be worst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
