### PR TITLE
refactor(config): audit pass — Color didn't survive a save/load round trip

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -12,7 +12,7 @@ rather than fixed in place.
 
 ## Active Subsystem
 
-*(between iterations — cross-cutting work landed; `pyguara/config` is next)*
+`pyguara/config` — **in review (awaiting approval)**
 
 ---
 
@@ -28,7 +28,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 ### Tier 2 — Core runtime
 - [x] `pyguara/ecs` — Entity, Component, EntityManager, QueryCache *(done)*
-- [ ] `pyguara/config` — configuration loading/merging
+- [x] `pyguara/config` — configuration loading/merging *(active)*
 - [ ] `pyguara/application` — Application loop, bootstrap, sandbox
 - [ ] `pyguara/scene` — Scene base, SceneManager, serializer
 - [ ] `pyguara/systems` — system manager / base systems
@@ -490,3 +490,62 @@ fictional APIs on its first run (see CC-10 above).
 **Not done:** the filename `docs/guides/Archictecture & Style Guide.md` is
 misspelled. Renaming it means touching the mkdocs nav and any inbound links, so
 it is left for whoever next edits that file.
+
+
+### `pyguara/config` — awaiting approval (2026-09-06)
+
+**Verification:** 1371/1371 tests pass (up from 1343); ruff clean; mypy clean.
+
+**Correctness fixes (all ten reproduced by probe before fixing):**
+- **`Color` did not survive a save/load round trip.** `asdict()` flattens it to
+  `{"r": ..., "g": ...}` and `from_dict` passed that straight back to
+  `WindowConfig`, so `display.default_color` came back as a `dict`. Both window
+  backends read it as `self._default_color` and pass it to `clear()`, so
+  `fill_color.r` raised AttributeError. Reachable on the *ordinary* path: run 1
+  finds no config file and writes defaults, run 2 reads them back and breaks.
+  `from_dict` is now field-driven and coerces by declared type, which also
+  removed five near-identical per-section blocks.
+- **`OnConfigurationLoaded` and `OnConfigurationSaved` were permanently stamped
+  `timestamp=0.0`.** Unlike the input/lifecycle events fixed in the `events`
+  pass, these had no `__post_init__` at all, and the manager never passed a
+  timestamp. Now `field(default_factory=time.time)`.
+- **`PhysicsConfig.fixed_dt` divided by zero** with nothing validating
+  `fixed_timestep_hz`. `Application.run()` reads it on every startup, so a zero
+  in a config file crashed the engine with a bare ZeroDivisionError naming
+  neither the setting nor the file. Now raises a named ValueError, and the
+  validator reports it as CRITICAL.
+- **`update_setting()` warned about a type mismatch and then assigned anyway**,
+  so `screen_width` could end up holding `"not a number"`. It now refuses, and
+  is stricter than `isinstance` where that matters: a `bool` is not an `int`
+  here, though `isinstance(True, int)` says otherwise.
+- **`update_setting()` bypassed validation entirely**, so it could put the
+  config into a state `load()` would have rejected (`master_volume = 99.0`). It
+  now reverts and refuses on an ERROR/CRITICAL issue; WARNING passes, since a
+  warning is advice.
+- **`from_dict` mutated the caller's dict** (the debug section was not copied).
+- **Unknown keys were dropped in silence** -- a typo'd setting simply never
+  took effect. Now ignored *and* logged, so a config from a newer engine still
+  loads but a typo is visible.
+- **Invalid env overrides failed silently** (`except ValueError: pass`), so a
+  typo in a launch script did nothing at all. Now reported, and the message
+  lists the valid values.
+- **Every validation issue was logged as a warning**, hiding ERROR and CRITICAL
+  among the merely suboptimal. Each is now logged at its own level.
+- **`ConfigManager._file_path` was hardcoded**; now a constructor argument,
+  which the tests needed anyway.
+
+**Validator coverage** went from 3 rules to 10: screen height, all three
+volumes rather than just master, gamepad deadzone, mouse sensitivity, fps
+target, fixed timestep and max frame time. `ValidationIssue` is now frozen and
+its `suggestion` field is actually populated.
+
+**Tests:** 5 -> 33. The existing five covered defaults, a mocked load, a mocked
+missing file and two `update_setting` cases -- all with mocks rather than real
+files, which is exactly why no round-trip bug could surface. The new ones use
+`tmp_path` and assert on real files, including a whole-config round trip that
+will catch the next field that fails to survive one.
+
+**Docs:** new `docs/core/configuration.md`, added to the nav;
+`application.md`'s config paragraph now links to it.
+
+**Deferred:** CC-3 through CC-8 (CC-1, CC-2, CC-9, CC-10 resolved).

--- a/docs/core/application.md
+++ b/docs/core/application.md
@@ -26,7 +26,8 @@ def create_application() -> Application:
 
 ## Configuration
 
-Configuration is managed by `ConfigManager` (`pyguara/config`), which handles:
+Configuration is managed by `ConfigManager` (`pyguara/config`) — see
+**[Configuration](configuration.md)** for the full reference. In brief:
 - **Loading/Saving**: JSON serialization.
 - **Validation**: Rules checking (e.g., "Screen width must be > 640").
 - **Events**: Dispatches `OnConfigurationChanged` when settings are modified.

