### PR TITLE
docs: require independent branches to be cut from main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,52 @@ pre-commit run --all-files
 python main.py
 ```
 
+## Branching and Pull Requests
+
+**Every independent branch is cut from `main`.** Not from another feature
+branch, and not from whatever happens to be checked out.
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b <type>/<scope>-<subject>
+```
+
+### Stack only for a real dependency
+
+Base a branch on another one only when it genuinely cannot build or be
+reviewed without it — it edits the same functions, or relies on an API the
+parent introduces. "It came next chronologically" is not a dependency.
+
+When you do stack, say so in the PR body: name the parent, state the
+dependency, and note the merge order.
+
+Why this matters here: GitHub retargets a stacked PR only when its base branch
+is **deleted** on merge. `delete_branch_on_merge` is enabled on this
+repository, so that now happens automatically — but merging a stack out of
+order still lands children in the wrong place, and a stack more than two deep
+compounds every rebase. Independent branches have neither problem.
+
+### Merging
+
+- **Merge commits**, not squash and not rebase-and-merge. Commits are split
+  deliberately (`fix:` separately from `docs:` and large mechanical churn) so
+  they review independently, and squashing destroys that. Rebase rewrites the
+  SHAs that verification notes refer to.
+- Merge a stack **bottom-up**, so each child retargets before its own turn.
+- If a branch falls behind `main`, rebase it — `git rebase origin/main` —
+  rather than merging `main` into it.
+
+### Before opening a PR
+
+The full suite, the linter and the type checker must all pass:
+
+```bash
+pytest && ruff check . && mypy pyguara
+```
+
+When a branch carries several commits, each one should pass on its own, not
+merely the tip.
+
 ## Architecture Overview
 
 ### Core Design Principles


### PR DESCRIPTION
Codifies the branching rule in `CLAUDE.md`, so it applies to every future session rather than living in one conversation.

## The rule

> **Every independent branch is cut from `main`.** Not from another feature branch, and not from whatever happens to be checked out.

Stack only when a branch genuinely cannot build or be reviewed without its parent — it edits the same functions, or relies on an API the parent introduces. *"It came next chronologically" is not a dependency.*

## Why

Three times during this audit, work reached `main` only after a manual repair. PRs #2–#6 and later #8 were stacked with no real dependency; each merged into its own base rather than `main`, and the chain had to be collapsed by hand:

```
*   8c2a5ef Merge the Tier 1 audit stack into main      ← manual
|\
| *   373e960 Merge pull request #6 …
| | *   ...
*   2b6949a Merge the application audit into main       ← manual
```

Compare #10 and #12, both cut from `main` — each merged cleanly, first time.

## Also recorded

Decisions taken along the way, so they don't get re-derived:

- **`delete_branch_on_merge` is enabled.** That's what makes GitHub retarget a stacked PR — it only ever did so when the base branch was *deleted*, which is exactly why the earlier stacks stranded.
- **Merge commits, not squash or rebase-and-merge.** Commits here are split deliberately (`fix:` apart from `docs:` and large mechanical churn) so they review independently; squash destroys that, and rebase rewrites the SHAs that verification notes cite.
- **Merge a stack bottom-up**, so each child retargets before its turn.
- **Rebase a branch that's fallen behind `main`**; don't merge `main` into it.
- **Every commit should pass on its own**, not merely the tip.

Docs only — no code touched. The suite on this branch (`main` plus these docs) passes: 1401. The higher counts quoted in #11 and #12 include their own new tests, which have not merged yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)