### PR TITLE
refactor(graphics) 1/5: the window boundary — Window reported the size it asked for, not the one it got

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -12,9 +12,9 @@ rather than fixed in place.
 
 ## Active Subsystem
 
-`pyguara/systems` — **in review (awaiting approval)**
+`pyguara/graphics` — **split across several iterations**; iteration 1 (the window boundary) in review.
 
-**Tier 2 completes with this iteration.**
+**Tier 2 is complete:** `config`, `application`, `scene`, `systems`.
 
 ---
 
@@ -33,10 +33,15 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 - [x] `pyguara/config` — configuration loading/merging *(done)*
 - [x] `pyguara/application` — Application loop, bootstrap, sandbox *(done)*
 - [x] `pyguara/scene` — Scene base, SceneManager, serializer *(done)*
-- [x] `pyguara/systems` — system manager / base systems *(active)*
+- [x] `pyguara/systems` — system manager / base systems *(done)*
 
 ### Tier 3 — Subsystems
-- [ ] `pyguara/graphics` — protocols, backends, window, batching
+- [~] `pyguara/graphics` — ~8,000 lines, too large for one iteration. Split:
+    - [x] 1. Window boundary — `window.py`, `IWindowBackend` *(active)*
+    - [ ] 2. Components — camera, particles, animation, geometry, sprite
+    - [ ] 3. Backends — pygame, ModernGL, headless renderers
+    - [ ] 4. Pipeline — graph, passes, framebuffer, viewport, batching
+    - [ ] 5. Assets & effects — spritesheet, ninepatch, materials, vfx, lighting
 - [ ] `pyguara/physics` — protocols, pymunk backend, joints, materials
 - [ ] `pyguara/input` — input manager, rebinding
 - [ ] `pyguara/audio` — audio manager, spatial audio