--- a/docs/core/configuration.md
+++ b/docs/core/configuration.md
@@ -1,0 +1,167 @@
+# Configuration
+
+`pyguara.config` holds the engine's settings as nested dataclasses, loads and
+saves them as JSON, and validates them against what the engine can actually
+honour.
+
+```python
+from pyguara.config import ConfigManager
+
+manager = ConfigManager()
+manager.load()                                   # config/game_config.json
+
+manager.config.display.fps_target                # read directly
+manager.update_setting("audio", "master_volume", 0.5)   # write through here
+```
+
+Bootstrap builds one `ConfigManager`, loads it, and registers it in the DI
+container, so any service can take a `ConfigManager` in its constructor.
+
+## Sections
+
+| Section | Holds |
+| --- | --- |
+| `display` | Resolution, FPS target, fullscreen, vsync, title, backend, clear colour |
+| `audio` | Master, SFX and music volumes; mute |
+| `input` | Mouse sensitivity, gamepad enable and deadzone |
+| `physics` | Fixed timestep, max frame time, gravity |
+| `debug` | Log level and destinations, profiler, inspector, collider and FPS overlays |
+
+```python
+manager.config.physics.fixed_dt   # 1 / fixed_timestep_hz, in seconds
+```
+
+`fixed_dt` raises `ValueError` rather than `ZeroDivisionError` if
+`fixed_timestep_hz` is not positive — `Application.run()` reads it on every
+startup, so the message names the setting.
+
+## Loading and saving
+
+```python
+manager.load()                      # default path
+manager.load("saves/settings.json") # explicit path
+manager.save()
+```
+
+A missing file is not an error: defaults are written to that path so the game
+has something to edit, and the call succeeds.
+
+`load()` returns whether the file was **readable**, not whether its contents
+are sensible. Call `validate()` for that.
+
+### Round-tripping
+
+Values are coerced back to their declared types on load, which plain
+construction would not do:
+
+- `Color` is rebuilt from its `{"r": …, "g": …}` form.
+- Enums resolve from either a member name (`"DEBUG"`, `"moderngl"`) or a raw
+  value (`10`, `"pygame"`).
+
+An unrecognised enum value falls back to the engine default and logs a warning
+rather than raising, so one bad line does not stop the game from starting.
+
+### Unknown keys
+
+Keys the engine does not recognise are ignored and logged:
+
+```
+Unknown config key 'display.screen_widht' ignored. Check for a typo, or a
+setting from a different engine version.
+```
+
+A config written by a newer engine therefore still loads.
+
+## Changing settings
+
+Write through `update_setting()` rather than assigning to the dataclass. It
+type-checks the value, refuses anything the validator considers unusable, and
+dispatches `OnConfigurationChanged`.
+
+```python
+manager.update_setting("display", "fps_target", 144)     # True
+manager.update_setting("display", "fps_target", "fast")  # False, unchanged
+manager.update_setting("display", "fps_target", True)    # False — bool is not an int here
+manager.update_setting("audio", "master_volume", 99.0)   # False, out of range
+manager.update_setting("display", "fps_target", 20)      # True — a warning is advice
+```
+
+Type rules are stricter than `isinstance` in one place and looser in another:
+
+- A `bool` is **not** accepted for an `int` field, though Python says
+  `isinstance(True, int)`.
+- An `int` **is** accepted where a `float` is declared, the one widening both
+  JSON and Python expect.
+
+A rejected change mutates nothing and dispatches no event.
+
+Direct assignment (`manager.config.audio.master_volume = 99.0`) bypasses all of
+this. It is legal, and occasionally what you want during bootstrap, but nothing
+will check it.
+
+## Validation
+
+```python
+for issue in manager.validate():
+    print(issue.severity, issue.section, issue.setting, issue.message)
+```
+
+| Severity | Meaning |
+| --- | --- |
+| `INFO` | Worth knowing; harmless |
+| `WARNING` | Legal but likely to disappoint |
+| `ERROR` | The engine will misbehave, but can still start |
+| `CRITICAL` | The engine cannot start with this value |
+
+`load()` logs each issue **at its own level**, so an `ERROR` appears as an
+error rather than being buried among warnings.
+
+`update_setting()` blocks a change that introduces an `ERROR` or `CRITICAL`
+issue for the field being set. `WARNING` and `INFO` pass through — they are
+advice, not a veto.
+
+## Environment overrides
+
+Applied after the file is read, so they win:
+
+| Variable | Overrides |
+| --- | --- |
+| `PYGUARA_LOG_LEVEL` | `debug.log_level` — a name, e.g. `DEBUG` |
+| `PYGUARA_BACKEND` | `display.backend` — `pygame` or `moderngl` |
+| `PYGUARA_WINDOW_WIDTH` | `display.screen_width` |
+| `PYGUARA_WINDOW_HEIGHT` | `display.screen_height` |
+
+An unparseable value is reported and skipped:
+
+```
+Ignoring PYGUARA_BACKEND='vulkan': not a valid RenderingBackend.
+Expected one of PYGAME, MODERNGL.
+```
+
+## Events
+
+With a dispatcher wired in, three events are published:
+
+```python
+from pyguara.config.events import (
+    OnConfigurationChanged,
+    OnConfigurationLoaded,
+    OnConfigurationSaved,
+)
+
+dispatcher.subscribe(OnConfigurationChanged, settings_menu.refresh)
+```
+
+`OnConfigurationChanged` carries `section`, `setting`, `old_value` and
+`new_value` — enough for a settings screen to react without re-reading the
+whole config.
+
+## Rules of thumb
+
+1. Load once at bootstrap; read from the injected `ConfigManager` afterwards.
+2. Write through `update_setting()`. Assign directly only when you mean to
+   skip validation.
+3. `load()` returning True means the file parsed, not that it is sane — check
+   `validate()` if you care.
+4. Adding a field to a config dataclass is enough; loading, saving and
+   coercion are driven by the declared types.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
       - Core Types: core/common-types.md
       - Event System: core/events.md
       - Dependency Injection: core/dependency-injection.md
+      - Configuration: core/configuration.md
       - Application & Lifecycle: core/application.md
       - Logging: core/logging.md
   - Graphics:

--- a/pyguara/config/events.py
+++ b/pyguara/config/events.py
@@ -1,6 +1,7 @@
-"""Configuration event definitions."""
+"""Events emitted by the configuration subsystem."""
 
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from typing import Any
 
 from pyguara.events.protocols import Event
@@ -8,32 +9,54 @@ from pyguara.events.protocols import Event
 
 @dataclass
 class OnConfigurationChanged(Event):
-    """Dispatched when configuration settings are modified."""
+    """Dispatched when a setting is changed through `ConfigManager`.
+
+    Attributes:
+        section: Config section name, e.g. `"display"`.
+        setting: Field name within that section.
+        old_value: Value before the change.
+        new_value: Value after the change.
+        timestamp: Unix time the event was created.
+        source: Whatever raised the event, if it identified itself.
+    """
 
     section: str
     setting: str
     old_value: Any
     new_value: Any
-    # Event protocol requirements
-    timestamp: float = 0.0
+    timestamp: float = field(default_factory=time.time)
     source: Any = None
 
 
 @dataclass
 class OnConfigurationLoaded(Event):
-    """Dispatched when configuration is loaded from file."""
+    """Dispatched after configuration is read from a file.
+
+    Attributes:
+        config_file: Path that was read.
+        success: Whether the file parsed.
+        timestamp: Unix time the event was created.
+        source: Whatever raised the event, if it identified itself.
+    """
 
     config_file: str
     success: bool
-    timestamp: float = 0.0
+    timestamp: float = field(default_factory=time.time)
     source: Any = None
 
 
 @dataclass
 class OnConfigurationSaved(Event):
-    """Dispatched when configuration is saved to file."""
+    """Dispatched after configuration is written to a file.
+
+    Attributes:
+        config_file: Path that was written.
+        success: Whether the write completed.
+        timestamp: Unix time the event was created.
+        source: Whatever raised the event, if it identified itself.
+    """
 
     config_file: str
     success: bool
-    timestamp: float = 0.0
+    timestamp: float = field(default_factory=time.time)
     source: Any = None

--- a/pyguara/config/manager.py
+++ b/pyguara/config/manager.py
@@ -1,9 +1,10 @@
-"""Central configuration management."""
+"""Loading, saving and mutating the game configuration."""
 
-import contextlib
+from __future__ import annotations
+
 import json
 import os
-import time
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -13,111 +14,188 @@ from pyguara.config.events import (
     OnConfigurationSaved,
 )
 from pyguara.config.types import GameConfig, RenderingBackend
-from pyguara.config.validation import ConfigValidator
+from pyguara.config.validation import (
+    ConfigValidator,
+    ValidationIssue,
+    ValidationSeverity,
+)
 from pyguara.events.dispatcher import EventDispatcher
 from pyguara.log.logger import EngineLogger
 from pyguara.log.types import LogLevel
 
+DEFAULT_CONFIG_PATH = Path("config/game_config.json")
+
+# Severities that mean the engine cannot honour the value, as opposed to merely
+# disliking it. update_setting() refuses a change that introduces one.
+_BLOCKING_SEVERITIES = frozenset(
+    {ValidationSeverity.ERROR, ValidationSeverity.CRITICAL}
+)
+
 
 class ConfigManager:
