### PR TITLE
refactor(graphics) 4/5: pipeline — a zero-height window produced a 450px viewport

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -12,7 +12,7 @@ rather than fixed in place.
 
 ## Active Subsystem
 
-`pyguara/graphics` — **split across several iterations**; iterations 1 (window boundary), 2 (components) and 3 (backends) done; 3 in review.
+`pyguara/graphics` — **split across several iterations**; iterations 1-4 done; 4 (pipeline) in review. Slice 5 (assets & effects) remains.
 
 **Tier 2 is complete:** `config`, `application`, `scene`, `systems`.
 
@@ -40,7 +40,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
     - [x] 1. Window boundary — `window.py`, `IWindowBackend` *(active)*
     - [x] 2. Components — camera, particles, animation, geometry, sprite *(active)*
     - [x] 3. Backends — pygame, ModernGL, headless renderers *(active)*
-    - [ ] 4. Pipeline — graph, passes, framebuffer, viewport, batching
+    - [x] 4. Pipeline — graph, passes, framebuffer, viewport, batching *(active)*
     - [ ] 5. Assets & effects — spritesheet, ninepatch, materials, vfx, lighting
 - [ ] `pyguara/physics` — protocols, pymunk backend, joints, materials
 - [ ] `pyguara/input` — input manager, rebinding
