### PR TITLE
refactor(graphics) 3/5: backends — the pygame compatibility stubs had drifted

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -12,7 +12,7 @@ rather than fixed in place.
 
 ## Active Subsystem
 
-`pyguara/graphics` — **split across several iterations**; iterations 1 (window boundary) and 2 (components) in review.
+`pyguara/graphics` — **split across several iterations**; iterations 1 (window boundary), 2 (components) and 3 (backends) done; 3 in review.
 
 **Tier 2 is complete:** `config`, `application`, `scene`, `systems`.
 
@@ -39,7 +39,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 - [~] `pyguara/graphics` — ~8,000 lines, too large for one iteration. Split:
     - [x] 1. Window boundary — `window.py`, `IWindowBackend` *(active)*
     - [x] 2. Components — camera, particles, animation, geometry, sprite *(active)*
-    - [ ] 3. Backends — pygame, ModernGL, headless renderers
+    - [x] 3. Backends — pygame, ModernGL, headless renderers *(active)*
     - [ ] 4. Pipeline — graph, passes, framebuffer, viewport, batching
     - [ ] 5. Assets & effects — spritesheet, ninepatch, materials, vfx, lighting
 - [ ] `pyguara/physics` — protocols, pymunk backend, joints, materials
@@ -816,3 +816,40 @@ a fixed pool with documented degree units. `animation.py` carries
 -- which belongs to CC-6 rather than this slice.
 
 **Deferred:** CC-3 through CC-8, CC-11 (issue #9, now partly addressed).
+
+
+### `pyguara/graphics` iteration 3 — backends — awaiting approval (2026-09-06)
+
+**Verification:** 1464/1464 tests pass; ruff clean; mypy clean.
+
+**Correctness fixes:**
+- **The pygame compatibility stubs had drifted from the classes they stand in
+  for.** `graphics/backends/pygame/stubs.py` exists so game code using
+  framebuffers, lighting or post-processing runs unchanged on pygame; its
+  entire value is interface parity. Comparing each stub's public surface
+  against its real counterpart found two holes:
+  `PygameLightingSystem` was missing `collect_lights_screen_space` (called by
+  `pipeline/passes/light_pass.py`) and `PygameRenderGraph` was missing `ctx`
+  (read by `application.py`). Either is an `AttributeError` that appears only
+  after switching backend -- precisely the failure the stubs exist to prevent.
+  The file had **no test references at all**.
+
+**Tests:** new `tests/test_pygame_stubs.py`, 15 tests. Two are parametrised
+parity checks comparing every stub against its counterpart, by member name and
+by argument list, so the next divergence fails in CI rather than in a game.
+Verified they bite: removing `collect_lights_screen_space` again reproduces the
+failure with a message naming it. The rest cover the no-op behaviour itself --
+that the lighting stub reports *full* ambient rather than darkness, that the
+post-process stack passes frames through untouched, and that the lifecycle
+calls are harmless.
+
+**Surveyed and clean:** all six shipped implementations satisfy their protocols
+structurally (`IWindowBackend`, `IRenderer`, `UIRenderer`, `TextureFactory`),
+with no missing members and no signature drift; `conversions.py` is two
+one-line adapters. One inconsistency noted but not changed: `IFramebuffer` and
+`IRenderPass` are the only graphics protocols not marked `@runtime_checkable`,
+while the other four are. Nothing currently needs to `isinstance` them, so
+changing it now would be speculative -- it belongs with slice 4, which is where
+those two protocols are actually implemented.
+
+**Deferred:** CC-3 through CC-8, CC-11 (issue #9).

--- a/pyguara/graphics/backends/pygame/stubs.py
+++ b/pyguara/graphics/backends/pygame/stubs.py
@@ -1,9 +1,13 @@
-"""Stub implementations for advanced graphics features on Pygame backend.
+"""No-op stand-ins for the ModernGL-only graphics features, for pygame.
 
-The Pygame backend doesn't support advanced rendering features like
-FBOs, lighting, or post-processing. These stubs provide no-op
-implementations that allow game code to run unchanged while
-rendering a "fully lit" scene.
+The pygame backend has no framebuffers, no dynamic lighting and no
+post-processing. These stubs let game code that uses those features run
+unchanged on it, rendering a fully lit scene instead of failing.
+
+Their entire value is interface parity: a method the real class has and the
+stub does not is an `AttributeError` that appears only after switching
+backend. `tests/test_pygame_stubs.py` compares each stub's public surface
+against its counterpart, so drift is caught here rather than in a game.
 """
 
 from __future__ import annotations
@@ -11,6 +15,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from pyguara.common.types import Vector2
     from pyguara.ecs.manager import EntityManager
 
 
@@ -55,6 +60,24 @@ class PygameLightingSystem:
     def cleanup(self) -> None:
         """No-op cleanup."""
         pass
+
+    def collect_lights_screen_space(
+        self,
+        camera_position: Vector2,
+        camera_zoom: float,
+        viewport_offset: Vector2,
+    ) -> list[Any]:
+        """Return no lights: this backend renders everything fully lit.
+
+        Args:
+            camera_position: Camera world position (unused).
+            camera_zoom: Camera zoom factor (unused).
+            viewport_offset: Viewport offset in screen space (unused).
+
+        Returns:
+            An empty list.
+        """
+        return []
 
     def update(self, dt: float) -> None:
         """No-op update."""
@@ -242,6 +265,17 @@ class PygameRenderGraph:
     def fbo_manager(self) -> PygameFramebufferManager:
         """Get the stub framebuffer manager."""
         return self._fbo_manager
+
+    @property
+    def ctx(self) -> None:
+        """Return None: there is no GL context behind the pygame backend.
+
+        The real `RenderGraph` hands its `moderngl.Context` to each pass.
+        Nothing consumes this on pygame -- `Application` branches on
+        `isinstance(candidate, RenderGraph)` rather than on mere resolvability
+        -- but the attribute has to exist for the surfaces to match.
+        """
+        return None
 
     @property
     def passes(self) -> list[Any]:

--- a/tests/test_pygame_stubs.py
+++ b/tests/test_pygame_stubs.py
@@ -1,0 +1,147 @@
+"""Parity tests for the pygame stand-ins for ModernGL-only features.
+
+`graphics/backends/pygame/stubs.py` exists so game code using framebuffers,
+lighting or post-processing runs unchanged on the pygame backend. Its entire
+value is interface parity: a method the real class has and the stub does not is
+an `AttributeError` that surfaces only after switching backend, in someone
+else's game.
+
+Nothing tested it, and it had drifted -- `PygameLightingSystem` was missing
+`collect_lights_screen_space` (which `light_pass.py` calls) and
+`PygameRenderGraph` was missing `ctx` (which `application.py` reads). These
+tests compare the public surfaces directly, so the next divergence fails here.
+"""
+
+import inspect
+
+import pytest
+
+from pyguara.graphics.backends.pygame.stubs import (
+    PygameFramebufferManager,
+    PygameLightingSystem,
+    PygamePostProcessStack,
+    PygameRenderGraph,
+)
+from pyguara.graphics.lighting.light_system import LightingSystem
+from pyguara.graphics.pipeline.framebuffer import FramebufferManager
+from pyguara.graphics.pipeline.graph import RenderGraph
+from pyguara.graphics.vfx.post_process import PostProcessStack
+
+STUB_PAIRS = [
+    (PygameLightingSystem, LightingSystem),
+    (PygamePostProcessStack, PostProcessStack),
+    (PygameFramebufferManager, FramebufferManager),
+    (PygameRenderGraph, RenderGraph),
+]
+
+
+def public_members(cls: type) -> set[str]:
+    """Public attribute names a caller could reach on instances of `cls`."""
+    return {
+        name
+        for name, member in inspect.getmembers(cls)
+        if not name.startswith("_")
+        and (isinstance(member, property) or callable(member))
+    }
+
+
+@pytest.mark.parametrize(
+    ("stub", "real"), STUB_PAIRS, ids=lambda c: getattr(c, "__name__", str(c))
+)
+def test_the_stub_covers_the_real_classs_surface(stub: type, real: type) -> None:
+    missing = sorted(public_members(real) - public_members(stub))
+
+    assert not missing, (
+        f"{stub.__name__} is missing {missing}, which exist on {real.__name__}. "
+        f"Game code calling them works on ModernGL and raises AttributeError on "
+        f"pygame -- exactly what these stubs exist to prevent."
+    )
+
+
+@pytest.mark.parametrize(
+    ("stub", "real"), STUB_PAIRS, ids=lambda c: getattr(c, "__name__", str(c))
+)
+def test_the_stub_takes_the_same_arguments(stub: type, real: type) -> None:
+    """Names alone are not parity: a caller passing the real signature must not
+    hit a TypeError on the stub."""
+    mismatches = []
+    for name in sorted(public_members(real) & public_members(stub)):
+        real_member, stub_member = getattr(real, name), getattr(stub, name)
+        if isinstance(real_member, property) or isinstance(stub_member, property):
+            continue
+        try:
+            real_params = list(inspect.signature(real_member).parameters)
+            stub_params = list(inspect.signature(stub_member).parameters)
+        except (TypeError, ValueError):
+            continue
+        # A stub accepting **kwargs absorbs whatever the real one declares.
+        if any(
+            inspect.signature(stub_member).parameters[p].kind
+            is inspect.Parameter.VAR_KEYWORD
+            for p in stub_params
+        ):
+            continue
+        if real_params != stub_params:
+            mismatches.append(
+                f"{name}: real{tuple(real_params)} stub{tuple(stub_params)}"
+            )
+
+    assert not mismatches, "\n".join(mismatches)
+
+
+class TestStubBehaviour:
+    """The no-op behaviour itself, which nothing covered either."""
+
+    def test_the_lighting_stub_reports_no_lights(self) -> None:
+        from unittest.mock import MagicMock
+
+        from pyguara.common.types import Vector2
+
+        system = PygameLightingSystem(MagicMock())
+
+        assert system.lights == []
+        assert (
+            system.collect_lights_screen_space(Vector2.zero(), 1.0, Vector2.zero())
+            == []
+        )
+
+    def test_the_lighting_stub_reports_full_ambient(self) -> None:
+        """The pygame backend renders everything fully lit, so ambient has to
+        read as full brightness rather than as darkness."""
+        from unittest.mock import MagicMock
+
+        system = PygameLightingSystem(MagicMock())
+
+        assert system.get_ambient_normalized() == (1.0, 1.0, 1.0)
+        assert system.ambient_intensity == 1.0
+
+    def test_the_render_graph_stub_has_no_context(self) -> None:
+        assert PygameRenderGraph(800, 600).ctx is None
+
+    def test_the_render_graph_stub_accepts_and_reports_passes(self) -> None:
+        graph = PygameRenderGraph(800, 600)
+        graph.add_pass(object())
+
+        assert graph.passes == []
+        assert graph.get_pass("anything") is None
+
+    def test_the_framebuffer_stub_reports_its_size(self) -> None:
+        manager = PygameFramebufferManager(800, 600)
+
+        assert (manager.width, manager.height) == (800, 600)
+        assert manager.get_or_create("world") is None
+
+    def test_the_post_process_stub_passes_frames_through_untouched(self) -> None:
+        stack = PygamePostProcessStack()
+        sentinel = object()
+
+        assert stack.process(sentinel) is sentinel
+        assert stack.effects == []
+
+    def test_stub_lifecycle_calls_are_harmless(self) -> None:
+        from unittest.mock import MagicMock
+
+        PygameLightingSystem(MagicMock()).cleanup()
+        PygameRenderGraph(8, 8).release()
+        PygameFramebufferManager(8, 8).release_all()
+        PygamePostProcessStack().release()


### PR DESCRIPTION
Graphics slice 3 of 5: `graphics/backends/`. Based on `main`.

## 🐞 The pygame stubs had drifted from what they stand in for

`graphics/backends/pygame/stubs.py` (302 lines) exists for one reason: so game code using framebuffers, lighting or post-processing runs unchanged on the pygame backend. Its **entire value is interface parity**.

It had **zero test references** anywhere in the suite. Comparing each stub's public surface against its real counterpart:

```
--- LightingSystem
    MISSING from stub : ['collect_lights_screen_space']
--- RenderGraph
    MISSING from stub : ['ctx']
```

Both are reachable — `pipeline/passes/light_pass.py:186` calls the first, `application.py:436` reads the second. Either is an `AttributeError` that appears **only after switching backend**, which is exactly the failure these stubs exist to prevent. A shim whose job is parity, with nothing checking parity.

## The durable fix is the test, not the two methods

Adding the missing members is the easy half. The other half is that this can drift again the moment `LightingSystem` or `RenderGraph` grows a method.

`tests/test_pygame_stubs.py` compares **every** stub against its counterpart — by member name, and by argument list where the stub doesn't absorb everything through `**kwargs`. Parametrised over all four pairs, so a new stub is covered by adding one tuple.

I confirmed it bites rather than assuming — removed `collect_lights_screen_space` again and watched it fail:

```
AssertionError: PygameLightingSystem is missing ['collect_lights_screen_space'],
which exist on LightingSystem. Game code calling them works on ModernGL and
raises AttributeError on pygame -- exactly what these stubs exist to prevent.
```

The other 13 tests cover the no-op behaviour, which nothing tested either — including that the lighting stub reports **full** ambient rather than darkness. Reporting `0.0` would be the technically-empty but semantically wrong no-op: the pygame backend renders everything lit.

## Surveyed and left alone

All six shipped implementations satisfy their protocols structurally — `IWindowBackend`, `IRenderer`, `UIRenderer`, `TextureFactory` — with no missing members and no signature drift. `conversions.py` is two one-line adapters.

One inconsistency found and **deliberately not changed**: `IFramebuffer` and `IRenderPass` are the only graphics protocols not marked `@runtime_checkable`, while the other four are. Nothing currently needs to `isinstance` them, so changing it now would be speculative — it belongs with slice 4, where both are actually implemented.

**1464 pass** (from 1449), ruff clean, mypy clean. Two commits, both verified green in an isolated worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