-    """Manages loading, saving, and updating game configuration."""
+    """Owns the live `GameConfig` and its persistence.
+
+    Reading is direct (`manager.config.display.fps_target`). Writing should go
+    through `update_setting()`, which type-checks the value, rejects changes
+    the validator considers unusable, and dispatches
+    `OnConfigurationChanged`.
+    """
 
     def __init__(
         self,
         event_dispatcher: EventDispatcher | None = None,
         logger: EngineLogger | None = None,
+        file_path: str | Path | None = None,
     ) -> None:
-        """Initialize the manager."""
+        """Initialise the manager with default settings.
+
+        Args:
+            event_dispatcher: If given, config events are dispatched here.
+            logger: Where load, save and validation problems are reported.
+            file_path: Default path for `load()` and `save()`.
+        """
         self._config = GameConfig()
-        self._file_path = Path("config/game_config.json")
+        self._file_path = Path(file_path) if file_path else DEFAULT_CONFIG_PATH
         self._dispatcher = event_dispatcher
         self._logger = logger
         self._validator = ConfigValidator()
 
     @property
     def config(self) -> GameConfig:
-        """Access the raw config object."""
+        """The live configuration object."""
         return self._config
 
+    @property
+    def file_path(self) -> Path:
+        """Path used by `load()` and `save()` when none is given."""
+        return self._file_path
+
     def load(self, file_path: str | Path | None = None) -> bool:
-        """Load configuration from JSON file."""
+        """Read configuration from a JSON file, then apply env overrides.
+
+        A missing file is not an error: defaults are written to that path so
+        the game has something to edit, and the call succeeds.
+
+        Args:
+            file_path: File to read. Defaults to `file_path` from the
+                constructor.
+
+        Returns:
+            True if the configuration was established, False if the file
+            existed but could not be read or parsed. Note this reports whether
+            the file was *readable*, not whether its contents are sane -- call
+            `validate()` for that.
+        """
         target_path = Path(file_path) if file_path else self._file_path
 
         if not target_path.exists():
-            if self._logger:
-                self._logger.warning(
-                    f"Config file not found: {target_path}. Using defaults."
-                )
+            self._log(
+                ValidationSeverity.WARNING,
+                f"Config file not found: {target_path}. Writing defaults.",
+            )
             self.save(target_path)
             return True
 
         try:
-            with open(target_path, encoding="utf-8") as f:
-                data = json.load(f)
-
+            with open(target_path, encoding="utf-8") as handle:
+                data = json.load(handle)
             self._config = GameConfig.from_dict(data)
-
-            self._apply_env_overrides()
-
-            # Run validation after load
-            issues = self._validator.validate(self._config)
-            if issues and self._logger:
-                for issue in issues:
-                    self._logger.warning(f"Config Validation: {issue.message}")
-
-            if self._dispatcher:
-                self._dispatcher.dispatch(
-                    OnConfigurationLoaded(config_file=str(target_path), success=True)
-                )
-
-            return True
-
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, TypeError, ValueError) as error:
             if self._logger:
-                self._logger.error(f"Failed to load config from {target_path}: {e}")
+                self._logger.error(f"Failed to load config from {target_path}: {error}")
             return False
 
+        self._apply_env_overrides()
+        self._report(self.validate())
+
+        if self._dispatcher:
+            self._dispatcher.dispatch(
+                OnConfigurationLoaded(config_file=str(target_path), success=True)
+            )
+        return True
+
     def save(self, file_path: str | Path | None = None) -> bool:
-        """Save current configuration to JSON file."""
+        """Write the current configuration to a JSON file.
+
+        Args:
+            file_path: File to write. Defaults to `file_path` from the
+                constructor. Parent directories are created.
+
+        Returns:
+            True if the file was written.
+        """
         target_path = Path(file_path) if file_path else self._file_path
 
         try:
             target_path.parent.mkdir(parents=True, exist_ok=True)
-
-            with open(target_path, "w", encoding="utf-8") as f:
-                json.dump(self._config.to_dict(), f, indent=4)
-
-            if self._dispatcher:
-                self._dispatcher.dispatch(
-                    OnConfigurationSaved(config_file=str(target_path), success=True)
-                )
-            return True
-
-        except Exception as e:
+            with open(target_path, "w", encoding="utf-8") as handle:
+                json.dump(self._config.to_dict(), handle, indent=4)
+        except (OSError, TypeError) as error:
             if self._logger:
-                self._logger.error(f"Failed to save config to {target_path}: {e}")
+                self._logger.error(f"Failed to save config to {target_path}: {error}")
             return False
+
+        if self._dispatcher:
+            self._dispatcher.dispatch(
+                OnConfigurationSaved(config_file=str(target_path), success=True)
+            )
+        return True
+
+    def validate(self) -> list[ValidationIssue]:
+        """Check the current configuration against the engine's limits.
+
+        Returns:
+            Every issue found, empty when the configuration is sound.
+        """
+        return self._validator.validate(self._config)
 
     def update_setting(self, section: str, setting: str, value: Any) -> bool:
-        """Update a specific setting and fire change events."""
-        if not hasattr(self._config, section):
-            return False
+        """Change one setting, if the new value is usable.
 
-        section_obj = getattr(self._config, section)
-        if not hasattr(section_obj, setting):
+        The change is rejected, and nothing is mutated, when the section or
+        setting is unknown, the value is the wrong type, or the validator
+        considers the result unusable. Rejection is logged.
+
+        Args:
+            section: Config section name, e.g. `"display"`.
+            setting: Field name within that section.
+            value: The new value.
+
+        Returns:
+            True if the setting was changed.
+        """
+        section_obj = getattr(self._config, section, None)
+        if section_obj is None or not hasattr(section_obj, setting):
+            self._log(
+                ValidationSeverity.WARNING,
+                f"Unknown config setting '{section}.{setting}'.",
+            )
             return False
 
         old_value = getattr(section_obj, setting)
-
-        # Basic Type Check
-        if not isinstance(value, type(old_value)) and old_value is not None:
-            if self._logger:
-                self._logger.warning(
-                    f"Type mismatch for {section}.{setting}. "
-                    f"Expected {type(old_value)}, got {type(value)}"
-                )
+        if not _is_assignable(old_value, value):
+            self._log(
+                ValidationSeverity.ERROR,
+                f"Rejected '{section}.{setting}': expected "
+                f"{type(old_value).__name__}, got {type(value).__name__} "
+                f"({value!r}).",
+            )
+            return False
 
         setattr(section_obj, setting, value)
+
+        blocking = [
+            issue
+            for issue in self._validator.validate_section(self._config, section)
+            if issue.severity in _BLOCKING_SEVERITIES and issue.setting == setting
+        ]
+        if blocking:
+            setattr(section_obj, setting, old_value)
+            self._log(
+                ValidationSeverity.ERROR,
+                f"Rejected '{section}.{setting}' = {value!r}: {blocking[0].message}",
+            )
+            return False
 
         if self._dispatcher:
             self._dispatcher.dispatch(
@@ -126,39 +204,130 @@ class ConfigManager:
                     setting=setting,
                     old_value=old_value,
                     new_value=value,
-                    timestamp=time.time(),
                 )
             )