@@ -853,3 +853,52 @@ changing it now would be speculative -- it belongs with slice 4, which is where
 those two protocols are actually implemented.
 
 **Deferred:** CC-3 through CC-8, CC-11 (issue #9).
+
+
+### `pyguara/graphics` iteration 4 — pipeline — awaiting approval (2026-09-06)
+
+**Verification:** 1485/1485 tests pass; ruff clean; mypy clean.
+
+**Correctness fixes:**
+- **`Viewport.create_best_fit()` fabricated a viewport for a zero-area
+  window.** The guard `window_ratio = w / h if h != 0 else 0` substituted a
+  ratio of zero, which is not greater than any positive target, so it fell
+  through to the letterbox branch:
+  `create_best_fit(800, 0, 16/9)` returned `Viewport(x=0, y=-225, width=800,
+  height=450)` -- a 450-pixel-tall viewport at a negative offset for a window
+  with no height. A minimised or mid-resize window is an ordinary transient
+  state, so it now yields a zero viewport. Negative dimensions do the same.
+  This is the third instance of the same shape in this audit, after the camera's
+  `safe_zoom = 0.001` and the DI container's swallowed errors: a zero guard
+  that returns a wrong answer instead of signalling.
+- **`create_best_fit()` divided by `target_aspect_ratio` with no check**, so
+  zero raised `ZeroDivisionError` from inside the letterbox branch and a
+  negative silently produced an inverted viewport. Unlike a minimised window
+  that is a caller error, so it raises `ValueError` naming the argument.
+- **`RenderGraph.passes` returned the live list.** `graph.passes.clear()`
+  emptied the pipeline without releasing a single pass. It is a snapshot now,
+  matching `SceneManager.children`.
+- **Duplicate pass names were silent.** Both passes execute -- the list is the
+  source of truth -- but `get_pass()` returns only the first and
+  `remove_pass()` removes only the first, so the second is unreachable by name.
+  Now logged, the same treatment `SystemManager` duplicate keys got.
+
+**Tests:** new `tests/test_graphics_pipeline.py`, 21 tests. Neither the
+viewport nor the graph had dedicated coverage. The viewport is pure arithmetic
+needing no GL context, so its edge cases are cheap to pin down; the graph's
+bookkeeping runs against a mocked context. Includes property-style checks that
+a fitted viewport keeps its target ratio and never exceeds the window, across
+four window shapes.
+
+**Surveyed:** `framebuffer.py`, `batch.py`, `queue.py`, `render_system.py` and
+the five passes need a live GL context to exercise meaningfully, so they are
+covered only by the existing ModernGL integration tests. No defects found by
+reading, but that is a weaker guarantee than the rest of this audit and worth
+saying plainly.
+
+**Related:** issue #16 records the `IFramebuffer`/`IRenderPass`
+`runtime_checkable` inconsistency found in slice 3. Not fixed here: it turns on
+whether `IRenderPass` or `BaseRenderPass(ABC)` is the real contract, which is a
+design decision rather than a defect.
+
+**Deferred:** CC-3 through CC-8, CC-11 (issue #9), issue #16.

--- a/pyguara/graphics/pipeline/graph.py
+++ b/pyguara/graphics/pipeline/graph.py
@@ -11,9 +11,13 @@ from typing import TYPE_CHECKING
 
 from pyguara.graphics.pipeline.framebuffer import FramebufferManager
 from pyguara.graphics.pipeline.render_pass import BaseRenderPass
+from pyguara.log import get_logger
 
 if TYPE_CHECKING:
     import moderngl
+
+
+logger = get_logger(__name__)
 
 
 class RenderGraph:
@@ -61,25 +65,53 @@ class RenderGraph:
 
     @property
     def passes(self) -> list[BaseRenderPass]:
-        """The ordered list of render passes."""
-        return self._passes
+        """The render passes, in execution order.
+
+        A snapshot: mutate the pipeline through `add_pass()`,
+        `insert_pass()` and `remove_pass()`. This used to hand back the live
+        list, so `graph.passes.clear()` silently emptied the pipeline without
+        releasing a single pass.
+        """
+        return list(self._passes)
 
     def add_pass(self, render_pass: BaseRenderPass) -> None:
-        """Add a render pass to the end of the pipeline.
+        """Append a render pass to the pipeline.
 
         Args:
-            render_pass: The pass to add.
+            render_pass: The pass to add. Its name should be unique; passes
+                are looked up by name, so a duplicate is unreachable through
+                `get_pass()` and survives `remove_pass()`.
         """
+        self._warn_if_name_taken(render_pass)
         self._passes.append(render_pass)
 
     def insert_pass(self, index: int, render_pass: BaseRenderPass) -> None:
-        """Insert a render pass at a specific position.
+        """Insert a render pass at a position in the pipeline.
 
         Args:
             index: Position in the pass list.
-            render_pass: The pass to insert.
+            render_pass: The pass to insert. Its name should be unique; see
+                `add_pass()`.
         """
+        self._warn_if_name_taken(render_pass)
         self._passes.insert(index, render_pass)
+
+    def _warn_if_name_taken(self, render_pass: BaseRenderPass) -> None:
+        """Report that a pass name now refers to more than one pass.
+
+        Both execute -- the pass list is the source of truth -- but `get_pass()`
+        returns only the first and `remove_pass()` removes only the first, so
+        the second is unreachable by name.
+
+        Args:
+            render_pass: The pass about to be added.
+        """
+        if any(existing.name == render_pass.name for existing in self._passes):
+            logger.warning(
+                f"A second render pass named '{render_pass.name}' is being added. "
+                f"Both will execute, but get_pass() and remove_pass() only ever "
+                f"reach the first. Give each pass a distinct name."
+            )
 
     def remove_pass(self, name: str) -> BaseRenderPass | None:
         """Remove a render pass by name.

--- a/pyguara/graphics/pipeline/viewport.py
+++ b/pyguara/graphics/pipeline/viewport.py
@@ -122,15 +122,35 @@ class Viewport(Rect):
         This automatically calculates the size and position for "Letterboxing"
         (black bars top/bottom) or "Pillarboxing" (black bars left/right).
 
+        A window with no area -- minimised, or mid-resize -- yields a zero
+        viewport rather than a fabricated one. The previous guard substituted a
+        window ratio of 0, which then took the letterbox branch and returned a
+        viewport hundreds of pixels tall at a negative y for a window of height
+        zero.
+
         Args:
             window_width (int): Current window width.
             window_height (int): Current window height.
             target_aspect_ratio (float): Desired ratio (e.g., 16/9 or 1.77).
 
         Returns:
-            Viewport: A centered viewport fitting the target ratio.
+            Viewport: A centered viewport fitting the target ratio, or a zero
+            viewport when the window has no area.
+
+        Raises:
+            ValueError: If `target_aspect_ratio` is not positive. That is a
+                caller error rather than a transient window state, and the
+                letterbox branch would otherwise divide by it.
         """
-        window_ratio = window_width / window_height if window_height != 0 else 0
+        if target_aspect_ratio <= 0:
+            raise ValueError(
+                f"target_aspect_ratio must be positive, got {target_aspect_ratio}."
+            )
+
+        if window_width <= 0 or window_height <= 0:
+            return Viewport(0, 0, 0, 0)
+
+        window_ratio = window_width / window_height
 
         if window_ratio > target_aspect_ratio:
             # Window is too wide (Pillarbox): Fit by height

--- a/tests/test_graphics_pipeline.py
+++ b/tests/test_graphics_pipeline.py
@@ -1,0 +1,209 @@
+"""Tests for the render pipeline's viewport maths and graph bookkeeping.
+
+Neither had dedicated tests. The viewport is pure arithmetic and needs no GL
+context, so its edge cases are cheap to pin down; the graph's pass list is
+plain bookkeeping around a mocked context.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyguara.graphics.pipeline.graph import RenderGraph
+from pyguara.graphics.pipeline.viewport import Viewport
+
+WIDESCREEN = 16 / 9
+
+
+def make_pass(name: str) -> MagicMock:
+    render_pass = MagicMock()
+    render_pass.name = name
+    render_pass.enabled = True
+    return render_pass
+
+
+class TestViewportBestFit:
+    def test_a_matching_window_fills_completely(self) -> None:
+        viewport = Viewport.create_best_fit(1920, 1080, WIDESCREEN)
+
+        assert (viewport.x, viewport.y) == (0, 0)
+        assert (viewport.width, viewport.height) == (1920, 1080)
+
+    def test_a_too_wide_window_is_pillarboxed(self) -> None:
+        viewport = Viewport.create_best_fit(2000, 1000, 1.0)
+
+        assert viewport.height == 1000
+        assert viewport.width == 1000
+        assert viewport.x == 500, "bars should be split evenly"
+
+    def test_a_too_tall_window_is_letterboxed(self) -> None:
+        viewport = Viewport.create_best_fit(1000, 2000, 1.0)
+
+        assert viewport.width == 1000
+        assert viewport.height == 1000
+        assert viewport.y == 500, "bars should be split evenly"
+
+    def test_the_fitted_viewport_keeps_the_target_ratio(self) -> None:
+        for window in ((1920, 1080), (1024, 768), (640, 1000), (3000, 500)):
+            viewport = Viewport.create_best_fit(*window, WIDESCREEN)
+            assert abs(viewport.aspect_ratio - WIDESCREEN) < 0.01, window
+
+    def test_the_viewport_never_exceeds_the_window(self) -> None:
+        for window in ((1920, 1080), (1024, 768), (640, 1000), (3000, 500)):
+            viewport = Viewport.create_best_fit(*window, WIDESCREEN)
+            assert viewport.width <= window[0], window
+            assert viewport.height <= window[1], window
+
+
+class TestViewportDegenerateInput:
+    """A zero-area window is an ordinary transient state -- minimised, or
+    mid-resize -- not a programming error. It used to produce a fabricated
+    viewport: `create_best_fit(800, 0, 16/9)` returned a 450px-tall viewport at
+    y=-225, because the zero guard substituted a window ratio of 0 and that
+    fell through to the letterbox branch.
+    """
+
+    def test_a_zero_height_window_yields_a_zero_viewport(self) -> None:
+        viewport = Viewport.create_best_fit(800, 0, WIDESCREEN)
+
+        assert (viewport.x, viewport.y, viewport.width, viewport.height) == (0, 0, 0, 0)
+
+    def test_a_zero_width_window_yields_a_zero_viewport(self) -> None:
+        viewport = Viewport.create_best_fit(0, 600, WIDESCREEN)
+
+        assert (viewport.width, viewport.height) == (0, 0)
+
+    def test_negative_dimensions_yield_a_zero_viewport(self) -> None:
+        viewport = Viewport.create_best_fit(-800, -600, WIDESCREEN)
+
+        assert (viewport.width, viewport.height) == (0, 0)
+
+    def test_a_non_positive_aspect_ratio_is_rejected(self) -> None:
+        """Unlike a minimised window, this is a caller error -- and the
+        letterbox branch divides by it."""
+        with pytest.raises(ValueError, match="must be positive"):
+            Viewport.create_best_fit(800, 600, 0.0)
+
+        with pytest.raises(ValueError, match="must be positive"):
+            Viewport.create_best_fit(800, 600, -1.5)
+
+    def test_fullscreen_passes_the_window_through(self) -> None:
+        viewport = Viewport.create_fullscreen(1280, 720)
+
+        assert (viewport.width, viewport.height) == (1280, 720)
+
+
+class TestRenderGraphPasses:
+    def test_passes_are_returned_in_insertion_order(self) -> None:
+        graph = RenderGraph(MagicMock(), 800, 600)
+        first, second = make_pass("world"), make_pass("ui")
+        graph.add_pass(first)
+        graph.add_pass(second)
+
+        assert graph.passes == [first, second]
+
+    def test_insert_pass_positions_it(self) -> None:
+        graph = RenderGraph(MagicMock(), 800, 600)
+        graph.add_pass(make_pass("world"))
+        early = make_pass("shadow")
+        graph.insert_pass(0, early)
+
+        assert graph.passes[0] is early
+
+    def test_the_returned_list_is_a_snapshot(self) -> None:
+        """`passes` handed back the live list, so a caller could empty the
+        pipeline without releasing a single pass."""
+        graph = RenderGraph(MagicMock(), 800, 600)
+        graph.add_pass(make_pass("world"))
+
+        graph.passes.clear()
+
+        assert len(graph.passes) == 1
+
+    def test_get_and_remove_by_name(self) -> None:
+        graph = RenderGraph(MagicMock(), 800, 600)
+        world = make_pass("world")
+        graph.add_pass(world)
+
+        assert graph.get_pass("world") is world
+        assert graph.remove_pass("world") is world
+        assert graph.get_pass("world") is None
+
+    def test_removing_an_unknown_name_returns_none(self) -> None:
+        graph = RenderGraph(MagicMock(), 800, 600)
+
+        assert graph.remove_pass("nope") is None
+
+    def test_a_duplicate_pass_name_is_reported(self, caplog) -> None:
+        """Both execute -- the list is the source of truth -- but only the
+        first is reachable by name, so the ambiguity is said out loud."""
+        import logging
+
+        graph = RenderGraph(MagicMock(), 800, 600)
+        graph.add_pass(make_pass("world"))
+
+        with caplog.at_level(logging.WARNING):
+            graph.add_pass(make_pass("world"))
+
+        assert "second render pass named 'world'" in caplog.text
+        assert len(graph.passes) == 2
+
+    def test_a_unique_name_is_not_reported(self, caplog) -> None:
+        import logging
+
+        graph = RenderGraph(MagicMock(), 800, 600)
+        graph.add_pass(make_pass("world"))
+
+        with caplog.at_level(logging.WARNING):
+            graph.add_pass(make_pass("ui"))
+
+        assert caplog.text == ""
+
+
+class TestRenderGraphExecution:
+    def test_only_enabled_passes_execute(self) -> None:
+        graph = RenderGraph(MagicMock(), 800, 600)
+        on, off = make_pass("on"), make_pass("off")
+        off.enabled = False
+        graph.add_pass(on)
+        graph.add_pass(off)
+
+        graph.execute()
+
+        assert on.execute.called
+        assert not off.execute.called
+
+    def test_passes_execute_in_order(self) -> None:
+        graph = RenderGraph(MagicMock(), 800, 600)
+        order: list[str] = []
+        for name in ("first", "second", "third"):
+            render_pass = make_pass(name)
+            render_pass.execute.side_effect = lambda _ctx, _graph, n=name: order.append(
+                n
+            )
+            graph.add_pass(render_pass)
+
+        graph.execute()
+
+        assert order == ["first", "second", "third"]
+
+    def test_resize_notifies_every_pass(self) -> None:
+        graph = RenderGraph(MagicMock(), 800, 600)
+        passes = [make_pass(n) for n in ("a", "b")]
+        for render_pass in passes:
+            graph.add_pass(render_pass)
+
+        graph.resize(1024, 768)
+
+        for render_pass in passes:
+            render_pass.on_resize.assert_called_once_with(1024, 768)
+
+    def test_release_drops_and_releases_every_pass(self) -> None:
+        graph = RenderGraph(MagicMock(), 800, 600)
+        render_pass = make_pass("world")
+        graph.add_pass(render_pass)
+
+        graph.release()
+
+        assert render_pass.release.called
+        assert graph.passes == []


### PR DESCRIPTION
Graphics slice 4 of 5: `graphics/pipeline/`. Based on `main`.

## 🐞 `Viewport.create_best_fit()` fabricated a size for a zero-area window

The guard was `window_ratio = w / h if h != 0 else 0`. A ratio of zero isn't greater than any positive target, so it fell straight through to the **letterbox** branch and computed a size from the width alone:

```
create_best_fit(800, 0, 16/9)  ->  Viewport(x=0, y=-225, width=800, height=450)
```

A 450-pixel-tall viewport at a **negative offset**, for a window with no height. A minimised or mid-resize window is an ordinary transient state, so it now yields a zero viewport — as do negative dimensions.

**This is the third instance of one shape in this audit.** After the camera's `safe_zoom = 0.001` (slice 2) and the DI container's swallowed disposal errors (#4): a guard that avoids a crash by returning a *wrong answer* rather than signalling. Worth naming as a pattern — the crash it prevents is much easier to diagnose than the plausible-looking garbage it substitutes.

`target_aspect_ratio` was unguarded entirely — zero raised `ZeroDivisionError` from inside the branch, a negative silently produced an inverted viewport. That one *is* a caller error, so it raises `ValueError` naming the argument.

## Two more in `RenderGraph`

**`passes` returned the live list**, so `graph.passes.clear()` emptied the pipeline without releasing a single pass. Now a snapshot, matching `SceneManager.children`.

**Duplicate pass names were silent.** Both execute — the list is the source of truth — but `get_pass()` and `remove_pass()` only ever reach the first, so the second is unreachable by name. Now logged, the same treatment `SystemManager`'s duplicate keys got in #11.

## Tests

New `tests/test_graphics_pipeline.py`, **21 tests**. Neither the viewport nor the graph had dedicated coverage. The viewport is pure arithmetic needing no GL context, so its edge cases are cheap to pin down; the graph's bookkeeping runs against a mocked context.

Includes property-style checks that a fitted viewport keeps its target ratio and never exceeds the window, across four window shapes.

**1485 pass** (from 1464), ruff clean, mypy clean. Two commits, both verified green in an isolated worktree.

## What this slice could *not* verify as strongly

Worth saying plainly rather than implying uniform coverage: `framebuffer.py`, `batch.py`, `queue.py`, `render_system.py` and the five render passes all need a **live GL context** to exercise meaningfully. They're covered only by the existing ModernGL integration tests. I read them and found no defects — but reading is a weaker guarantee than the probes used everywhere else in this audit, and I'd rather flag that than let the slice read as fully audited.

## Related

Issue #16 (opened from slice 3) records the `IFramebuffer`/`IRenderPass` `runtime_checkable` inconsistency. **Not fixed here** — it turns on whether `IRenderPass` or `BaseRenderPass(ABC)` is the real contract, which is a design decision rather than a defect, and `CLAUDE.md`'s stated Protocol-over-ABC preference makes it a question worth answering deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
