### PR TITLE
refactor(systems): audit pass — every game system started up uninitialised

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -12,7 +12,9 @@ rather than fixed in place.
 
 ## Active Subsystem
 
-`pyguara/scene` — **in review (awaiting approval)**
+`pyguara/systems` — **in review (awaiting approval)**
+
+**Tier 2 completes with this iteration.**
 
 ---
 
@@ -30,8 +32,8 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 - [x] `pyguara/ecs` — Entity, Component, EntityManager, QueryCache *(done)*
 - [x] `pyguara/config` — configuration loading/merging *(done)*
 - [x] `pyguara/application` — Application loop, bootstrap, sandbox *(done)*
-- [x] `pyguara/scene` — Scene base, SceneManager, serializer *(active)*
-- [ ] `pyguara/systems` — system manager / base systems
+- [x] `pyguara/scene` — Scene base, SceneManager, serializer *(done)*
+- [x] `pyguara/systems` — system manager / base systems *(active)*
 
 ### Tier 3 — Subsystems
 - [ ] `pyguara/graphics` — protocols, backends, window, batching
@@ -59,6 +61,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/scene` | 2026-09-06 | Fixed `switch_to()` abandoning every stacked scene, unguarded re-entrancy during transitions, and a `pop_scene()` that stranded the scene it returned to. PR #10. |
 | `pyguara/application` | 2026-09-06 | Fixed an event budget spent per fixed step (15x per lagged frame), a `shutdown()` that skipped everything after the first failure, and three lifecycle events with no publisher. PR #8. |
 | `pyguara/config` | 2026-09-06 | Fixed `Color` not surviving a save/load round trip (a second-launch crash), `fixed_dt` dividing by zero unvalidated, and `update_setting` accepting wrong types and out-of-range values. PR #7. |
 | `pyguara/log` | 2026-09-06 | Fixed source attribution (every record reported `logger.py:138`), a `shutdown()` that did not stop logging, handler clobbering on a process-global logger, and a docs page describing a nonexistent API. PR #5. |
@@ -615,7 +618,7 @@ registration, not defects.
 **Deferred:** CC-3 through CC-8, CC-11.
 
 
-### `pyguara/scene` — awaiting approval (2026-09-06)
+### `pyguara/scene` — CLOSED 2026-09-06 (PR #10, branch `refactor/scene-audit`)
 
 **Verification:** 1399/1399 tests pass (up from 1384); ruff clean; mypy clean.
 
@@ -663,3 +666,55 @@ dedicated page; `pause_below` semantics, the switch-versus-push lifetime
 difference and the one-transition-at-a-time rule were undocumented.
 
 **Deferred:** CC-3 through CC-8, CC-11 (now GitHub issue #9).
+
+
+### `pyguara/systems` — awaiting approval (2026-09-06)
+
+**Verification:** 1414/1414 tests pass (up from 1401); ruff clean; mypy clean.
+
+The smallest subsystem so far (165 lines of manager, 63 of protocols) with the
+best existing test ratio. Three real defects nonetheless.
+
+**Correctness fixes (all reproduced by probe before fixing):**
+- **A system registered after `initialize()` was never initialised.**
+  `initialize()` sets a flag and returns early on every later call, and
+  `Scene.resolve_dependencies()` calls it *before* `on_enter()` -- which is
+  precisely where a game is documented to register its own systems (priority
+  >=500). Every game system therefore started up uninitialised. A late
+  registration now initialises immediately.
+- **`unregister()` tested truthiness, not `None`.** A system defining
+  `__len__` or `__bool__` falsily was dropped from the lookup table but left
+  in the update list: still ticking every frame, never cleaned up, and
+  returned as though removed.
+- **Duplicate registration keys were silent.** Several systems can share a key
+  -- they all update -- but the lookup table holds one entry per key, so the
+  earlier ones become unreachable by `get_system()` and survive
+  `unregister()`. Now logged, with the fix (`system_type=`) named in the
+  message.
+
+**A design choice I reversed mid-iteration.** My first fix made duplicate
+registration *evict* the earlier system, on the reasoning that an unreachable
+system still consuming a frame budget is a leak. Three existing tests failed:
+they register several `MockSystem`/`OrderedSystem` instances under one class
+and expect all of them to update. That is a legitimate pattern -- multiple
+instances of one generic system -- and eviction destroyed it. The update list
+is the source of truth; the type map is a convenience index that simply cannot
+represent duplicates. So the fix became surfacing the ambiguity rather than
+resolving it by force.
+
+**Also:** `get_system()` was typed `-> Any | None` and now returns the
+requested type, so callers stop losing type information at every lookup.
+
+**Tests:** 21 -> 34. The existing suite was genuinely good on the happy paths
+and the pause/resume gate; the gaps were registration *after* initialize, key
+collisions, and `unregister` edge cases.
+
+**Docs:** `docs/core/scenes.md` gains a Systems section -- a scene's
+`SystemManager` is where these are encountered. It records the priority band
+convention, that late registration is safe, and that the priority direction is
+the opposite of `EventDispatcher`'s (ascending here, descending there), which
+was written down nowhere.
+
+**Deferred:** CC-3 through CC-8, CC-11 (GitHub issue #9).
+
+**Tier 2 complete:** `config`, `application`, `scene`, `systems`.

--- a/docs/core/scenes.md
+++ b/docs/core/scenes.md
@@ -117,6 +117,52 @@ produced this tick.
 scene first, so `Transform.interpolate` entities are drawn between fixed steps
 rather than snapping at the physics rate.
 
+## Systems
+
+A scene's `SystemManager` holds its systems and updates them in **ascending**
+priority order — a lower number runs earlier.
+
+```python
+class Level(Scene):
+    def on_enter(self) -> None:
+        self.system_manager.register(CombatSystem(self.entity_manager), priority=500)
+```
+
+`resolve_dependencies()` registers the four engine systems in the 100–399 band
+and calls `initialize()`. Game systems should use **500 or above** to stay
+clear of it.
+
+Registering after `initialize()` is fine: a late system is initialised as it is
+registered. That matters because `resolve_dependencies()` runs *before*
+`on_enter()`, so anything a game registers in `on_enter()` is by definition
+late.
+
+!!! note "Priority runs the other way from events"
+    `SystemManager` runs **lower** priority first; `EventDispatcher` runs
+    **higher** priority first. Systems are a pipeline — input, then physics,
+    then rendering — where ascending reads as a sequence. Event handlers
+    compete for one event, where "most important first" is the natural
+    reading.
+
+### Retrieving systems
+
+```python
+combat = self.system_manager.get_system(CombatSystem)
+```
+
+Lookup is keyed by type. Several systems may share a key — they all update —
+but `get_system()` and `unregister()` then reach only the most recently
+registered, and that is logged. Pass a distinct `system_type=` to keep them
+individually addressable:
+
+```python
+self.system_manager.register(spawner_a, system_type=EnemySpawnerA)
+self.system_manager.register(spawner_b, system_type=EnemySpawnerB)
+```
+
+Systems are cleaned up when the scene exits, via `SceneManager`, so a system
+implementing `cleanup()` gets it called exactly once.
+
 ## Shutdown
 
 `cleanup()` exits every live scene exactly once, LIFO — including a scene a

--- a/pyguara/systems/manager.py
+++ b/pyguara/systems/manager.py
@@ -1,106 +1,141 @@
-"""System manager for orchestrating game logic systems."""
+"""Ordered registry of the systems that make up a scene's game logic."""
 
-from typing import Any
+from __future__ import annotations
 
-from pyguara.systems.protocols import CleanupSystem, InitializableSystem
+from typing import Any, TypeVar
+
+from pyguara.log import get_logger
+from pyguara.systems.protocols import CleanupSystem, InitializableSystem, System
+
+logger = get_logger(__name__)
+
+_S = TypeVar("_S")
+
+DEFAULT_PRIORITY = 100
 
 
 class SystemManager:
-    """Manages and orchestrates game logic systems.
+    """Holds a scene's systems and updates them in a fixed order.
 
-    The SystemManager maintains a collection of systems and updates them
-    in priority order each frame. This centralizes system management and
-    removes the need for scenes to manually update each system.
+    Each scene owns one of these; there is no global instance. Systems run in
+    ascending priority order, so a lower number updates earlier.
+
+    Note:
+        The direction is the opposite of `EventDispatcher`, where a *higher*
+        priority runs first. Systems are a pipeline -- input before physics
+        before rendering -- so ascending reads naturally as a sequence; event
+        handlers compete for the same event, where "most important first" is
+        the natural reading.
 
     Example:
-        >>> # Setup
-        >>> system_manager = SystemManager()
-        >>> system_manager.register(PhysicsSystem(engine, dispatcher), priority=100)
-        >>> system_manager.register(AISystem(entity_manager), priority=200)
-        >>> system_manager.initialize()
-        >>>
-        >>> # Game loop
-        >>> system_manager.update(dt)
+        ```python
+        systems = SystemManager()
+        systems.register(PhysicsSystem(engine, dispatcher), priority=100)
+        systems.register(AISystem(entity_manager), priority=200)
+        systems.initialize()
+
+        systems.update(dt)   # physics, then AI
+        ```
     """
 
     def __init__(self) -> None:
-        """Initialize the system manager."""
+        """Initialise an empty, enabled manager."""
         self._systems: list[tuple[int, Any]] = []  # (priority, system)
         self._systems_by_type: dict[type[Any], Any] = {}
         self._initialized = False
         self._enabled = True
 
     def register(
-        self, system: Any, priority: int = 100, system_type: type[Any] | None = None
+        self,
+        system: Any,
+        priority: int = DEFAULT_PRIORITY,
+        system_type: type[Any] | None = None,
     ) -> None:
-        """Register a system.
+        """Add a system to the update order.
+
+        If `initialize()` has already run, the new system is initialised
+        immediately rather than never: a scene initialises its manager in
+        `resolve_dependencies()`, which happens *before* `on_enter()`, so
+        every system a game registers in `on_enter()` would otherwise go
+        uninitialised.
+
+        Several systems may share a key. They all update, but `get_system()`
+        and `unregister()` then reach only the most recently registered, which
+        is logged. Give each a distinct `system_type` to keep them
+        addressable.
 
         Args:
-            system: System instance to register (must have update(dt) method)
-            priority: Update priority (lower values update first, default=100)
-            system_type: Optional type key for retrieval (defaults to type(system))
+            system: The system to add. Must expose `update(dt)`.
+            priority: Update order; lower runs earlier.
+            system_type: Key for `get_system()`. Defaults to the system's own
+                class. Pass it when several systems share a base class, or to
+                register against an interface.
 
         Raises:
-            ValueError: If system doesn't have update() method
+            ValueError: If `system` has no `update()` method.
         """
-        if not hasattr(system, "update"):
+        if not isinstance(system, System):
             raise ValueError(f"System {system} must have an update(dt) method")
 
-        # Store system with priority
-        self._systems.append((priority, system))
-        # Sort by priority after adding
-        self._systems.sort(key=lambda x: x[0])
-
-        # Store by type for retrieval
         key = system_type or type(system)
+        self._warn_if_key_reused(key, system)
+
+        self._systems.append((priority, system))
+        self._systems.sort(key=lambda entry: entry[0])
         self._systems_by_type[key] = system
 
+        if self._initialized and isinstance(system, InitializableSystem):
+            system.initialize()
+
     def unregister(self, system_type: type[Any]) -> Any | None:
-        """Unregister a system by type.
+        """Remove a system by key, cleaning it up if it supports that.
 
         Args:
-            system_type: Type of system to remove
+            system_type: The key the system was registered under.
 
         Returns:
-            The removed system, or None if not found
+            The removed system, or None if nothing was registered under that
+            key.
         """
         system = self._systems_by_type.pop(system_type, None)
-        if system:
-            self._systems = [(p, s) for p, s in self._systems if s is not system]
+        if system is None:
+            # `is None`, not truthiness: a system that defines __len__ or
+            # __bool__ falsily was dropped from the type map but left in the
+            # update list, still ticking and never cleaned up.
+            return None
 
-            # Cleanup if needed
-            if isinstance(system, CleanupSystem):
-                system.cleanup()
-
+        self._systems = [(p, s) for p, s in self._systems if s is not system]
+        if isinstance(system, CleanupSystem):
+            system.cleanup()
         return system
 
-    def get_system(self, system_type: type[Any]) -> Any | None:
-        """Get a registered system by type.
+    def get_system(self, system_type: type[_S]) -> _S | None:
+        """Retrieve a system by the key it was registered under.
 
         Args:
-            system_type: Type of system to retrieve
+            system_type: The registration key.
 
         Returns:
-            The system instance, or None if not found
+            The system, or None if nothing is registered under that key.
         """
         return self._systems_by_type.get(system_type)
 
     def has_system(self, system_type: type[Any]) -> bool:
-        """Check if a system type is registered.
+        """Report whether a key has a system registered.
 
         Args:
-            system_type: Type of system to check
+            system_type: The registration key.
 
         Returns:
-            True if system is registered
+            True if a system is registered under that key.
         """
         return system_type in self._systems_by_type
 
     def initialize(self) -> None:
-        """Initialize all systems.
+        """Initialise every registered system that supports it.
 
-        Calls initialize() on systems that support InitializableSystem protocol.
-        Should be called once before the first update.
+        Idempotent. Systems registered afterwards are initialised as they are
+        registered, so this need only be called once.
         """
         if self._initialized:
             return
@@ -112,12 +147,12 @@ class SystemManager:
         self._initialized = True
 
     def update(self, dt: float) -> None:
-        """Update all registered systems.
+        """Update every system in ascending priority order.
 
-        Systems are updated in priority order (lowest priority first).
+        Does nothing while disabled.
 
         Args:
-            dt: Delta time in seconds
+            dt: Delta time in seconds.
         """
         if not self._enabled:
             return
@@ -126,9 +161,11 @@ class SystemManager:
             system.update(dt)
 
     def cleanup(self) -> None:
-        """Cleanup all systems.
+        """Clean up and drop every system, leaving the manager empty.
 
-        Calls cleanup() on systems that support CleanupSystem protocol.
+        Systems supporting `CleanupSystem` get `cleanup()` called. The manager
+        is reusable afterwards: registering again and calling `initialize()`
+        works as it did the first time.
         """
         for _, system in self._systems:
             if isinstance(system, CleanupSystem):
@@ -139,27 +176,56 @@ class SystemManager:
         self._initialized = False
 
     def set_enabled(self, enabled: bool) -> None:
-        """Enable or disable all system updates.
+        """Turn `update()` on or off without unregistering anything.
+
+        Used by scene pause and resume.
 
         Args:
-            enabled: If False, update() will be a no-op
+            enabled: False makes `update()` a no-op.
         """
         self._enabled = enabled
 
     @property
     def enabled(self) -> bool:
-        """Check if system updates are enabled."""
+        """Whether `update()` currently does anything."""
         return self._enabled
 
     @property
     def system_count(self) -> int:
-        """Get number of registered systems."""
+        """How many systems are registered."""
         return len(self._systems)
 
     def get_all_systems(self) -> list[Any]:
-        """Get all registered systems in priority order.
+        """Return every registered system, in update order.
 
         Returns:
-            List of system instances
+            A snapshot list, lowest priority first.
         """
         return [system for _, system in self._systems]
+
+    def _warn_if_key_reused(self, key: type[Any], system: Any) -> None:
+        """Report that a lookup key now refers to more than one system.
+
+        Registering several systems under one key is allowed -- they all
+        update, in priority order -- but the lookup table holds a single entry
+        per key, so `get_system()` returns only the newest and
+        `unregister()` removes only that one. The earlier systems keep
+        updating with no way to reach them by type.
+
+        Pass a distinct `system_type` to each registration to keep them
+        individually addressable.
+
+        Args:
+            key: The registration key being reused.
+            system: The incoming system, so re-registering the same object is
+                not mistaken for a second one.
+        """
+        existing = self._systems_by_type.get(key)
+        if existing is None or existing is system:
+            return
+
+        logger.warning(
+            f"A second system is being registered as '{key.__name__}'. Both "
+            f"will update, but get_system() and unregister() will only see the "
+            f"newest. Pass a distinct system_type to address them separately."
+        )

--- a/tests/test_system_manager.py
+++ b/tests/test_system_manager.py
@@ -390,3 +390,207 @@ class TestSystemManagerIntegration:
         manager.set_enabled(True)
         manager.update(0.016)
         assert system.update_count == 2
+
+
+class TestLateRegistration:
+    """A system registered after initialize() was never initialised.
+
+    Scene.resolve_dependencies() calls initialize() on the scene's manager,
+    and that runs *before* on_enter() -- which is exactly where a game is
+    meant to register its own systems. Every one of them started up
+    uninitialised.
+    """
+
+    def test_a_system_registered_after_initialize_is_initialised(self):
+        manager = SystemManager()
+        manager.register(MockInitializableSystem())
+        manager.initialize()
+
+        late = MockInitializableSystem()
+        manager.register(late, system_type=type("LateKey", (), {}))
+
+        assert late.initialized
+
+    def test_a_late_system_is_not_initialised_twice(self):
+        class CountingInit:
+            def __init__(self):
+                self.init_count = 0
+
+            def initialize(self):
+                self.init_count += 1
+
+            def update(self, dt):
+                pass
+
+        manager = SystemManager()
+        manager.initialize()
+        system = CountingInit()
+        manager.register(system)
+        manager.initialize()
+
+        assert system.init_count == 1
+
+    def test_registering_before_initialize_still_defers(self):
+        manager = SystemManager()
+        system = MockInitializableSystem()
+        manager.register(system)
+
+        assert not system.initialized
+        manager.initialize()
+        assert system.initialized
+
+    def test_a_late_system_without_initialize_is_fine(self):
+        manager = SystemManager()
+        manager.initialize()
+        manager.register(MockSystem())
+
+        assert manager.system_count == 1
+
+
+class TestDuplicateRegistrationKeys:
+    """Several systems may share a key, but only one is addressable.
+
+    The lookup table holds one entry per key while the update list holds them
+    all, so the earlier systems keep updating with no way to reach them by
+    type. That is allowed -- the update list is the source of truth -- but it
+    is now said out loud instead of being silent.
+    """
+
+    def test_both_systems_still_update(self):
+        manager = SystemManager()
+        first, second = MockSystem(), MockSystem()
+        manager.register(first)
+        manager.register(second)
+
+        manager.update(0.016)
+
+        assert first.update_count == 1
+        assert second.update_count == 1
+
+    def test_the_ambiguity_is_logged(self, caplog):
+        import logging
+
+        manager = SystemManager()
+        manager.register(MockSystem())
+
+        with caplog.at_level(logging.WARNING):
+            manager.register(MockSystem())
+
+        assert "get_system() and unregister() will only see the newest" in caplog.text
+
+    def test_re_registering_the_same_object_is_not_flagged(self, caplog):
+        import logging
+
+        manager = SystemManager()
+        system = MockSystem()
+        manager.register(system)
+
+        with caplog.at_level(logging.WARNING):
+            manager.register(system)
+
+        assert caplog.text == ""
+
+    def test_distinct_keys_keep_both_addressable(self):
+        class KeyA:
+            pass
+
+        class KeyB:
+            pass
+
+        manager = SystemManager()
+        first, second = MockSystem(), MockSystem()
+        manager.register(first, system_type=KeyA)
+        manager.register(second, system_type=KeyB)
+
+        assert manager.get_system(KeyA) is first
+        assert manager.get_system(KeyB) is second
+
+
+class TestUnregisterEdgeCases:
+    def test_a_falsy_system_is_fully_removed(self):
+        """`if system:` dropped a falsy system from the lookup table but left
+        it in the update list -- still ticking every frame, never cleaned up,
+        and reported as removed."""
+
+        class FalsySystem:
+            def __init__(self):
+                self.cleaned = False
+                self.ticked = False
+
+            def __len__(self):
+                return 0
+
+            def update(self, dt):
+                self.ticked = True
+
+            def cleanup(self):
+                self.cleaned = True
+
+        manager = SystemManager()
+        system = FalsySystem()
+        manager.register(system)
+
+        returned = manager.unregister(FalsySystem)
+        manager.update(0.016)
+
+        assert returned is system
+        assert manager.system_count == 0
+        assert system.cleaned
+        assert not system.ticked
+
+    def test_unregistering_an_unknown_type_returns_none(self):
+        manager = SystemManager()
+
+        assert manager.unregister(MockSystem) is None
+
+    def test_unregister_removes_only_the_named_system(self):
+        class KeyA:
+            pass
+
+        class KeyB:
+            pass
+
+        manager = SystemManager()
+        keep = MockSystem()
+        manager.register(MockSystem(), system_type=KeyA)
+        manager.register(keep, system_type=KeyB)
+
+        manager.unregister(KeyA)
+        manager.update(0.016)
+
+        assert manager.system_count == 1
+        assert keep.update_count == 1
+
+
+class TestManagerReuse:
+    def test_a_manager_can_be_rebuilt_after_cleanup(self):
+        manager = SystemManager()
+        manager.register(MockInitializableSystem())
+        manager.initialize()
+        manager.cleanup()
+
+        rebuilt = MockInitializableSystem()
+        manager.register(rebuilt)
+        manager.initialize()
+
+        assert rebuilt.initialized
+        assert manager.system_count == 1
+
+    def test_priority_order_is_ascending(self):
+        """Ascending, unlike EventDispatcher where higher priority runs
+        first. Systems are a pipeline; event handlers compete."""
+        order: list[str] = []
+
+        class Ordered:
+            def __init__(self, name):
+                self.name = name
+
+            def update(self, dt):
+                order.append(self.name)
+
+        manager = SystemManager()
+        manager.register(Ordered("late"), priority=300, system_type=type("L", (), {}))
+        manager.register(Ordered("early"), priority=100, system_type=type("E", (), {}))
+        manager.update(0.016)
+
+        assert order == ["early", "late"]


### PR DESCRIPTION
Ninth subsystem iteration, and the last of Tier 2. Scope is `pyguara/systems`. Based on `main`.

The smallest module audited so far — 165 lines of manager, 63 of protocols — with the best existing test ratio. Three real defects nonetheless.

## 🐞 A system registered after `initialize()` was never initialised

`initialize()` sets a flag and returns early on every later call. And `Scene.resolve_dependencies()` calls it at line 108 — **before** `on_enter()`, which is precisely where a game is documented to register its own systems (the `>=500` priority band).

```
early.inited=True  late.inited=False
```

So every game system in the engine started up uninitialised. A late registration now initialises immediately, making "systems are initialised before their first update" hold regardless of ordering.

## 🐞 `unregister()` tested truthiness, not `None`

A system defining `__len__` or `__bool__` falsily was popped from the lookup table but **left in the update list** — still ticking every frame, never cleaned up, and returned to the caller as though removed.

```
returned=<FalsySys object>   still in _systems: 1
cleanup() called: False      still updating after unregister: True
```

## 🐞 Duplicate registration keys were silent

Several systems can share a key and all of them update, but the lookup table holds one entry per key — so earlier systems become unreachable through `get_system()` and survive `unregister()`. Now logged, with the remedy (`system_type=`) named in the message.

## A design choice I reversed mid-iteration

My first fix made duplicate registration **evict** the earlier system, reasoning that something unreachable still consuming frame budget is a leak. Three existing tests failed: they register several `MockSystem`/`OrderedSystem` instances under one class and expect all to update.

That's a legitimate pattern — multiple instances of one generic system — and eviction destroyed it. The update list is the source of truth; the type map is a convenience index that simply *cannot* represent duplicates. So the fix became surfacing the ambiguity rather than resolving it by force. The tests were right and my first instinct was wrong.

## Also

`get_system()` was typed `-> Any | None`, discarding the type the caller had just supplied. It now returns the requested type.

## Tests

**21 → 34.** The existing suite was genuinely good on the happy paths and the pause/resume gate; the gaps were registration *after* initialize, key collisions, and `unregister` edge cases.

**1414 pass** (from 1401), ruff clean, mypy clean. Two commits, both verified green in an isolated worktree.

## Docs

`docs/core/scenes.md` gains a Systems section — a scene's `SystemManager` is where these are met. It records the 100–399 engine priority band and the `>=500` convention, that late registration is safe, and that **priority runs ascending here while `EventDispatcher` runs it descending**. Two opposite conventions in one engine, previously written down nowhere.

---

## Tier 2 complete

| PR | Subsystem | Headline |
|---|---|---|
| #7 | `config` | `Color` didn't survive a round trip — a second-launch crash |
| #8 | `application` | Event budget spent 15× per lagged frame |
| #10 | `scene` | `switch_to()` abandoned every stacked scene |
| #11 | `systems` | Every game system started up uninitialised |

Tier 3 opens with `graphics`, which is where issue #9 (pygame in the backend-agnostic core) gets resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