-
         return True
 
     def _apply_env_overrides(self) -> None:
-        """Allow environment variables to override config."""
-        # --- Debug / Engine Settings ---
-        # Map PYGUARA_LOG_LEVEL -> config.debug.log_level
-        env_log = os.getenv("PYGUARA_LOG_LEVEL")
-        if env_log:
-            # An unrecognised level keeps the configured default.
-            with contextlib.suppress(KeyError):
-                self._config.debug.log_level = LogLevel[env_log.upper()]
+        """Let `PYGUARA_*` environment variables override loaded settings.
 
-        # --- Display Settings ---
-        # Map PYGUARA_BACKEND -> config.display.backend
-        env_backend = os.getenv("PYGUARA_BACKEND")
-        if env_backend:
-            with contextlib.suppress(ValueError):
-                self._config.display.backend = RenderingBackend(env_backend.lower())
+        An unparseable value is reported and skipped rather than silently
+        ignored, since a typo in a launch script is otherwise invisible.
+        """
+        self._override_enum(
+            "PYGUARA_LOG_LEVEL", self._config.debug, "log_level", LogLevel
+        )
+        self._override_enum(
+            "PYGUARA_BACKEND", self._config.display, "backend", RenderingBackend
+        )
+        self._override_int("PYGUARA_WINDOW_WIDTH", self._config.display, "screen_width")
+        self._override_int(
+            "PYGUARA_WINDOW_HEIGHT", self._config.display, "screen_height"
+        )
 
-        # Map PYGUARA_WINDOW_WIDTH -> config.display.screen_width
-        env_width = os.getenv("PYGUARA_WINDOW_WIDTH")
-        if env_width:
-            with contextlib.suppress(ValueError):
-                self._config.display.screen_width = int(env_width)
+    def _override_enum(
+        self, variable: str, section: Any, setting: str, enum_type: type[Enum]
+    ) -> None:
+        """Apply an enum-valued environment override.
 
-        # Map PYGUARA_WINDOW_HEIGHT -> config.display.screen_height
-        env_height = os.getenv("PYGUARA_WINDOW_HEIGHT")
-        if env_height:
-            with contextlib.suppress(ValueError):
-                self._config.display.screen_height = int(env_height)
+        Args:
+            variable: Environment variable name.
+            section: Config section object to write to.
+            setting: Field name within that section.
+            enum_type: Enum to resolve the value against, by name or by value.
+        """
+        raw = os.getenv(variable)
+        if not raw:
+            return
+        try:
+            setattr(section, setting, enum_type[raw.upper()])
+            return
+        except KeyError:
+            pass
+        try:
+            setattr(section, setting, enum_type(raw.lower()))
+        except ValueError:
+            valid = ", ".join(member.name for member in enum_type)
+            self._log(
+                ValidationSeverity.WARNING,
+                f"Ignoring {variable}={raw!r}: not a valid {enum_type.__name__}. "
+                f"Expected one of {valid}.",
+            )
 
-        return
+    def _override_int(self, variable: str, section: Any, setting: str) -> None:
+        """Apply an integer-valued environment override.
+
+        Args:
+            variable: Environment variable name.
+            section: Config section object to write to.
+            setting: Field name within that section.
+        """
+        raw = os.getenv(variable)
+        if not raw:
+            return
+        try:
+            setattr(section, setting, int(raw))
+        except ValueError:
+            self._log(
+                ValidationSeverity.WARNING,
+                f"Ignoring {variable}={raw!r}: not an integer.",
+            )
+
+    def _report(self, issues: list[ValidationIssue]) -> None:
+        """Log validation issues, each at its own severity.
+
+        Args:
+            issues: Issues to report.
+        """
+        for issue in issues:
+            detail = f" {issue.suggestion}" if issue.suggestion else ""
+            self._log(
+                issue.severity,
+                f"Config {issue.section}.{issue.setting}: {issue.message}{detail}",
+            )
+
+    def _log(self, severity: ValidationSeverity, message: str) -> None:
+        """Emit a message at the level matching a validation severity.
+
+        Everything used to be logged as a warning, which hid ERROR and
+        CRITICAL problems among the merely suboptimal ones.
+
+        Args:
+            severity: Severity to map to a log level.
+            message: Text to log.
+        """
+        if self._logger is None:
+            return
+        if severity is ValidationSeverity.CRITICAL:
+            self._logger.critical(message)
+        elif severity is ValidationSeverity.ERROR:
+            self._logger.error(message)
+        elif severity is ValidationSeverity.WARNING:
+            self._logger.warning(message)
+        else:
+            self._logger.info(message)
+
+
+def _is_assignable(old_value: Any, new_value: Any) -> bool:
+    """Report whether a new value may replace an existing setting.
+
+    Stricter than `isinstance`, which treats `bool` as an `int` and so let
+    `fps_target = True` through, and looser about ints where a float is
+    declared, which is the one widening JSON and Python both expect.
+
+    Args:
+        old_value: The current value, whose type defines what is acceptable.
+        new_value: The candidate value.
+
+    Returns:
+        True if the assignment is type-compatible.
+    """
+    if old_value is None:
+        return True
+    if isinstance(old_value, bool):
+        return isinstance(new_value, bool)
+    if isinstance(old_value, int):
+        return isinstance(new_value, int) and not isinstance(new_value, bool)
+    if isinstance(old_value, float):
+        return isinstance(new_value, (int, float)) and not isinstance(new_value, bool)
+    return isinstance(new_value, type(old_value))

--- a/pyguara/config/types.py
+++ b/pyguara/config/types.py
@@ -1,11 +1,14 @@
 """Configuration data structures."""
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields, is_dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, get_type_hints
 
 from pyguara.common.types import Color
+from pyguara.log import get_logger
 from pyguara.log.types import LogLevel
+
+logger = get_logger(__name__)
 
 
 class RenderingBackend(Enum):
@@ -73,7 +76,22 @@ class PhysicsConfig:
 
     @property
     def fixed_dt(self) -> float:
-        """Get the fixed delta time in seconds."""
+        """The fixed timestep in seconds.
+
+        Returns:
+            Seconds per physics tick, `1 / fixed_timestep_hz`.
+
+        Raises:
+            ValueError: If `fixed_timestep_hz` is not positive. Application.run()
+                reads this on every startup, so a zero from a config file used
+                to surface as a bare ZeroDivisionError with no mention of
+                config.
+        """
+        if self.fixed_timestep_hz <= 0:
+            raise ValueError(
+                f"physics.fixed_timestep_hz must be positive, got "
+                f"{self.fixed_timestep_hz}."
+            )
         return 1.0 / self.fixed_timestep_hz
 
 
