### PR TITLE
refactor(application): audit pass — the event budget was spent 15× per frame, shutdown skipped on crash

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -12,7 +12,7 @@ rather than fixed in place.
 
 ## Active Subsystem
 
-`pyguara/config` — **in review (awaiting approval)**
+`pyguara/application` — **in review (awaiting approval)**
 
 ---
 
@@ -28,8 +28,8 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 ### Tier 2 — Core runtime
 - [x] `pyguara/ecs` — Entity, Component, EntityManager, QueryCache *(done)*
-- [x] `pyguara/config` — configuration loading/merging *(active)*
-- [ ] `pyguara/application` — Application loop, bootstrap, sandbox
+- [x] `pyguara/config` — configuration loading/merging *(done)*
+- [x] `pyguara/application` — Application loop, bootstrap, sandbox *(active)*
 - [ ] `pyguara/scene` — Scene base, SceneManager, serializer
 - [ ] `pyguara/systems` — system manager / base systems
 
@@ -59,6 +59,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/config` | 2026-09-06 | Fixed `Color` not surviving a save/load round trip (a second-launch crash), `fixed_dt` dividing by zero unvalidated, and `update_setting` accepting wrong types and out-of-range values. PR #7. |
 | `pyguara/log` | 2026-09-06 | Fixed source attribution (every record reported `logger.py:138`), a `shutdown()` that did not stop logging, handler clobbering on a process-global logger, and a docs page describing a nonexistent API. PR #5. |
 | `pyguara/di` | 2026-09-06 | Fixed a missing lock in `DIScope.get()` that fabricated circular dependencies under concurrency (140/160 resolutions), plus captive lifetimes, dead-scope resolution, silent re-registration and varargs injection. PR #4. |
 | `pyguara/events` | 2026-09-06 | Broke a latent `log` <-> `events` import cycle, fixed a timestamp sentinel that made 0.0 inexpressible, brought filter errors under the error strategy, and memoised handler resolution (5.7us -> 3.1us per dispatch). PR #3. |
@@ -168,6 +169,21 @@ Hoisted to a new top-level `pyguara/errors.py`, which imports nothing from the
 engine and so cannot cycle. `di/types.py` and `events/types.py` re-export it, so
 existing import paths keep working. `di.RAISE == events.RAISE` is now True.
 *Discovered in:* `di`. *Status:* **resolved**.
+
+### CC-11 — pygame reaches into the backend-agnostic core
+CLAUDE.md states the engine is backend-agnostic and that code should never
+import pygame directly, but `Application` uses `pygame.time.Clock` for all
+frame timing, compares against `pygame.QUIT`, calls `pygame.event.pump()` and
+catches `pygame.error`. `SandboxApplication` uses `pygame.K_F1`-style constants
+for its tool hotkeys. The ModernGL path therefore still depends on pygame for
+timing and quit detection.
+Not fixed in the `application` pass because the fix belongs on the other side
+of the boundary: `Window.poll_events()` would have to yield engine events
+rather than raw SDL ones, and a `Clock` protocol would have to join the
+graphics protocols. **Fix:** take it with the `graphics` audit, so the protocol
+and both backends move together. `WindowResizeEvent` is defined and never
+dispatched for the same reason -- nothing detects the resize.
+*Discovered in:* `application`. *Status:* parked until `graphics`.
 
 ### CC-8 — Package `__init__.py` files export nothing
 Most subsystem packages have a docstring-only `__init__.py`, so callers reach
@@ -492,7 +508,7 @@ misspelled. Renaming it means touching the mkdocs nav and any inbound links, so
 it is left for whoever next edits that file.
 
 
-### `pyguara/config` — awaiting approval (2026-09-06)
+### `pyguara/config` — CLOSED 2026-09-06 (PR #7, branch `refactor/config-audit`)
 
 **Verification:** 1371/1371 tests pass (up from 1343); ruff clean; mypy clean.
 
@@ -549,3 +565,49 @@ will catch the next field that fails to survive one.
 `application.md`'s config paragraph now links to it.
 
 **Deferred:** CC-3 through CC-8 (CC-1, CC-2, CC-9, CC-10 resolved).
+
+
+### `pyguara/application` — awaiting approval (2026-09-06)
+
+**Verification:** 1384/1384 tests pass (up from 1373); ruff clean; mypy clean.
+
+**Correctness fixes (all reproduced by probe before fixing):**
+- **The event-queue time budget was spent per fixed step, not per frame.**
+  `_fixed_update()` drained the queue, and it runs once per accumulated step,
+  so a frame lagging by the full `max_frame_time` called `process_queue(
+  max_time_ms=5)` **15 times** -- up to 75ms in one frame. The budget exists
+  specifically to stop an event death spiral, and it was multiplied by the step
+  count at exactly the moment a spiral begins. Drained once per frame now.
+- **`shutdown()` was neither idempotent nor exception-safe.** A raising
+  `scene_manager.cleanup()` meant the window was never closed and the log
+  manager never shut down -- on the crash path, where releasing them matters
+  most. Steps are isolated and logged now, and a second call is a no-op.
+- **The ModernGL render path hardcoded `Color(0, 0, 0, 255)`**, so
+  `display.default_color` silently did nothing under that backend while the
+  pygame path honoured it via `window.clear()`.
+- **Three lifecycle events had no publisher.** `ApplicationStartEvent` and
+  `QuitEvent` are now dispatched; `pyguara/tools/event_monitor.py` subscribes
+  to `QuitEvent`, so its handler had been unreachable. `WindowResizeEvent`
+  still has none -- see CC-11.
+- **`ServiceNotFoundException` was imported inside the `try` block whose
+  `except` names it**, so an ImportError there would have raised NameError
+  instead of being handled.
+- `raise e` in the loop's handler appended a frame to the traceback; now a bare
+  `raise`.
+
+**Tests:** 2 -> 13 in `test_app_flow.py`. The existing two covered a single
+frame and a scene switch; nothing covered shutdown, lifecycle events, the event
+budget, or the failure paths.
+
+**Docs:** `docs/core/application.md` rewritten. Its "Main Loop" section listed
+`Time.tick()`, `Input.process()`, `Update()`, `Render()` -- none of which are
+real method names -- so it described the loop's shape without matching the
+code. Now documents the actual sequence, why frame time is clamped, and why the
+event queue is drained outside the accumulator loop.
+
+**Parked:** CC-11 (pygame in the backend-agnostic core). `bootstrap.py` and
+`sandbox.py` were scanned and are otherwise clean; their `# type: ignore[
+type-abstract]` markers are the known mypy limitation around Protocol
+registration, not defects.
+
+**Deferred:** CC-3 through CC-8, CC-11.

--- a/docs/core/application.md
+++ b/docs/core/application.md
@@ -1,28 +1,99 @@
 # Application Lifecycle
 
-The `pyguara.application` package manages the main game loop, initialization, and shutdown sequences.
+`pyguara.application` owns the game loop, the composition root that wires
+everything together, and the shutdown sequence.
 
-## The Application Class
+## The loop
 
-The `Application` class (`pyguara/application/application.py`) is the runtime coordinator. It is responsible for:
+`Application.run()` drives a **fixed-timestep loop with an accumulator**, so
+physics behaves identically whatever the display framerate:
 
-1.  **Dependency Resolution**: Retrieving core systems (Window, Input, SceneManager) from the DI Container.
-2.  **Main Loop**:
-    - `Time.tick()`
-    - `Input.process()`
-    - `Update()` (Logic & Physics)
-    - `Render()`
+```
+per frame:
+  1. measure frame time, clamped to physics.max_frame_time
+  2. poll input and system events
+  3. drain the queued-event backlog  (once, under a time budget)
+  4. while accumulator >= fixed_dt:  _fixed_update(fixed_dt)
+  5. _update(frame_time)
+  6. _render()
+```
+
+**`_fixed_update(fixed_dt)`** may run several times in one frame, or none at
+all. Anything that must be reproducible belongs here: physics, AI decisions,
+collision response.
+
+**`_update(dt)`** runs exactly once per frame, at display rate. Anything that
+should look smooth belongs here: UI, tweens, particles, camera smoothing,
+coroutines.
+
+**`_render()`** computes `alpha` — how far the frame sits between the last two
+fixed steps — and hands it to the scene so `Transform.interpolate` entities do
+not visibly move at the physics rate.
+
+### Why the frame time is clamped
+
+`physics.max_frame_time` (0.25s by default) bounds how much backlog one frame
+can add. Without it, a frame that takes longer than the work it schedules
+compounds into an ever-growing queue of fixed updates — the "spiral of death".
+At 60 Hz the clamp caps a single frame at 15 fixed steps.
+
+### Why the event queue is drained outside that loop
+
+Queued events are drained **once per frame**, before the fixed updates that
+consume them, under `event_queue_time_budget_ms` (5ms by default).
+
+Draining inside the accumulator loop would multiply the budget by the step
+count — a frame lagging by the full `max_frame_time` would spend 15× the
+budget, at exactly the moment a spiral is beginning. The budget exists to
+prevent that, so it is spent per frame.
+
+## Lifecycle events
+
+```python
+from pyguara.events.lifecycle import ApplicationStartEvent, QuitEvent
+
+dispatcher.subscribe(ApplicationStartEvent, on_start)
+dispatcher.subscribe(QuitEvent, save_before_exit)
+```
+
+`ApplicationStartEvent` fires once, after the starting scene is active and
+before the first frame. `QuitEvent` fires when the window reports a close
+request, before `shutdown()` runs, so handlers can still touch live state.
+
+## Shutdown
+
+`run()` always calls `shutdown()` on the way out — normal exit, `KeyboardInterrupt`,
+or an uncaught exception alike. It is idempotent, so calling it yourself
+afterwards is harmless.
+
+Each teardown step is isolated: scene cleanup, render-graph release and window
+close each run even if an earlier one raised, and a failure is logged rather
+than swallowed. The log manager is shut down last, since everything above
+reports through it.
 
 ## Bootstrapping
 
-The entry point is managed by `create_application()` in `bootstrap.py`. This implementation of the **Composition Root** pattern ensures that all dependencies are wired *before* the game starts.
+`bootstrap.py` is the **composition root**: every service is registered and
+wired before the game starts.
 
 ```python