@@ -61,6 +66,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/systems` | 2026-09-06 | Fixed every game system starting up uninitialised (`initialize()` runs before `on_enter()`), an `unregister()` testing truthiness rather than `None`, and silent duplicate registration keys. PR #11. |
 | `pyguara/scene` | 2026-09-06 | Fixed `switch_to()` abandoning every stacked scene, unguarded re-entrancy during transitions, and a `pop_scene()` that stranded the scene it returned to. PR #10. |
 | `pyguara/application` | 2026-09-06 | Fixed an event budget spent per fixed step (15x per lagged frame), a `shutdown()` that skipped everything after the first failure, and three lifecycle events with no publisher. PR #8. |
 | `pyguara/config` | 2026-09-06 | Fixed `Color` not surviving a save/load round trip (a second-launch crash), `fixed_dt` dividing by zero unvalidated, and `update_setting` accepting wrong types and out-of-range values. PR #7. |
@@ -668,7 +674,7 @@ difference and the one-transition-at-a-time rule were undocumented.
 **Deferred:** CC-3 through CC-8, CC-11 (now GitHub issue #9).
 
 
-### `pyguara/systems` — awaiting approval (2026-09-06)
+### `pyguara/systems` — CLOSED 2026-09-06 (PR #11, branch `refactor/systems-audit`)
 
 **Verification:** 1414/1414 tests pass (up from 1401); ruff clean; mypy clean.
 
@@ -718,3 +724,46 @@ was written down nowhere.
 **Deferred:** CC-3 through CC-8, CC-11 (GitHub issue #9).
 
 **Tier 2 complete:** `config`, `application`, `scene`, `systems`.
+
+### `pyguara/graphics` iteration 1 — the window boundary — awaiting approval (2026-09-06)
+
+`pyguara/graphics` is ~8,000 lines across five distinct areas, so it is being
+audited in slices rather than as one iteration. This is the first: `window.py`
+and the `IWindowBackend` contract.
+
+**Verification:** 1427/1427 tests pass; ruff clean; mypy clean.
+
+**Correctness fixes:**
+- **`Window.width`/`height` reported the *requested* size, never the granted
+  one.** Both returned `WindowConfig` values unconditionally, so a window the
+  OS sized differently -- a fullscreen window is routinely handed the desktop
+  resolution instead -- reported whatever had been asked for.
+  `Application.__init__` feeds these straight into
+  `SceneManager.set_screen_size()`, and from there they reach transitions and
+  viewport calculations. They now come from the backend once the window
+  exists, falling back to config before `create()`.
+- **The `IWindowBackend` contract was split three ways.** The protocol declared
+  no size accessors, yet the ModernGL window and headless renderer both
+  implemented them and the pygame window did not. Nothing checked, because
+  nothing asked. `width`/`height` are now on the protocol and implemented by
+  all three -- mypy caught the missing headless implementation the moment the
+  protocol declared them, which is the protocol finally doing its job.
+- Corrected `Window.clear()`'s docstring, which claimed to use the configured
+  default colour while actually forwarding `None` for the backend to resolve.
+
+**Tests:** new `tests/test_window_boundary.py`, 13 tests. `Window` had no
+dedicated tests at all -- it was exercised only incidentally through
+`MagicMock` window fixtures in the application suite, which is why a size
+accessor that ignored the backend entirely went unnoticed. Includes protocol
+conformance checks for both real backends.
+
+**Issue #9 updated.** Mapping every non-backend pygame import turned up nine
+files across five subsystems, not the two originally recorded. Two matter:
+`input/manager.py` interprets SDL events directly (`pygame.KEYDOWN`,
+`pygame.key.get_mods()`, `KMOD_*`), so event translation is an input change as
+much as a graphics one; and `graphics/components/geometry.py` is an ECS
+component importing pygame, the clearest single violation and the cheapest to
+fix alone. The issue now carries a four-step sequence, each step independently
+shippable.
+
+**Deferred:** CC-3 through CC-8, CC-11 (issue #9).

--- a/pyguara/graphics/backends/headless_renderer.py
+++ b/pyguara/graphics/backends/headless_renderer.py
@@ -29,9 +29,17 @@ class HeadlessWindowBackend:
     def __init__(self) -> None:
         """Initialize the dummy window backend."""
         self._is_open = False
+        self._width = 0
+        self._height = 0
 
     def open(self, config: WindowConfig) -> bool:
-        """Pretend to open a window; no real display is ever created."""
+        """Pretend to open a window; no real display is ever created.
+
+        Records the requested size so the surface dimensions read back the way
+        a real backend's would.
+        """
+        self._width = config.screen_width
+        self._height = config.screen_height
         self._is_open = True
         return True
 
@@ -55,6 +63,16 @@ class HeadlessWindowBackend:
     def get_screen(self) -> Any:
         """Return `None`: there is no native surface/handle."""
         return None
+
+    @property
+    def width(self) -> int:
+        """The requested width; a headless window always gets what it asks for."""
+        return self._width
+
+    @property
+    def height(self) -> int:
+        """The requested height; a headless window always gets what it asks for."""
+        return self._height
 
 
 class HeadlessBackend:

--- a/pyguara/graphics/backends/pygame/pygame_window.py
+++ b/pyguara/graphics/backends/pygame/pygame_window.py
@@ -38,6 +38,20 @@ class PygameWindow:
         self._is_open = True
         return True
 
+    @property
+    def width(self) -> int:
+        """The drawable surface width in pixels, read back from SDL."""
+        if self._screen is None:
+            return 0
+        return int(self._screen.get_width())
+
+    @property
+    def height(self) -> int:
+        """The drawable surface height in pixels, read back from SDL."""
+        if self._screen is None:
+            return 0
+        return int(self._screen.get_height())
+
     def close(self) -> None:
         """Quit the display module."""
         # Pygame uses quit() to kill the window context

--- a/pyguara/graphics/protocols.py
+++ b/pyguara/graphics/protocols.py
@@ -280,16 +280,39 @@ class IWindowBackend(Protocol):
         ...
 
     def poll_events(self) -> Iterable[Any]:
-        """
-        Poll system events (input, window events).
+        """Poll system events and hand them on for interpretation.
 
         Returns:
-            Iterable of opaque event objects to be passed to InputManager.
+            Backend-native event objects, opaque to the engine.
+
+        Note:
+            These are the backend's own event objects -- SDL events under
+            pygame -- so every consumer has to know the backend's constants to
+            read them. That is why `Application` and `InputManager` still
+            import pygame despite the engine being nominally backend-agnostic.
+            Translating here, into engine events, is tracked as issue #9; it
+            spans graphics, input and application, so it is not something this
+            protocol can fix alone.
         """
         ...
 
     def get_screen(self) -> Any:
         """Return the native OS window."""
+        ...
+
+    @property
+    def width(self) -> int:
+        """The drawable surface width in pixels, as the OS actually granted it.
+
+        Not the width that was requested: a fullscreen window is commonly
+        handed the desktop resolution instead, and any resize changes it
+        again.
+        """
+        ...
+
+    @property
+    def height(self) -> int:
+        """The drawable surface height in pixels, as the OS actually granted it."""
         ...
 
 

--- a/pyguara/graphics/window.py
+++ b/pyguara/graphics/window.py
@@ -46,7 +46,12 @@ class Window:
             self._is_open = False
 
     def clear(self, color: Color | None = None) -> None:
-        """Clear the window with configured default Color."""
+        """Fill the window with a colour.
+
+        Args:
+            color: Colour to fill with. When None, the backend uses the
+                `default_color` it took from `WindowConfig` at open time.
+        """
         self._backend.clear(color)
 
     def present(self) -> None:
@@ -54,7 +59,13 @@ class Window:
         self._backend.present()
 
     def poll_events(self) -> Iterable[Any]:
-        """Fetch pygame events and handle internal window state."""
+        """Drain the OS event queue.
+
+        Returns:
+            Backend-native event objects. See `IWindowBackend.poll_events` and
+            issue #9: these are not yet engine events, which is why callers
+            still compare against pygame constants.
+        """
         return self._backend.poll_events()
 
     def set_title(self, title: str) -> None:
@@ -71,12 +82,29 @@ class Window:
 
     @property
     def width(self) -> int:
-        """Get the configured window width."""
+        """The drawable width in pixels.
+
+        Reported by the backend once the window exists, since the OS need not
+        grant the size that was asked for -- a fullscreen window is commonly
+        given the desktop resolution instead. Falls back to the configured
+        width before `create()`.
+
+        Returning the configured value unconditionally is what fed a wrong
+        screen size to `SceneManager.set_screen_size()`, and from there to
+        transitions and viewport calculations, whenever the two differed.
+        """
+        if self._is_open:
+            return self._backend.width
         return self._config.screen_width
 
     @property
     def height(self) -> int:
-        """Get the configured window height."""
+        """The drawable height in pixels.
+
+        Backend-reported once the window exists; see `width`.
+        """
+        if self._is_open:
+            return self._backend.height
         return self._config.screen_height
 
     @property

--- a/tests/test_window_boundary.py
+++ b/tests/test_window_boundary.py
@@ -1,0 +1,168 @@
+"""Tests for the Window/IWindowBackend boundary.
+
+`Window` is the engine's only sanctioned view of the OS window, so what it
+reports has to come from the backend rather than from the configuration that
+merely *asked* for a window of that shape.
+"""
+
+from typing import Any
+
+import pytest
+
+from pyguara.common.types import Color
+from pyguara.config.types import WindowConfig
+from pyguara.graphics.backends.headless_renderer import HeadlessWindowBackend
+from pyguara.graphics.protocols import IWindowBackend
+from pyguara.graphics.window import Window
+
+
+class GrantsADifferentSize:
+    """A backend that is handed a size other than the one requested.
+
+    This is ordinary behaviour, not a contrivance: a fullscreen window is
+    commonly given the desktop resolution instead of what was asked for.
+    """
+
+    def __init__(self, granted_width: int, granted_height: int) -> None:
+        self._width = granted_width
+        self._height = granted_height
+        self.cleared_with: list[Color | None] = []
+        self.caption = ""
+
+    def open(self, config: WindowConfig) -> bool:
+        return True
+
+    def close(self) -> None: ...
+
+    def clear(self, color: Color | None = None) -> None:
+        self.cleared_with.append(color)
+
+    def set_caption(self, title: str) -> None:
+        self.caption = title
+
+    def present(self) -> None: ...
+
+    def poll_events(self):
+        return []
+
+    def get_screen(self) -> Any:
+        return object()
+
+    @property
+    def width(self) -> int:
+        return self._width
+
+    @property
+    def height(self) -> int:
+        return self._height
+
+
+@pytest.fixture
+def config() -> WindowConfig:
+    return WindowConfig(screen_width=800, screen_height=600, title="Test")
+
+
+class TestReportedSize:
+    def test_size_comes_from_the_backend_once_open(self, config) -> None:
+        """Window.width returned the *configured* width unconditionally, so a
+        window the OS sized differently reported the size that was asked for.
+        Application feeds this to SceneManager.set_screen_size(), and from
+        there it reaches transitions and viewport maths."""
+        backend = GrantsADifferentSize(1920, 1080)
+        window = Window(config, backend)
+        window.create()
+
+        assert window.width == 1920
+        assert window.height == 1080
+
+    def test_size_falls_back_to_config_before_create(self, config) -> None:
+        window = Window(config, GrantsADifferentSize(1920, 1080))
+
+        assert window.width == 800
+        assert window.height == 600
+
+    def test_size_falls_back_to_config_after_close(self, config) -> None:
+        backend = GrantsADifferentSize(1920, 1080)
+        window = Window(config, backend)
+        window.create()
+        window.close()
+
+        assert window.width == 800
+
+
+class TestBackendConformance:
+    """Every shipped backend must satisfy IWindowBackend.
+
+    The protocol declared no size accessors while ModernGL and headless
+    implemented them and pygame did not -- a contract split three ways with
+    nothing checking it.
+    """
+
+    def test_headless_window_backend_conforms(self) -> None:
+        assert isinstance(HeadlessWindowBackend(), IWindowBackend)
+
+    def test_pygame_window_backend_conforms(self) -> None:
+        from pyguara.graphics.backends.pygame.pygame_window import PygameWindow
+
+        assert isinstance(PygameWindow(), IWindowBackend)
+
+    def test_headless_reports_the_size_it_was_opened_with(self) -> None:
+        backend = HeadlessWindowBackend()
+        backend.open(WindowConfig(screen_width=320, screen_height=240))
+
+        assert (backend.width, backend.height) == (320, 240)
+
+    def test_headless_reports_zero_before_open(self) -> None:
+        backend = HeadlessWindowBackend()
+
+        assert (backend.width, backend.height) == (0, 0)
+
+
+class TestLifecycle:
+    def test_create_is_idempotent(self, config) -> None:
+        window = Window(config, GrantsADifferentSize(800, 600))
+        window.create()
+        window.create()
+
+        assert window.is_open
+
+    def test_native_handle_before_create_raises(self, config) -> None:
+        window = Window(config, GrantsADifferentSize(800, 600))
+
+        with pytest.raises(RuntimeError, match="Window not created"):
+            _ = window.native_handle
+
+    def test_a_backend_that_fails_to_open_raises_and_stays_closed(self, config) -> None:
+        class RefusesToOpen(GrantsADifferentSize):
+            def open(self, config: WindowConfig) -> bool:
+                return False
+
+        window = Window(config, RefusesToOpen(800, 600))
+
+        with pytest.raises(RuntimeError, match="Failed to initialize"):
+            window.create()
+        assert not window.is_open
+
+    def test_close_before_create_is_a_noop(self, config) -> None:
+        window = Window(config, GrantsADifferentSize(800, 600))
+        window.close()
+
+        assert not window.is_open
+
+    def test_set_title_updates_config_and_backend(self, config) -> None:
+        backend = GrantsADifferentSize(800, 600)
+        window = Window(config, backend)
+
+        window.set_title("New Title")
+
+        assert backend.caption == "New Title"
+        assert config.title == "New Title"
+
+    def test_clear_forwards_none_so_the_backend_uses_its_default(self, config) -> None:
+        backend = GrantsADifferentSize(800, 600)
+        window = Window(config, backend)
+
+        window.clear()
+        window.clear(Color(1, 2, 3))
+
+        assert backend.cleared_with == [None, Color(1, 2, 3)]


### PR DESCRIPTION
Tenth iteration, and the **first of five** covering `pyguara/graphics`. Based on `main`.

## Why this is split

`pyguara/graphics` is ~8,000 lines across five genuinely distinct areas. Auditing it as one iteration would produce a PR nobody can review:

| | Slice | Approx. |
|---|---|---|
| **1** | **Window boundary** — `window.py`, `IWindowBackend` | 550 |
| 2 | Components — camera, particles, animation, geometry, sprite | 1,300 |
| 3 | Backends — pygame, ModernGL, headless | 1,500 |
| 4 | Pipeline — graph, passes, framebuffer, viewport, batching | 1,000 |
| 5 | Assets & effects — spritesheet, ninepatch, materials, vfx, lighting | 1,000 |

This PR is slice 1 — the architectural spine, and the prerequisite for the rest.

## 🐞 `Window.width`/`height` reported the requested size, never the granted one

Both returned `WindowConfig` values unconditionally. Those differ routinely — a fullscreen window is commonly handed the desktop resolution instead of what was asked for, and any resize changes it again.

Not cosmetic: `Application.__init__` passes both straight into `SceneManager.set_screen_size()`, which is what transitions and viewport maths are computed against. So a fullscreen game computed its transitions against a resolution it wasn't running at.

They now come from the backend once the window exists, falling back to config before `create()`.

## 🐞 The `IWindowBackend` contract was split three ways

The protocol declared **no** size accessors — yet the ModernGL window and headless renderer both implemented them, and the pygame window didn't. Three backends, three different shapes, nothing checking, because nothing asked.

`width`/`height` are now on the protocol and implemented by all three. The pygame one reads back from the SDL surface rather than echoing the request. mypy flagged the missing headless implementation the instant the protocol declared them — the protocol finally doing its job.

## Tests

New `tests/test_window_boundary.py`, **13 tests**. `Window` had no dedicated tests at all — it appeared only as a `MagicMock` in the application fixtures, which is precisely why a size accessor that never consulted the backend went unnoticed. Two assert protocol conformance for the real backends, so the contract can't split again.

**1414 pass**, ruff clean, mypy clean. Two commits, both verified green in an isolated worktree.

## 📋 Issue #9 turned out to be bigger than recorded

Mapping every non-backend pygame import found **nine files across five subsystems**, not the two originally documented. [Commented on the issue](https://github.com/Wedeueis/pyguara/issues/9) with the full map and a revised four-step sequence. Two findings matter:

- **`input/manager.py`** doesn't just receive SDL events, it *interprets* them — `pygame.KEYDOWN`, `pygame.key.get_mods()`, `KMOD_SHIFT`/`CTRL`/`ALT`. So event translation is an input change as much as a graphics one, and can't land under a one-subsystem iteration.
- **`graphics/components/geometry.py`** is an ECS component importing pygame — the clearest single violation in the tree, and the cheapest to fix on its own. It's slice 2.

This PR makes partial progress on #9: there was previously *no way* to ask the window how big it really is, which a meaningful `WindowResizeEvent` requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