@@ -123,57 +141,126 @@ class GameConfig:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "GameConfig":
-        """Create config from dictionary (manual for safety/speed)."""
-        cfg = cls()
+        """Build a config from a decoded JSON document.
 
-        # Display
-        if "display" in data:
-            d = data["display"].copy()
-            # Handle backend enum conversion from string
-            if "backend" in d and isinstance(d["backend"], str):
-                d["backend"] = RenderingBackend(d["backend"])
-            cfg.display = WindowConfig(
-                **{k: v for k, v in d.items() if k in WindowConfig.__annotations__}
+        Unknown keys are ignored and logged rather than raising, so a config
+        written by a newer engine still loads. Nested values are coerced back
+        to their declared types -- `Color` from its dict form, enums from their
+        string or integer value -- which plain construction would not do.
+
+        The input is never mutated.
+
+        Args:
+            data: Decoded configuration document.
+
+        Returns:
+            The populated config. Sections absent from `data` keep their
+            defaults.
+        """
+        config = cls()
+        for section_name in ("display", "audio", "input", "physics", "debug"):
+            section_data = data.get(section_name)
+            if section_data is None:
+                continue
+            current = getattr(config, section_name)
+            setattr(
+                config,
+                section_name,
+                _build_section(type(current), section_data, section_name),
             )
 