-def create_application() -> Application:
-    container = DIContainer()
-    # ... register services ...
-    return Application(container)
+from pyguara.application.bootstrap import create_application
+
+app = create_application()
+app.run(MyScene("game", dispatcher))
 ```
+
+| Entry point | Backend |
+| --- | --- |
+| `create_application()` | The configured backend — pygame or ModernGL |
+| `create_sandbox_application()` | Same, plus the developer tool overlays |
+| `create_headless_application()` | No SDL video at all; for tests |
+| `create_headless_sandbox_application()` | Headless, plus tools |
+
+The headless entry points are **test-only**. They swap the
+window/renderer/UI-renderer/texture-factory quartet for no-op equivalents so
+the suite can boot a real `Application` without a display; everything else
+wires up identically.
 
 ## Configuration
 

--- a/pyguara/application/application.py
+++ b/pyguara/application/application.py
@@ -9,13 +9,16 @@ regardless of frame rate variations.
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import pygame
 
 from pyguara.config.manager import ConfigManager
 from pyguara.di.container import DIContainer
+from pyguara.di.exceptions import ServiceNotFoundException
 from pyguara.events.dispatcher import EventDispatcher
+from pyguara.events.lifecycle import ApplicationStartEvent, QuitEvent
 from pyguara.graphics.protocols import IRenderer, UIRenderer
 from pyguara.graphics.window import Window
 from pyguara.input.manager import InputManager
@@ -59,6 +62,7 @@ class Application:
         """
         self._container = container
         self._is_running = False
+        self._has_shut_down = False
         self._event_queue_time_budget_ms = event_queue_time_budget_ms
 
         # Resolve Core Dependencies
@@ -85,13 +89,16 @@ class Application:
         # backend identity (isinstance) rather than mere resolvability.
         self._render_graph: RenderGraph | None = None
         try:
-            from pyguara.di.exceptions import ServiceNotFoundException
+            # Imported here, not at module scope, because the ModernGL pipeline
+            # is an optional dependency. ServiceNotFoundException is imported
+            # above: naming it in the `except` while importing it inside the
+            # `try` meant an ImportError here would raise NameError instead.
             from pyguara.graphics.pipeline.graph import RenderGraph
 
             candidate = container.get(RenderGraph)
             if isinstance(candidate, RenderGraph):
                 self._render_graph = candidate
-        except (ImportError, KeyError, ServiceNotFoundException):
+        except (ImportError, ServiceNotFoundException):
             pass  # Render graph not available (Pygame backend or tests)
 
         self._scene_manager.set_container(container)
@@ -113,15 +120,22 @@ class Application:
         self.logger.info("Application instance created.")
 
     def run(self, starting_scene: Scene) -> None:
-        """Execute the main game loop with fixed timestep physics.
+        """Execute the main game loop with a fixed timestep, until the window closes.
 
-        The loop uses the accumulator pattern:
-        1. Measure frame time (variable)
-        2. Accumulate time for physics
-        3. Run physics updates at fixed rate (e.g., 60 Hz)
-        4. Render at display framerate
+        Each frame measures its own duration, clamps it to
+        `physics.max_frame_time`, accumulates it, and runs as many fixed-rate
+        updates as that buys before rendering once. Physics therefore behaves
+        identically regardless of display framerate.
 
-        This ensures deterministic physics regardless of display framerate.
+        Dispatches `ApplicationStartEvent` before the first frame, and always
+        calls `shutdown()` on the way out.
+
+        Args:
+            starting_scene: Scene to register and activate before the loop.
+
+        Raises:
+            ValueError: If `physics.fixed_timestep_hz` is not positive.
+            Exception: Anything raised inside the loop, after logging it.
         """
         self.logger.info(f"Starting with scene: {starting_scene.name}")
 
@@ -136,8 +150,11 @@ class Application:
         max_frame_time = physics_config.max_frame_time
 
         self.logger.debug(
-            f"Game loop: target_fps={target_fps}, physics_hz={physics_config.fixed_timestep_hz}, fixed_dt={fixed_dt}"
+            f"Game loop: target_fps={target_fps}, "
+            f"physics_hz={physics_config.fixed_timestep_hz}, fixed_dt={fixed_dt}"
         )
+
+        self._event_dispatcher.dispatch(ApplicationStartEvent(source=self))
 
         # Force an initial event pump to show the window immediately. No-op
         # (raises pygame.error) under a backend that never initializes SDL's
@@ -163,7 +180,17 @@ class Application:
                 self._input_manager.update()
                 self._process_input(frame_time)
 
-                # 3. Accumulate time and run fixed updates
+                # 3. Drain queued events once per frame, before the fixed
+                # updates that consume them. Not inside the accumulator loop:
+                # the time budget exists to stop an event death spiral, and a
+                # per-step budget multiplies by the step count, so a lagged
+                # frame could spend 15x the budget at exactly the moment the
+                # spiral is starting.
+                self._event_dispatcher.process_queue(
+                    max_time_ms=self._event_queue_time_budget_ms
+                )
+
+                # 4. Accumulate time and run fixed updates
                 self._accumulator += frame_time
 
                 while self._accumulator >= fixed_dt:
@@ -171,21 +198,23 @@ class Application:
                     self._fixed_update(fixed_dt)
                     self._accumulator -= fixed_dt
 
-                # 4. Variable-rate update (UI, animations that should be smooth)
+                # 5. Variable-rate update (UI, animations that should be smooth)
                 self._update(frame_time)
 
-                # 5. Render (at display framerate)
-                # The alpha value represents how far we are between physics steps
-                # This can be used for interpolation in the future
-                # alpha = self._accumulator / fixed_dt
+                # 6. Render at display framerate, interpolating between the
+                # last two fixed steps.
                 self._render()
         except KeyboardInterrupt:
             # Handle Ctrl+C gracefully
             self.logger.info("KeyboardInterrupt received. Stopping.")
-        except Exception as e:
-            # Log unexpected crashes before shutting down
-            self.logger.critical(f"Uncaught exception in game loop: {e}", exc_info=True)
-            raise e  # Re-raise to show traceback
+        except Exception as error:
+            # Log unexpected crashes before shutting down. Bare `raise` rather
+            # than `raise error`, which would append this frame to the
+            # traceback and obscure the original site.
+            self.logger.critical(
+                f"Uncaught exception in game loop: {error}", exc_info=True
+            )
+            raise
         finally:
             # CRITICAL: This ensures cleanup happens even if sys.exit() is called
             self.shutdown()
@@ -295,13 +324,23 @@ class Application:
                 self._replay_player = None
 
     def _process_input(self, frame_time: float) -> None:
-        """Poll system events, or feed replayed ones when a replay is active."""
+        """Poll system events, or feed replayed ones when a replay is active.
+
+        Args:
+            frame_time: This frame's duration in seconds, recorded alongside
+                the events when a replay is being captured.
+        """
         self._begin_replay_frame(frame_time)
 
         # This call is CRITICAL. It keeps the OS window responsive.
         for event in self._window.poll_events():
             if hasattr(event, "type") and event.type == pygame.QUIT:
                 self._is_running = False
+                # Publish the close request so game code and tools can react
+                # before shutdown() runs. QuitEvent had no publisher at all,
+                # which left tools/event_monitor.py subscribed to something
+                # that could never fire.
+                self._event_dispatcher.dispatch(QuitEvent(source=self))
 
             # While a replay drives the game, real input is swallowed rather
             # than dispatched, so both runs see exactly the same events.
@@ -311,41 +350,28 @@ class Application:
         self._end_replay_frame(frame_time)
 
     def _fixed_update(self, fixed_dt: float) -> None:
-        """Fixed-rate update for physics and deterministic game logic.
+        """Advance physics and deterministic game logic by one fixed step.
 
-        This method runs at a fixed rate (default 60 Hz) regardless of display
-        framerate. Use this for:
-        - Physics simulation
-        - Game logic that must be deterministic
-        - AI decision making
-        - Collision detection
+        May run several times in one frame, or none at all, depending on how
+        much time the accumulator holds. Anything that must be reproducible --
+        physics, AI decisions, collision response -- belongs here rather than
+        in `_update()`.
 
         Args:
-            fixed_dt: Fixed delta time in seconds (e.g., 1/60 for 60 Hz).
+            fixed_dt: Fixed delta time in seconds, e.g. 1/60.
         """
-        # 1. Process background thread events with time budget (P1-009)
-        # Enforce time budget to prevent event death spirals
-        self._event_dispatcher.process_queue(
-            max_time_ms=self._event_queue_time_budget_ms
-        )
-
-        # 2. Update each active scene's own SystemManager (Steering, AI,
-        # AudioSource, Animation) and scene logic at fixed rate. There's no
-        # global SystemManager: each scene owns and ticks its own.
+        # Each scene owns and ticks its own SystemManager (Steering, AI,
+        # AudioSource, Animation); there is no global one.
         self._scene_manager.fixed_update(fixed_dt)
 
     def _update(self, dt: float) -> None:
-        """Variable-rate update for UI and smooth animations.
+        """Advance everything that should track display framerate, once a frame.
 
-        This method runs once per frame at display framerate. Use this for:
-        - UI updates
-        - Smooth visual animations (tweens, particles)
-        - Camera smoothing
-        - Audio updates
-        - Coroutine-based scripting
+        UI, tweens, particles, camera smoothing and coroutines belong here:
+        they should look smooth rather than be reproducible.
 
         Args:
-            dt: Variable delta time in seconds (frame time).
+            dt: This frame's duration in seconds.
         """
         # Update UI at display framerate for smooth interactions
         self._ui_manager.update(dt)
@@ -357,12 +383,11 @@ class Application:
         self._scene_manager.update(dt)
 
     def _render(self) -> None:
-        """Render frame.
+        """Draw one frame through whichever pipeline the backend provides.
 
-        Uses the render graph pipeline if available (ModernGL), otherwise
-        falls back to direct rendering (Pygame). Computes `alpha` -- how far
-        the current frame sits between the last two fixed steps -- for
-        `Transform.interpolate` entities.
+        Computes `alpha` -- how far this frame sits between the last two fixed
+        steps -- which `Transform.interpolate` entities use to avoid looking
+        like they move at the physics rate.
         """
         alpha = self._accumulator / self._fixed_dt if self._fixed_dt > 0 else 0.0
 
@@ -372,7 +397,11 @@ class Application:
             self._render_direct(alpha)
 
     def _render_direct(self, alpha: float) -> None:
-        """Direct rendering path (Pygame backend)."""
+        """Draw straight to the window, for backends with no render graph.
+
+        Args:
+            alpha: Interpolation factor between the last two fixed steps.
+        """
         self._window.clear()
         self._scene_manager.render(self._world_renderer, self._ui_renderer, alpha)
         self._ui_manager.render(self._ui_renderer)
@@ -380,22 +409,23 @@ class Application:
         self._window.present()
 
     def _render_with_graph(self, alpha: float) -> None:
-        """Multi-pass rendering path using RenderGraph (ModernGL backend).
+        """Draw through the multi-pass render graph (ModernGL backend).
 
-        Pipeline:
-        1. Render world to FBO (scene content)
-        2. Final pass blits to screen
-        3. UI overlay
+        The world is drawn into an offscreen buffer, the final pass blits it to
+        the screen, and UI is drawn on top.
+
+        Args:
+            alpha: Interpolation factor between the last two fixed steps.
         """
         if self._render_graph is None:
             return
 
-        from pyguara.common.types import Color
-
-        # Get the world FBO and bind it for scene rendering
+        # Honour the configured clear colour, as the direct path does through
+        # window.clear(). This used to be a hardcoded black, so
+        # display.default_color silently did nothing under ModernGL.
         world_fbo = self._render_graph.fbo_manager.get_or_create("world")
         world_fbo.bind()
-        world_fbo.clear(Color(0, 0, 0, 255))  # Black background
+        world_fbo.clear(self._config_manager.config.display.default_color)
 
         # Render scenes to the world FBO
         self._scene_manager.render(self._world_renderer, self._ui_renderer, alpha)
@@ -413,13 +443,34 @@ class Application:
         self._window.present()
 
     def shutdown(self) -> None:
-        """Close Application."""
+        """Release every resource the application owns.
+
+        Called automatically when `run()` returns, including on the exception
+        path, and safe to call again afterwards.
+
+        Each step is isolated: a failure in one is logged and the rest still
+        run. Previously a raising `scene_manager.cleanup()` left the window
+        open and the log manager running, which is precisely the situation --
+        a crash -- where releasing them matters most.
+        """
+        if self._has_shut_down:
+            return
+        self._has_shut_down = True
+
         self.logger.info("Shutting down application")
-        self._scene_manager.cleanup()
 
-        # Release render graph resources (ModernGL only)
+        steps: list[tuple[str, Callable[[], None]]] = [
+            ("scene cleanup", self._scene_manager.cleanup),
+            ("window close", self._window.close),
+        ]
         if self._render_graph is not None:
-            self._render_graph.release()
+            steps.insert(1, ("render graph release", self._render_graph.release))
 
-        self._window.close()
+        for name, step in steps:
+            try:
+                step()
+            except Exception:
+                self.logger.error(f"Error during {name}; continuing.", exc_info=True)
+
+        # Last: it owns the logger everything above reports through.
         self._log_manager.shutdown()

--- a/tests/integration/test_app_flow.py
+++ b/tests/integration/test_app_flow.py
@@ -151,3 +151,188 @@ def test_scene_switching_integration(app_container: DIContainer) -> None:
     sm.switch_to("B")
     assert sm._current_scene == scene_b
     assert scene_b.enter_called
+
+
+# -- Event queue budget --
+
+
+def test_the_event_queue_is_drained_once_per_frame(app_container: DIContainer) -> None:
+    """The budget exists to stop an event death spiral, but draining inside the
+    accumulator loop multiplied it by the step count -- a frame lagging by the
+    full max_frame_time spent 15x the budget, at exactly the moment a spiral is
+    starting.
+    """
+    dispatcher = app_container.get(EventDispatcher)
+    budgets: list[float | None] = []
+    dispatcher.process_queue = lambda **kw: (  # type: ignore[method-assign]
+        budgets.append(kw.get("max_time_ms")) or 0
+    )
+
+    app = Application(app_container)
+    fixed_dt = 1.0 / 60.0
+    app._accumulator = 0.25  # a full max_frame_time of backlog
+
+    while app._accumulator >= fixed_dt:
+        app._fixed_update(fixed_dt)
+        app._accumulator -= fixed_dt
+
+    assert budgets == [], "fixed_update must not drain the queue"
+
+
+def test_a_single_frame_drains_the_queue_exactly_once(
+    app_container: DIContainer,
+) -> None:
+    dispatcher = app_container.get(EventDispatcher)
+    calls: list[int] = []
+    dispatcher.process_queue = lambda **kw: calls.append(1) or 0  # type: ignore[method-assign]
+
+    window = app_container.get(Window)
+    frames = [True, False]
+    type(window).is_open = property(lambda self: frames.pop(0) if frames else False)
+    window.poll_events.return_value = []
+
+    app = Application(app_container)
+    app.run(MockScene("s", dispatcher))
+
+    assert len(calls) == 1
+    del type(window).is_open
+
+
+# -- Shutdown --
+
+
+def test_shutdown_is_idempotent(app_container: DIContainer) -> None:
+    app = Application(app_container)
+    window = app_container.get(Window)
+
+    app.shutdown()
+    app.shutdown()
+
+    assert window.close.call_count == 1
+
+
+def test_shutdown_closes_the_window_even_if_scene_cleanup_raises(
+    app_container: DIContainer,
+) -> None:
+    """A crash is exactly when releasing the window and log handlers matters
+    most, and it was exactly when they were skipped."""
+    app = Application(app_container)
+    window = app_container.get(Window)
+    app._scene_manager.cleanup = MagicMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("scene cleanup failed")
+    )
+
+    app.shutdown()
+
+    assert window.close.called
+
+
+def test_shutdown_logs_a_failing_step(app_container: DIContainer, caplog) -> None:
+    import logging
+
+    app = Application(app_container)
+    app._scene_manager.cleanup = MagicMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("scene cleanup failed")
+    )
+
+    with caplog.at_level(logging.ERROR):
+        app.shutdown()
+
+    assert "scene cleanup" in caplog.text
+
+
+def test_run_shuts_down_even_when_the_loop_raises(app_container: DIContainer) -> None:
+    window = app_container.get(Window)
+    window.poll_events.side_effect = RuntimeError("loop exploded")
+
+    app = Application(app_container)
+    with pytest.raises(RuntimeError, match="loop exploded"):
+        app.run(MockScene("s", app_container.get(EventDispatcher)))
+
+    assert window.close.called
+
+
+# -- Lifecycle events --
+
+
+def test_application_start_event_is_dispatched(app_container: DIContainer) -> None:
+    """ApplicationStartEvent was defined and never published by anything."""
+    from pyguara.events.lifecycle import ApplicationStartEvent
+
+    dispatcher = app_container.get(EventDispatcher)
+    seen = []
+    dispatcher.subscribe(ApplicationStartEvent, lambda e: seen.append(e))
+
+    window = app_container.get(Window)
+    type(window).is_open = property(lambda self: False)
+
+    Application(app_container).run(MockScene("s", dispatcher))
+
+    assert len(seen) == 1
+    del type(window).is_open
+
+
+def test_quit_event_is_dispatched_when_the_window_closes(
+    app_container: DIContainer,
+) -> None:
+    """QuitEvent had no publisher, so tools/event_monitor.py was subscribed to
+    something that could never fire."""
+    import pygame
+
+    from pyguara.events.lifecycle import QuitEvent
+
+    dispatcher = app_container.get(EventDispatcher)
+    seen = []
+    dispatcher.subscribe(QuitEvent, lambda e: seen.append(e))
+
+    quit_event = MagicMock()
+    quit_event.type = pygame.QUIT
+    window = app_container.get(Window)
+    window.poll_events.return_value = [quit_event]
+
+    app = Application(app_container)
+    app.run(MockScene("s", dispatcher))
+
+    assert len(seen) == 1
+    assert seen[0].source is app
+
+
+def test_a_quit_event_stops_the_loop(app_container: DIContainer) -> None:
+    import pygame
+
+    quit_event = MagicMock()
+    quit_event.type = pygame.QUIT
+    window = app_container.get(Window)
+    window.poll_events.return_value = [quit_event]
+
+    app = Application(app_container)
+    app.run(MockScene("s", app_container.get(EventDispatcher)))
+
+    assert not app._is_running
+
+
+# -- Fixed timestep --
+
+
+def test_a_non_positive_fixed_timestep_is_reported_against_the_setting(
+    app_container: DIContainer,
+) -> None:
+    """Application.run() reads fixed_dt on every startup; a zero in a config
+    file used to surface as a bare ZeroDivisionError naming neither the setting
+    nor the file."""
+    app_container.get(ConfigManager).config.physics.fixed_timestep_hz = 0
+
+    app = Application(app_container)
+    with pytest.raises(ValueError, match="fixed_timestep_hz must be positive"):
+        app.run(MockScene("s", app_container.get(EventDispatcher)))
+
+
+def test_frame_time_is_clamped_so_the_step_count_stays_bounded(
+    app_container: DIContainer,
+) -> None:
+    """max_frame_time is what stops a lag spike turning into an unbounded run
+    of fixed updates."""
+    config = app_container.get(ConfigManager).config
+    steps = int(config.physics.max_frame_time / config.physics.fixed_dt)
+
+    assert steps == 15


### PR DESCRIPTION
Seventh subsystem iteration. Scope is `pyguara/application` — the runtime loop, bootstrap and sandbox.

> **Stacked on #7** (one deep). `application` reads `physics.fixed_dt`, whose contract #7 changed, so the two belong together. Tick *Delete branch* when merging #7 and this retargets to `main` on its own.

## 🐞 The event-queue budget was spent per fixed step, not per frame

`_fixed_update()` drained the queue — and it runs once per accumulated step. A frame lagging by the full `max_frame_time`:

```
one lagged frame -> process_queue called 15 times
budget per call: 5.0 ms  => up to 75.0 ms in a single frame
```

The budget exists *specifically* to stop an event death spiral, and it was being multiplied by the step count at exactly the moment a spiral begins. The worse the lag, the more budget it granted. Now drained once per frame, before the fixed updates that consume it.

## 🐞 `shutdown()` skipped everything after the first failure

```
scene cleanup raised; window closed: False
-> the window and log manager are never torn down
```

A raising `scene_manager.cleanup()` left the window open and the log manager running — on the **crash path**, which is precisely when releasing them matters. It also wasn't idempotent: `run()`'s `finally` plus a manual call closed the window twice.

Steps are now isolated and individually logged, and a second call is a no-op.

## 🐞 Three lifecycle events had no publisher

`ApplicationStartEvent`, `QuitEvent` and `WindowResizeEvent` were all defined and never dispatched by anything. `pyguara/tools/event_monitor.py` **subscribes to `QuitEvent`** — that handler could never fire.

The first two are now dispatched (`QuitEvent` before `shutdown()`, so handlers still see live state). `WindowResizeEvent` still isn't: nothing detects a resize, which needs a `Window` protocol change — see CC-11.

## Two more

The ModernGL path cleared its framebuffer to a hardcoded `Color(0, 0, 0, 255)`, so `display.default_color` silently did nothing on that backend while pygame honoured it. And `ServiceNotFoundException` was imported *inside* the `try` block whose `except` clause names it — an `ImportError` there would have raised `NameError` instead of being handled.

## 🅿️ Parked: CC-11 — pygame in the backend-agnostic core

CLAUDE.md says the engine is backend-agnostic and code should never import pygame directly. `Application` uses `pygame.time.Clock` for **all** frame timing, compares against `pygame.QUIT`, calls `pygame.event.pump()` and catches `pygame.error`; `SandboxApplication` uses `pygame.K_F1`-style constants. So the ModernGL path depends on pygame for timing and quit detection.

I did **not** fix this here, deliberately: the fix belongs on the other side of the boundary — `poll_events()` yielding engine events rather than raw SDL ones, and a `Clock` protocol joining the graphics protocols. Doing it from this side would mean guessing at an interface the graphics audit should design. Parked to move with that pass, along with the missing `WindowResizeEvent` publisher.

## Tests

**2 → 13** in `test_app_flow.py`. The existing two covered one frame and a scene switch; shutdown, lifecycle events, the event budget and every failure path were untested.

**1384 pass** (from 1373), ruff clean, mypy clean. Two commits, both verified green in an isolated worktree.

## Docs

`docs/core/application.md` described the loop as `Time.tick()`, `Input.process()`, `Update()`, `Render()` — none of which are real method names. It conveyed the shape of *a* loop without matching this one. Rewritten against the real sequence, plus the two things worth knowing that weren't written down anywhere: why frame time is clamped, and why the event queue is drained outside the accumulator loop.

`bootstrap.py` and `sandbox.py` were scanned and are otherwise clean — their `type-abstract` ignores are the known mypy limitation around Protocol registration, not defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