-        # Audio
-        if "audio" in data:
-            a = data["audio"]
-            cfg.audio = AudioConfig(
-                **{k: v for k, v in a.items() if k in AudioConfig.__annotations__}
+        version = data.get("version")
+        if isinstance(version, str):
+            config.version = version
+
+        return config
+
+
+def _build_section(
+    section_type: type[Any], data: dict[str, Any], section_name: str
+) -> Any:
+    """Construct one config section, coercing each value to its declared type.
+
+    Args:
+        section_type: The dataclass to build.
+        data: That section's raw values.
+        section_name: Section name, for log messages.
+
+    Returns:
+        The constructed section.
+    """
+    hints = get_type_hints(section_type)
+    known = {f.name for f in fields(section_type)}
+
+    kwargs: dict[str, Any] = {}
+    for key, value in data.items():
+        if key not in known:
+            logger.warning(
+                f"Unknown config key '{section_name}.{key}' ignored. "
+                f"Check for a typo, or a setting from a different engine version."
             )
+            continue
+        kwargs[key] = _coerce(hints[key], value, f"{section_name}.{key}")
 
-        # Input
-        if "input" in data:
-            i = data["input"]
-            cfg.input = InputConfig(
-                **{k: v for k, v in i.items() if k in InputConfig.__annotations__}
-            )
+    return section_type(**kwargs)
 
-        # Physics
-        if "physics" in data:
-            p = data["physics"]
-            cfg.physics = PhysicsConfig(
-                **{k: v for k, v in p.items() if k in PhysicsConfig.__annotations__}
-            )
 
-        # Debug
-        if "debug" in data:
-            d = data["debug"]
-            # Handle Enum conversion manually if needed
-            if "log_level" in d and isinstance(d["log_level"], (str, int)):
-                # If string "DEBUG", convert to LogLevel.DEBUG
-                # If int 10, convert to LogLevel(10)
-                try:
-                    if isinstance(d["log_level"], str):
-                        d["log_level"] = LogLevel[d["log_level"].upper()]
-                    else:
-                        d["log_level"] = LogLevel(d["log_level"])
-                except (KeyError, ValueError):
-                    d["log_level"] = LogLevel.INFO
+def _coerce(target_type: Any, value: Any, label: str) -> Any:
+    """Convert a decoded JSON value to the type a config field declares.
 
-            cfg.debug = DebugConfig(
-                **{k: v for k, v in d.items() if k in DebugConfig.__annotations__}
-            )
+    JSON has no enums and no dataclasses, so a round trip through a file turns
+    `Color` into a dict and `RenderingBackend` into a string. Without this,
+    `default_color` came back as a plain dict and every reader of it broke on
+    attribute access.
 
-        return cfg
+    Args:
+        target_type: The field's declared type.
+        value: The decoded value.
+        label: Dotted field name, for log messages.
+
+    Returns:
+        The coerced value, or the original if no rule applies.
+    """
+    if isinstance(target_type, type):
+        if isinstance(value, target_type) and not isinstance(value, bool):
+            return value
+
+        if is_dataclass(target_type) and isinstance(value, dict):
+            nested = {f.name for f in fields(target_type)}
+            return target_type(**{k: v for k, v in value.items() if k in nested})
+
+        if issubclass(target_type, Enum):
+            return _coerce_enum(target_type, value, label)
+
+    return value
+
+
+def _coerce_enum(enum_type: type[Enum], value: Any, label: str) -> Any:
+    """Resolve an enum from its value, or from its member name.
+
+    Args:
+        enum_type: The enum to resolve into.
+        value: A member value, or a member name such as `"DEBUG"`.
+        label: Dotted field name, for log messages.
+
+    Returns:
+        The matching member, or the enum's engine default when nothing matches.
+    """
+    if isinstance(value, enum_type):
+        return value
+    try:
+        return enum_type(value)
+    except ValueError:
+        pass
+    if isinstance(value, str):
+        try:
+            return enum_type[value.upper()]
+        except KeyError:
+            pass
+
+    fallback = next(iter(enum_type))
+    logger.warning(
+        f"Config value {value!r} is not a valid {enum_type.__name__} for "
+        f"'{label}'; falling back to {fallback.name}."
+    )
+    return fallback

--- a/pyguara/config/validation.py
+++ b/pyguara/config/validation.py
@@ -1,13 +1,32 @@
-"""Configuration validation logic."""
+"""Rules that check a `GameConfig` for values the engine cannot honour."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
 
-from pyguara.config.types import AudioConfig, GameConfig, WindowConfig
+from pyguara.config.types import (
+    AudioConfig,
+    GameConfig,
+    InputConfig,
+    PhysicsConfig,
+    WindowConfig,
+)
+
+MIN_SCREEN_WIDTH = 640
+MIN_SCREEN_HEIGHT = 480
+MIN_COMFORTABLE_FPS = 30
 
 
 class ValidationSeverity(Enum):
-    """Severity levels for validation issues."""
+    """How badly a configuration issue affects the engine.
+
+    Attributes:
+        INFO: Worth knowing; harmless.
+        WARNING: Legal but likely to disappoint, e.g. a very low frame target.
+        ERROR: The engine will misbehave, but can still start.
+        CRITICAL: The engine cannot start with this value.
+    """
 
     INFO = "info"
     WARNING = "warning"
@@ -15,9 +34,17 @@ class ValidationSeverity(Enum):
     CRITICAL = "critical"
 
 
-@dataclass
+@dataclass(frozen=True)
 class ValidationIssue:
-    """Report of a configuration issue."""
+    """One problem found in a configuration.
+
+    Attributes:
+        severity: How badly this affects the engine.
+        section: Config section the setting belongs to.
+        setting: Field name within that section.
+        message: What is wrong.
+        suggestion: What to do about it, when there is an obvious answer.
+    """
 
     severity: ValidationSeverity
     section: str
@@ -27,49 +54,182 @@ class ValidationIssue:
 
 
 class ConfigValidator:
-    """Validates GameConfig state against defined rules."""
+    """Checks a `GameConfig` against the engine's operating limits."""
 
     def validate(self, config: GameConfig) -> list[ValidationIssue]:
-        """Run all validation rules."""
-        issues = []
-        issues.extend(self._validate_display(config.display))
-        issues.extend(self._validate_audio(config.audio))
-        return issues
+        """Run every rule against a configuration.
+
+        Args:
+            config: The configuration to check.
+
+        Returns:
+            Every issue found, in section order. Empty when the config is
+            sound.
+        """
+        return [
+            *self._validate_display(config.display),
+            *self._validate_audio(config.audio),
+            *self._validate_input(config.input),
+            *self._validate_physics(config.physics),
+        ]
+
+    def validate_section(
+        self, config: GameConfig, section: str
+    ) -> list[ValidationIssue]:
+        """Run only the rules belonging to one section.
+
+        Args:
+            config: The configuration to check.
+            section: Section name, e.g. `"audio"`.
+
+        Returns:
+            Issues for that section, or an empty list if it has no rules.
+        """
+        return [issue for issue in self.validate(config) if issue.section == section]
 
     def _validate_display(self, display: WindowConfig) -> list[ValidationIssue]:
-        """Validate display settings."""
+        """Check window and rendering settings.
+
+        Args:
+            display: The display section.
+
+        Returns:
+            Issues found.
+        """
         issues = []
-        if display.screen_width < 640:
+        if display.screen_width < MIN_SCREEN_WIDTH:
             issues.append(
                 ValidationIssue(
                     ValidationSeverity.ERROR,
                     "display",
                     "screen_width",
-                    f"Width {display.screen_width} is too small (min 640).",
+                    f"Width {display.screen_width} is below the {MIN_SCREEN_WIDTH} "
+                    f"minimum.",
+                    f"Use at least {MIN_SCREEN_WIDTH}.",
                 )
             )
-
-        if display.fps_target < 30:
+        if display.screen_height < MIN_SCREEN_HEIGHT:
+            issues.append(
+                ValidationIssue(
+                    ValidationSeverity.ERROR,
+                    "display",
+                    "screen_height",
+                    f"Height {display.screen_height} is below the "
+                    f"{MIN_SCREEN_HEIGHT} minimum.",
+                    f"Use at least {MIN_SCREEN_HEIGHT}.",
+                )
+            )
+        if display.fps_target <= 0:
+            issues.append(
+                ValidationIssue(
+                    ValidationSeverity.CRITICAL,
+                    "display",
+                    "fps_target",
+                    f"FPS target must be positive, got {display.fps_target}.",
+                    "Use 60 unless you have a reason not to.",
+                )
+            )
+        elif display.fps_target < MIN_COMFORTABLE_FPS:
             issues.append(
                 ValidationIssue(
                     ValidationSeverity.WARNING,
                     "display",
                     "fps_target",
-                    "FPS target below 30 may cause poor experience.",
+                    f"FPS target {display.fps_target} is below "
+                    f"{MIN_COMFORTABLE_FPS} and will feel sluggish.",
                 )
             )
         return issues
 
     def _validate_audio(self, audio: AudioConfig) -> list[ValidationIssue]:
-        """Validate audio settings."""
+        """Check that every volume sits within 0.0-1.0.
+
+        Args:
+            audio: The audio section.
+
+        Returns:
+            Issues found.
+        """
+        return [
+            ValidationIssue(
+                ValidationSeverity.ERROR,
+                "audio",
+                name,
+                f"{name} must be between 0.0 and 1.0, got {value}.",
+                "Clamp the value to 0.0-1.0.",
+            )
+            for name, value in (
+                ("master_volume", audio.master_volume),
+                ("sfx_volume", audio.sfx_volume),
+                ("music_volume", audio.music_volume),
+            )
+            if not 0.0 <= value <= 1.0
+        ]
+
+    def _validate_input(self, input_config: InputConfig) -> list[ValidationIssue]:
+        """Check input tuning values.
+
+        Args:
+            input_config: The input section.
+
+        Returns:
+            Issues found.
+        """
         issues = []
-        if not (0.0 <= audio.master_volume <= 1.0):
+        if not 0.0 <= input_config.gamepad_deadzone < 1.0:
             issues.append(
                 ValidationIssue(
                     ValidationSeverity.ERROR,
-                    "audio",
-                    "master_volume",
-                    "Volume must be between 0.0 and 1.0.",
+                    "input",
+                    "gamepad_deadzone",
+                    f"Deadzone must be within [0.0, 1.0), got "
+                    f"{input_config.gamepad_deadzone}. A deadzone of 1.0 or more "
+                    f"ignores the stick entirely.",
+                )
+            )
+        if input_config.mouse_sensitivity <= 0.0:
+            issues.append(
+                ValidationIssue(
+                    ValidationSeverity.ERROR,
+                    "input",
+                    "mouse_sensitivity",
+                    f"Mouse sensitivity must be positive, got "
+                    f"{input_config.mouse_sensitivity}.",
+                )
+            )
+        return issues
+
+    def _validate_physics(self, physics: PhysicsConfig) -> list[ValidationIssue]:
+        """Check the fixed-timestep settings the game loop depends on.
+
+        Args:
+            physics: The physics section.
+
+        Returns:
+            Issues found.
+        """
+        issues = []
+        if physics.fixed_timestep_hz <= 0:
+            issues.append(
+                ValidationIssue(
+                    ValidationSeverity.CRITICAL,
+                    "physics",
+                    "fixed_timestep_hz",
+                    f"Fixed timestep must be positive, got "
+                    f"{physics.fixed_timestep_hz}. Application.run() divides by "
+                    f"it on startup.",
+                    "Use 60, or 120 for higher precision.",
+                )
+            )
+        if physics.max_frame_time <= 0.0:
+            issues.append(
+                ValidationIssue(
+                    ValidationSeverity.ERROR,
+                    "physics",
+                    "max_frame_time",
+                    f"Max frame time must be positive, got "
+                    f"{physics.max_frame_time}; the loop would never step.",
+                    "0.25 is the usual ceiling.",
                 )
             )
         return issues

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,12 @@
 from unittest.mock import mock_open, patch
 
+import pytest
+
+from pyguara.common.types import Color
 from pyguara.config.manager import ConfigManager
+from pyguara.config.types import GameConfig, PhysicsConfig, RenderingBackend
+from pyguara.config.validation import ConfigValidator, ValidationSeverity
+from pyguara.log.types import LogLevel
 
 SAMPLE_CONFIG_JSON = """
 {
@@ -80,3 +86,364 @@ def test_invalid_setting_update():
     assert not manager.update_setting("bad_section", "val", 1)
     # Non-existent setting
     assert not manager.update_setting("display", "bad_setting", 1)
+
+
+# -- Round-tripping through a real file --
+
+
+def test_color_survives_a_save_load_round_trip(tmp_path):
+    """`asdict()` turns Color into a plain dict and from_dict fed it straight
+    back to WindowConfig, so `default_color` came back as a dict and every
+    reader of it broke on attribute access."""
+    path = tmp_path / "game_config.json"
+    writer = ConfigManager(file_path=path)
+    writer.config.display.default_color = Color(10, 20, 30, 40)
+    writer.save()
+
+    reader = ConfigManager(file_path=path)
+    reader.load()
+
+    assert reader.config.display.default_color == Color(10, 20, 30, 40)
+    assert isinstance(reader.config.display.default_color, Color)
+
+
+def test_second_launch_loads_a_usable_default_color(tmp_path):
+    """The failing path was the ordinary one: a first run finds no config file
+    and writes defaults, and the second run reads them back. `default_color`
+    then reached the window backend as a dict."""
+    path = tmp_path / "game_config.json"
+
+    ConfigManager(file_path=path).load()  # first launch writes defaults
+    second = ConfigManager(file_path=path)
+    second.load()
+
+    assert second.config.display.default_color.r == 0
+
+
+def test_enums_survive_a_round_trip(tmp_path):
+    path = tmp_path / "c.json"
+    writer = ConfigManager(file_path=path)
+    writer.config.display.backend = RenderingBackend.MODERNGL
+    writer.config.debug.log_level = LogLevel.DEBUG
+    writer.save()
+
+    reader = ConfigManager(file_path=path)
+    reader.load()
+
+    assert reader.config.display.backend is RenderingBackend.MODERNGL
+    assert reader.config.debug.log_level is LogLevel.DEBUG
+
+
+def test_every_field_survives_a_round_trip(tmp_path):
+    """Guards the whole surface, so a newly added field cannot quietly fail to
+    round-trip the way default_color did."""
+    path = tmp_path / "c.json"
+    original = ConfigManager(file_path=path)
+    original.config.display.screen_width = 1920
+    original.config.audio.sfx_volume = 0.25
+    original.config.input.gamepad_deadzone = 0.4
+    original.config.physics.gravity_y = 900.0
+    original.config.debug.show_fps = True
+    original.save()
+
+    restored = ConfigManager(file_path=path)
+    restored.load()
+
+    assert restored.config == original.config
+
+
+# -- from_dict --
+
+
+def test_from_dict_does_not_mutate_its_input():
+    raw = {"debug": {"log_level": "DEBUG"}}
+
+    GameConfig.from_dict(raw)
+
+    assert raw == {"debug": {"log_level": "DEBUG"}}
+
+
+def test_unknown_keys_are_ignored_and_reported(caplog):
+    """A typo'd key was dropped in silence, so the setting simply never took
+    effect and nothing said why."""
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        config = GameConfig.from_dict(
+            {"display": {"screen_widht": 1920, "fps_target": 144}}
+        )
+
+    assert config.display.screen_width == 1200
+    assert config.display.fps_target == 144
+    assert "screen_widht" in caplog.text
+
+
+def test_absent_sections_keep_their_defaults():
+    config = GameConfig.from_dict({"audio": {"master_volume": 0.5}})
+
+    assert config.audio.master_volume == 0.5
+    assert config.display.screen_width == 1200
+    assert config.physics.fixed_timestep_hz == 60
+
+
+def test_an_unparseable_enum_value_falls_back_and_warns(caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        config = GameConfig.from_dict({"display": {"backend": "vulkan"}})
+
+    assert config.display.backend is RenderingBackend.PYGAME
+    assert "vulkan" in caplog.text
+
+
+def test_log_level_accepts_both_a_name_and_a_number():
+    assert GameConfig.from_dict({"debug": {"log_level": "DEBUG"}}).debug.log_level is (
+        LogLevel.DEBUG
+    )
+    assert GameConfig.from_dict({"debug": {"log_level": 10}}).debug.log_level is (
+        LogLevel.DEBUG
+    )
+
+
+# -- update_setting type enforcement --
+
+
+def test_update_setting_rejects_the_wrong_type():
+    """The old check only warned and then assigned anyway, so screen_width
+    could be left holding the string "not a number"."""
+    manager = ConfigManager()
+
+    assert not manager.update_setting("display", "screen_width", "not a number")
+    assert manager.config.display.screen_width == 1200
+
+
+def test_update_setting_rejects_a_bool_for_an_int_field():
+    """isinstance(True, int) is True, so a bare isinstance check let a bool
+    through into fps_target."""
+    manager = ConfigManager()
+
+    assert not manager.update_setting("display", "fps_target", True)
+    assert manager.config.display.fps_target == 60
+
+
+def test_update_setting_accepts_an_int_where_a_float_is_declared():
+    manager = ConfigManager()
+
+    assert manager.update_setting("audio", "master_volume", 1)
+    assert manager.config.audio.master_volume == 1
+
+
+def test_update_setting_accepts_a_matching_bool():
+    manager = ConfigManager()
+
+    assert manager.update_setting("display", "fullscreen", True)
+    assert manager.config.display.fullscreen is True
+
+
+# -- update_setting validation --
+
+
+def test_update_setting_rejects_a_value_the_validator_refuses():
+    """The validator only ever ran on load, so update_setting could put the
+    config into a state load() would have rejected."""
+    manager = ConfigManager()
+
+    assert not manager.update_setting("audio", "master_volume", 99.0)
+    assert manager.config.audio.master_volume == 1.0
+
+
+def test_a_rejected_update_dispatches_no_event(event_dispatcher):
+    from pyguara.config.events import OnConfigurationChanged
+
+    events = []
+    event_dispatcher.subscribe(OnConfigurationChanged, lambda e: events.append(e))
+    manager = ConfigManager(event_dispatcher=event_dispatcher)
+
+    manager.update_setting("audio", "master_volume", 99.0)
+    manager.update_setting("display", "screen_width", "wide")
+
+    assert events == []
+
+
+def test_update_setting_allows_a_merely_suboptimal_value():
+    """A WARNING is advice, not a veto: a low frame target is legal."""
+    manager = ConfigManager()
+
+    assert manager.update_setting("display", "fps_target", 20)
+    assert manager.config.display.fps_target == 20
+
+
+# -- Validation rules --
+
+
+def test_a_zero_fixed_timestep_is_reported_as_critical():
+    """Application.run() divides by fixed_timestep_hz on startup, and nothing
+    checked it, so a zero in a config file crashed with a bare
+    ZeroDivisionError naming neither the setting nor the file."""
+    config = GameConfig()
+    config.physics.fixed_timestep_hz = 0
+
+    issues = ConfigValidator().validate(config)
+
+    assert any(
+        i.setting == "fixed_timestep_hz" and i.severity is ValidationSeverity.CRITICAL
+        for i in issues
+    )
+
+
+def test_fixed_dt_raises_a_named_error_rather_than_dividing_by_zero():
+    with pytest.raises(ValueError, match="fixed_timestep_hz must be positive"):
+        _ = PhysicsConfig(fixed_timestep_hz=0).fixed_dt
+
+
+def test_all_three_volumes_are_validated():
+    config = GameConfig()
+    config.audio.master_volume = 2.0
+    config.audio.sfx_volume = -1.0
+    config.audio.music_volume = 0.5
+
+    settings = {i.setting for i in ConfigValidator().validate(config)}
+
+    assert settings == {"master_volume", "sfx_volume"}
+
+
+def test_screen_height_and_deadzone_are_validated():
+    config = GameConfig()
+    config.display.screen_height = 10
+    config.input.gamepad_deadzone = 1.5
+
+    settings = {i.setting for i in ConfigValidator().validate(config)}
+
+    assert "screen_height" in settings
+    assert "gamepad_deadzone" in settings
+
+
+def test_a_sound_default_config_produces_no_issues():
+    assert ConfigValidator().validate(GameConfig()) == []
+
+
+# -- Severity reaches the log --
+
+
+def test_load_reports_issues_at_their_own_severity(tmp_path, caplog):
+    """Every issue was logged as a warning, so ERROR and CRITICAL problems sat
+    among the merely suboptimal ones."""
+    import json
+    import logging
+
+    from pyguara.log import get_logger
+
+    path = tmp_path / "bad.json"
+    path.write_text(
+        json.dumps(
+            {"display": {"screen_width": 10}, "physics": {"fixed_timestep_hz": 0}}
+        )
+    )
+
+    with caplog.at_level(logging.WARNING):
+        ConfigManager(logger=get_logger("test.config"), file_path=path).load()
+
+    levels = {r.levelname for r in caplog.records}
+    assert "ERROR" in levels
+    assert "CRITICAL" in levels
+
+
+# -- Environment overrides --
+
+
+def test_env_overrides_are_applied(tmp_path, monkeypatch):
+    import json
+
+    path = tmp_path / "c.json"
+    path.write_text(json.dumps(GameConfig().to_dict()))
+    monkeypatch.setenv("PYGUARA_WINDOW_WIDTH", "1920")
+    monkeypatch.setenv("PYGUARA_BACKEND", "moderngl")
+    monkeypatch.setenv("PYGUARA_LOG_LEVEL", "DEBUG")
+
+    manager = ConfigManager(file_path=path)
+    manager.load()
+
+    assert manager.config.display.screen_width == 1920
+    assert manager.config.display.backend is RenderingBackend.MODERNGL
+    assert manager.config.debug.log_level is LogLevel.DEBUG
+
+
+def test_an_invalid_env_override_is_reported_not_swallowed(
+    tmp_path, monkeypatch, caplog
+):
+    """`except ValueError: pass` meant a typo in a launch script silently did
+    nothing at all."""
+    import json
+    import logging
+
+    from pyguara.log import get_logger
+
+    path = tmp_path / "c.json"
+    path.write_text(json.dumps(GameConfig().to_dict()))
+    monkeypatch.setenv("PYGUARA_WINDOW_WIDTH", "not-an-int")
+
+    with caplog.at_level(logging.WARNING):
+        manager = ConfigManager(logger=get_logger("test.env"), file_path=path)
+        manager.load()
+
+    assert manager.config.display.screen_width == 1200
+    assert "PYGUARA_WINDOW_WIDTH" in caplog.text
+
+
+# -- Events --
+
+
+def test_load_and_save_events_carry_a_real_timestamp(tmp_path, event_dispatcher):
+    """These two events had no __post_init__ at all, so their timestamp was
+    permanently 0.0."""
+    import time
+
+    from pyguara.config.events import OnConfigurationLoaded, OnConfigurationSaved
+
+    seen = []
+    event_dispatcher.subscribe(OnConfigurationLoaded, lambda e: seen.append(e))
+    event_dispatcher.subscribe(OnConfigurationSaved, lambda e: seen.append(e))
+
+    before = time.time()
+    manager = ConfigManager(
+        event_dispatcher=event_dispatcher, file_path=tmp_path / "c.json"
+    )
+    manager.save()
+    manager.load()
+    after = time.time()
+
+    assert len(seen) == 2
+    assert all(before <= e.timestamp <= after for e in seen)
+
+
+# -- load() failure modes --
+
+
+def test_load_returns_false_on_malformed_json(tmp_path):
+    path = tmp_path / "broken.json"
+    path.write_text("{ this is not json")
+
+    manager = ConfigManager(file_path=path)
+
+    assert not manager.load()
+    assert manager.config.display.screen_width == 1200
+
+
+def test_a_failed_load_leaves_the_previous_config_intact(tmp_path):
+    path = tmp_path / "broken.json"
+    path.write_text("{ nope")
+    manager = ConfigManager(file_path=path)
+    manager.update_setting("display", "screen_width", 800)
+
+    manager.load()
+
+    assert manager.config.display.screen_width == 800
+
+
+def test_file_path_is_configurable(tmp_path):
+    path = tmp_path / "nested" / "custom.json"
+    manager = ConfigManager(file_path=path)
+
+    assert manager.file_path == path
+    assert manager.save()
+    assert path.exists()


### PR DESCRIPTION
Sixth subsystem iteration, and the first of Tier 2. Scope is `pyguara/config`.

> Based on `main` this time — the Tier 1 stack is merged, so no stacking.

## 🐞 `Color` did not survive a save/load round trip

`to_dict()` runs `asdict()`, which flattens `Color` into `{"r": …, "g": …}`. `from_dict()` passed that dict straight back to `WindowConfig`, so `display.default_color` came back as a **plain dict**. Both window backends store it and hand it to `clear()`, where `fill_color.r` raises `AttributeError`.

This is not an exotic path. `load()` writes defaults when no config file exists, so the ordinary lifecycle is enough:

```
RUN 1: fresh install, no config file
  file created: True
  default_color: Color(r=0, g=0, b=0, a=255)
RUN 2: same game, second launch
  default_color: {'r': 0, 'g': 0, 'b': 0, 'a': 255}  (dict)
  AttributeError: 'dict' object has no attribute 'r'
```

`from_dict` is now driven by each section's declared field types instead of five near-identical hand-written blocks — which also fixes enums, and means a newly added field round-trips without anyone remembering to wire it.

## 🐞 `fixed_dt` divided by zero, unvalidated

`Application.run()` reads `physics_config.fixed_dt` on **every startup**. Nothing checked `fixed_timestep_hz`, so a `0` in a config file crashed the engine with a bare `ZeroDivisionError` naming neither the setting nor the file. Now a named `ValueError`, and the validator reports it as `CRITICAL`.

## 🐞 `update_setting()` warned, then did it anyway

The type check logged a mismatch and assigned regardless, so `screen_width` could hold `"not a number"`. It also never ran the validator, so `master_volume = 99.0` was accepted silently — a state `load()` would have rejected.

Both now refuse and mutate nothing. The type rule is deliberately stricter than `isinstance` in one place and looser in another:

- a **`bool` is not an `int`** here, though `isinstance(True, int)` is `True` and the old check let `fps_target = True` through;
- an **`int` is accepted for a `float`**, the one widening JSON and Python both expect.

`WARNING`-severity issues still pass — a low frame target is advice, not a veto.

## Six more

`OnConfigurationLoaded`/`OnConfigurationSaved` were permanently stamped `timestamp=0.0` (no `__post_init__` at all, and the manager never passed one). `from_dict` mutated its input. Unknown keys were dropped in silence, so a typo'd setting just never took effect. Invalid env overrides failed silently behind `except ValueError: pass`. Every validation issue was logged as a *warning* regardless of severity, burying `ERROR` and `CRITICAL`. `_file_path` was hardcoded.

Validator coverage went from **3 rules to 10** — screen height, two of the three volumes, deadzone, mouse sensitivity, max frame time and the fixed timestep were all previously unchecked.

## Tests

**5 → 33.** The original five used `mock_open` and patched `Path.exists` throughout and never touched a real file — which is exactly why no round-trip bug could ever surface. The new ones write and read `tmp_path` files, including a whole-config round trip that will catch the next field that fails to survive one.

**1373 pass** (from 1343), ruff clean, mypy clean. Three commits, each verified green in an isolated worktree: 1343 / 1371 / 1373.

## Docs

New `docs/core/configuration.md`. It states what this iteration had to establish by probing: `load()` returning True means the file *parsed*, not that its contents are sane; `update_setting` is the checked path and direct assignment deliberately isn't; and which severities veto a change versus merely advise against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
