### PR TITLE
refactor(graphics) 5/5: assets & effects — nine-patch produced negative source rects

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -12,7 +12,7 @@ rather than fixed in place.
 
 ## Active Subsystem
 
-`pyguara/graphics` — **split across several iterations**; iterations 1-4 done; 4 (pipeline) in review. Slice 5 (assets & effects) remains.
+`pyguara/graphics` — **split across several iterations**; all five slices done; slice 5 (assets & effects) in review. **Tier 3 continues with `physics`.**
 
 **Tier 2 is complete:** `config`, `application`, `scene`, `systems`.
 
@@ -36,12 +36,12 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 - [x] `pyguara/systems` — system manager / base systems *(done)*
 
 ### Tier 3 — Subsystems
-- [~] `pyguara/graphics` — ~8,000 lines, too large for one iteration. Split:
+- [x] `pyguara/graphics` — ~8,000 lines, audited in five slices:
     - [x] 1. Window boundary — `window.py`, `IWindowBackend` *(active)*
     - [x] 2. Components — camera, particles, animation, geometry, sprite *(active)*
     - [x] 3. Backends — pygame, ModernGL, headless renderers *(active)*
     - [x] 4. Pipeline — graph, passes, framebuffer, viewport, batching *(active)*
-    - [ ] 5. Assets & effects — spritesheet, ninepatch, materials, vfx, lighting
+    - [x] 5. Assets & effects — spritesheet, ninepatch, materials, vfx, lighting *(active)*
 - [ ] `pyguara/physics` — protocols, pymunk backend, joints, materials
 - [ ] `pyguara/input` — input manager, rebinding
 - [ ] `pyguara/audio` — audio manager, spatial audio
@@ -900,5 +900,61 @@ saying plainly.
 `runtime_checkable` inconsistency found in slice 3. Not fixed here: it turns on
 whether `IRenderPass` or `BaseRenderPass(ABC)` is the real contract, which is a
 design decision rather than a defect.
+
+**Deferred:** CC-3 through CC-8, CC-11 (issue #9), issue #16.
+
+
+### `pyguara/graphics` iteration 5 — assets & effects — awaiting approval (2026-09-06)
+
+**Verification:** 1503/1503 tests pass; ruff clean; mypy clean.
+**This completes the graphics subsystem.**
+
+**Correctness fixes:**
+- **`NinePatchSprite.get_patch_rects()` produced negative source rectangles.**
+  Edges wider than the texture leave the centre with negative extent, and five
+  of the nine source rects came back malformed --
+  `Rect(x=40, y=0, width=-32, height=40)` for `uniform(40)` on a 48px texture --
+  which reach the renderer as geometry rather than as an error. The asymmetry
+  is the tell: `get_dest_rects()` clamps its own input with
+  `max(width, min_size)`, three lines the source side never had. Now raises,
+  naming both the edges and the texture size.
+- **`NinePatchMetrics` accepted negative edges.** `uniform(-5)` was fine, and
+  every rect derived from it was malformed. Rejected at construction.
+- **`PostProcessStack.effects` returned the live list**, so
+  `stack.effects.clear()` emptied the stack without releasing a single effect.
+- **Duplicate effect names were silent**, leaving the second unreachable
+  through `get_effect()` and surviving `remove_effect()`.
+
+The last two are the *same pair* fixed in `RenderGraph` one slice earlier.
+`PostProcessStack` and `RenderGraph` are siblings -- an ordered list plus a
+name lookup -- and carried identical defects. Fixed identically, and the
+docstrings now cross-reference so the parallel is visible.
+
+**Tests:** +18. `test_ninepatch.py` gains metrics validation, the source/
+destination asymmetry, and a check that valid source rects tile the texture
+exactly. New `test_post_process_stack.py` covers the stack's bookkeeping.
+
+**Surveyed, not deeply verified:** `materials/`, `vfx/effects/` (bloom,
+vignette) and the shader loading in `post_process.py` need a live GL context,
+so they remain covered only by the ModernGL integration tests -- the same
+caveat as slice 4. `spritesheet.py`, `atlas.py` and `animation_system.py` were
+read and probed and behaved correctly on degenerate input.
+
+### `pyguara/graphics` — SUMMARY of all five slices
+
+| Slice | Headline defect |
+| --- | --- |
+| 1. Boundary | `Window` reported the requested size, not the granted one |
+| 2. Components | `Box`/`Circle` hard-wired to pygame; camera zoom accepted 0 |
+| 3. Backends | pygame compatibility stubs had drifted from their counterparts |
+| 4. Pipeline | a zero-height window produced a 450px viewport at negative y |
+| 5. Assets | nine-patch produced negative source rects |
+
+**A pattern worth recording.** Four of the five slices turned up the same
+shape: a guard that avoids a crash by returning a wrong answer.
+`safe_zoom = 0.001`, `window_ratio ... else 0`, the nine-patch's missing
+clamp, and the DI container's swallowed disposal errors from an earlier tier.
+In every case the crash would have been easier to diagnose than the
+plausible-looking garbage substituted for it.
 
 **Deferred:** CC-3 through CC-8, CC-11 (issue #9), issue #16.

--- a/pyguara/graphics/ninepatch.py
+++ b/pyguara/graphics/ninepatch.py
@@ -26,6 +26,28 @@ class NinePatchMetrics:
     top: int
     bottom: int
 
+    def __post_init__(self) -> None:
+        """Reject negative edges.
+
+        A negative edge produces negative-width source and destination rects,
+        which reach the renderer as geometry rather than as an error.
+
+        Raises:
+            ValueError: If any edge is negative.
+        """
+        negative = {
+            name: value
+            for name, value in (
+                ("left", self.left),
+                ("right", self.right),
+                ("top", self.top),
+                ("bottom", self.bottom),
+            )
+            if value < 0
+        }
+        if negative:
+            raise ValueError(f"Nine-patch edges cannot be negative: {negative}.")
+
     @classmethod
     def uniform(cls, size: int) -> "NinePatchMetrics":
         """Create uniform metrics (all edges same size).
@@ -100,10 +122,24 @@ class NinePatchSprite:
         Returns:
             List of 9 Rect objects for source positions
             in order: TL, T, TR, L, C, R, BL, B, BR
+
+        Raises:
+            ValueError: If the edges do not fit inside the source. Overlapping
+                edges leave the centre with negative extent, and five of the
+                nine source rects came out with negative width or height --
+                geometry the renderer has no way to interpret. `get_dest_rects`
+                already clamped its own equivalent; this side did not.
         """
         m = self.metrics
         sw = source_width
         sh = source_height
+
+        if m.left + m.right > sw or m.top + m.bottom > sh:
+            raise ValueError(
+                f"Nine-patch edges do not fit the source texture: edges "
+                f"{m.left}+{m.right} wide and {m.top}+{m.bottom} tall against a "
+                f"{sw}x{sh} texture. The centre patch would have negative extent."
+            )
 
         # Source rectangles (from texture)
         src_rects = [

--- a/pyguara/graphics/vfx/post_process.py
+++ b/pyguara/graphics/vfx/post_process.py
@@ -11,6 +11,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from pyguara.log import get_logger
+
 if TYPE_CHECKING:
     import moderngl
 
@@ -19,6 +21,9 @@ if TYPE_CHECKING:
 
 # Shader directory
 _SHADER_DIR = Path(__file__).parent.parent / "backends" / "moderngl" / "shaders"
+
+
+logger = get_logger(__name__)
 
 
 class PostProcessEffect(ABC):
@@ -116,25 +121,54 @@ class PostProcessStack:
 
     @property
     def effects(self) -> list[PostProcessEffect]:
-        """Get the effect list."""
-        return self._effects
+        """The effects, in application order.
+
+        A snapshot: change the stack through `add_effect()`,
+        `insert_effect()` and `remove_effect()`. This used to hand back the
+        live list, so `stack.effects.clear()` silently emptied the stack
+        without releasing a single effect.
+        """
+        return list(self._effects)
 
     def add_effect(self, effect: PostProcessEffect) -> None:
-        """Add an effect to the end of the stack.
+        """Append an effect to the stack.
 
         Args:
-            effect: The effect to add.
+            effect: The effect to add. Its name should be unique; effects are
+                looked up by name, so a duplicate is unreachable through
+                `get_effect()` and survives `remove_effect()`.
         """
+        self._warn_if_name_taken(effect)
         self._effects.append(effect)
 
     def insert_effect(self, index: int, effect: PostProcessEffect) -> None:
-        """Insert an effect at a specific position.
+        """Insert an effect at a position in the stack.
 
         Args:
             index: Position in the stack.
-            effect: The effect to insert.
+            effect: The effect to insert. Its name should be unique; see
+                `add_effect()`.
         """
+        self._warn_if_name_taken(effect)
         self._effects.insert(index, effect)
+
+    def _warn_if_name_taken(self, effect: PostProcessEffect) -> None:
+        """Report that an effect name now refers to more than one effect.
+
+        Both apply -- the effect list is the source of truth -- but
+        `get_effect()` returns only the first and `remove_effect()` removes
+        only the first, so the second is unreachable by name. The sibling
+        `RenderGraph` treats duplicate pass names the same way.
+
+        Args:
+            effect: The effect about to be added.
+        """
+        if any(existing.name == effect.name for existing in self._effects):
+            logger.warning(
+                f"A second post-process effect named '{effect.name}' is being "
+                f"added. Both will apply, but get_effect() and remove_effect() "
+                f"only ever reach the first. Give each effect a distinct name."
+            )
 
     def remove_effect(self, name: str) -> PostProcessEffect | None:
         """Remove an effect by name.

--- a/tests/test_ninepatch.py
+++ b/tests/test_ninepatch.py
@@ -252,3 +252,88 @@ class TestNinePatchUsagePatterns:
 
         # Content area accounts for asymmetry
         assert dest_rects[4].height == 160  # 200 - 30 - 10
+
+
+class TestNinePatchMetricsValidation:
+    """Negative edges produce negative-width rects that reach the renderer as
+    geometry rather than as an error."""
+
+    def test_negative_edges_are_rejected(self):
+        import pytest
+
+        from pyguara.graphics.ninepatch import NinePatchMetrics
+
+        with pytest.raises(ValueError, match="cannot be negative"):
+            NinePatchMetrics.uniform(-5)
+
+    def test_the_error_names_the_offending_edges(self):
+        import pytest
+
+        from pyguara.graphics.ninepatch import NinePatchMetrics
+
+        with pytest.raises(ValueError, match="'right'"):
+            NinePatchMetrics(left=4, right=-1, top=4, bottom=4)
+
+    def test_zero_edges_are_allowed(self):
+        from pyguara.graphics.ninepatch import NinePatchMetrics
+
+        assert NinePatchMetrics.uniform(0).left == 0
+
+
+class TestNinePatchSourceRects:
+    """get_dest_rects clamped its input; get_patch_rects did not.
+
+    Edges wider than the source leave the centre with negative extent, and five
+    of the nine source rects came out with negative width or height --
+    e.g. Rect(x=40, y=0, width=-32, height=40) for uniform(40) on a 48px
+    texture.
+    """
+
+    def _sprite(self, edge: int, size: int = 48):
+        from unittest.mock import MagicMock
+
+        from pyguara.graphics.ninepatch import NinePatchMetrics, NinePatchSprite
+
+        texture = MagicMock()
+        texture.width = size
+        texture.height = size
+        return NinePatchSprite(texture, NinePatchMetrics.uniform(edge))
+
+    def test_edges_wider_than_the_source_are_rejected(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="do not fit the source"):
+            self._sprite(40).get_patch_rects(48, 48)
+
+    def test_the_error_reports_both_the_edges_and_the_texture(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="40\\+40.*48x48"):
+            self._sprite(40).get_patch_rects(48, 48)
+
+    def test_edges_exactly_filling_the_source_are_allowed(self):
+        """left+right == width leaves a zero-width centre, which is degenerate
+        but not negative -- a legitimate patch with no stretchable middle."""
+        rects = self._sprite(24).get_patch_rects(48, 48)
+
+        assert len(rects) == 9
+        assert all(r.width >= 0 and r.height >= 0 for r in rects)
+
+    def test_valid_metrics_produce_nine_non_negative_rects(self):
+        rects = self._sprite(16).get_patch_rects(48, 48)
+
+        assert len(rects) == 9
+        assert all(r.width >= 0 and r.height >= 0 for r in rects)
+
+    def test_the_source_rects_tile_the_texture(self):
+        rects = self._sprite(16).get_patch_rects(48, 48)
+        covered = sum(r.width * r.height for r in rects)
+
+        assert covered == 48 * 48
+
+    def test_destination_rects_stay_clamped_for_a_tiny_target(self):
+        """The destination side already handled this; the test pins it so the
+        two sides cannot diverge again."""
+        rects = self._sprite(16).get_dest_rects(0, 0, 4, 4)
+
+        assert all(r.width >= 0 and r.height >= 0 for r in rects)

--- a/tests/test_post_process_stack.py
+++ b/tests/test_post_process_stack.py
@@ -1,0 +1,116 @@
+"""Bookkeeping tests for the post-process stack.
+
+`PostProcessStack` and `RenderGraph` are siblings with the same design -- an
+ordered list plus name lookup -- and they carried the same two defects. The
+graph's were fixed in the pipeline slice; these are the stack's.
+
+Only the bookkeeping is covered here. Applying an effect needs a live GL
+context and stays with the ModernGL integration tests.
+"""
+
+from unittest.mock import MagicMock
+
+from pyguara.graphics.vfx.post_process import PostProcessStack
+
+
+def make_effect(name: str) -> MagicMock:
+    effect = MagicMock()
+    effect.name = name
+    effect.enabled = True
+    return effect
+
+
+def make_stack() -> PostProcessStack:
+    return PostProcessStack(MagicMock(), MagicMock())
+
+
+class TestEffectOrdering:
+    def test_effects_are_returned_in_insertion_order(self) -> None:
+        stack = make_stack()
+        first, second = make_effect("bloom"), make_effect("vignette")
+        stack.add_effect(first)
+        stack.add_effect(second)
+
+        assert stack.effects == [first, second]
+
+    def test_insert_effect_positions_it(self) -> None:
+        stack = make_stack()
+        stack.add_effect(make_effect("vignette"))
+        early = make_effect("bloom")
+        stack.insert_effect(0, early)
+
+        assert stack.effects[0] is early
+
+
+class TestEffectListEncapsulation:
+    def test_the_returned_list_is_a_snapshot(self) -> None:
+        """`effects` handed back the live list, so a caller could empty the
+        stack without releasing a single effect."""
+        stack = make_stack()
+        stack.add_effect(make_effect("bloom"))
+
+        stack.effects.clear()
+
+        assert len(stack.effects) == 1
+
+    def test_mutating_the_snapshot_does_not_reorder_the_stack(self) -> None:
+        stack = make_stack()
+        first, second = make_effect("a"), make_effect("b")
+        stack.add_effect(first)
+        stack.add_effect(second)
+
+        snapshot = stack.effects
+        snapshot.reverse()
+
+        assert stack.effects == [first, second]
+
+
+class TestEffectLookup:
+    def test_get_and_remove_by_name(self) -> None:
+        stack = make_stack()
+        bloom = make_effect("bloom")
+        stack.add_effect(bloom)
+
+        assert stack.get_effect("bloom") is bloom
+        assert stack.remove_effect("bloom") is bloom
+        assert stack.get_effect("bloom") is None
+
+    def test_removing_an_unknown_name_returns_none(self) -> None:
+        assert make_stack().remove_effect("nope") is None
+
+    def test_a_duplicate_effect_name_is_reported(self, caplog) -> None:
+        """Both apply -- the list is the source of truth -- but only the first
+        is reachable by name. Same treatment RenderGraph gives duplicate pass
+        names."""
+        import logging
+
+        stack = make_stack()
+        stack.add_effect(make_effect("bloom"))
+
+        with caplog.at_level(logging.WARNING):
+            stack.add_effect(make_effect("bloom"))
+
+        assert "second post-process effect named 'bloom'" in caplog.text
+        assert len(stack.effects) == 2
+
+    def test_a_unique_name_is_not_reported(self, caplog) -> None:
+        import logging
+
+        stack = make_stack()
+        stack.add_effect(make_effect("bloom"))
+
+        with caplog.at_level(logging.WARNING):
+            stack.add_effect(make_effect("vignette"))
+
+        assert caplog.text == ""
+
+    def test_insert_effect_also_reports_a_duplicate(self, caplog) -> None:
+        import logging
+
+        stack = make_stack()
+        stack.add_effect(make_effect("bloom"))
+
+        with caplog.at_level(logging.WARNING):
+            stack.insert_effect(0, make_effect("bloom"))
+
+        assert "second post-process effect" in caplog.text


### PR DESCRIPTION
Graphics slice 5 of 5: `ninepatch`, `spritesheet`, `atlas`, `materials`, `vfx`, `lighting`. Based on `main`. **This completes the graphics subsystem.**

## 🐞 `get_patch_rects()` produced negative source rectangles

Edges wider than the texture leave the centre with negative extent, and five of the nine rects came back malformed:

```
uniform(40) on a 48x48 texture ->
  Rect(x=40, y=0,  width=-32, height=40)
  Rect(x=0,  y=40, width=40,  height=-32)
  Rect(x=40, y=40, width=-32, height=-32)
```

Those reach the renderer as *geometry*, not as an error.

**The asymmetry is the tell.** `get_dest_rects()` clamps its own input with `max(width, min_size)` — three lines the source side never had. So the destination case was protected and the source case wasn't, in two methods sitting forty lines apart in the same class. Now raises, naming both the edges and the texture size.

`NinePatchMetrics` also accepted negative edges outright — `uniform(-5)` constructed fine, and everything derived from it was malformed.

## The same two defects as last slice

`PostProcessStack.effects` returned the **live list** (so `stack.effects.clear()` emptied the stack without releasing anything), and **duplicate effect names were silent**.

That's the exact pair fixed in `RenderGraph` in #17. The two are siblings — an ordered list plus a name lookup — and had drifted into identical bugs. Fixed identically, with the docstrings now cross-referencing so this isn't rediscovered a third time.

## Tests

**+18.** `test_ninepatch.py` gains metrics validation, the source/destination asymmetry, and a check that valid source rects tile the texture exactly. New `test_post_process_stack.py` covers the stack's bookkeeping.

**1503 pass** (from 1485), ruff clean, mypy clean. Two commits, both verified green in an isolated worktree.

## Scope caveat, same as slice 4

`materials/`, `vfx/effects/` (bloom, vignette) and the shader loading in `post_process.py` need a **live GL context**, so they stay covered only by the ModernGL integration tests. `spritesheet.py`, `atlas.py` and `animation_system.py` were read and probed with degenerate input and behaved correctly.

---

## `pyguara/graphics` complete — all five slices

| Slice | PR | Headline defect |
|---|---|---|
| 1. Boundary | #12 | `Window` reported the requested size, not the granted one |
| 2. Components | #14 | `Box`/`Circle` hard-wired to pygame; camera zoom accepted 0 |
| 3. Backends | #15 | pygame compatibility stubs had drifted from their counterparts |
| 4. Pipeline | #17 | a zero-height window produced a 450px viewport at negative y |
| 5. Assets | *this* | nine-patch produced negative source rects |

### One pattern ran through four of the five

A guard that avoids a crash by **returning a wrong answer**:

- `safe_zoom = 0.001` → coordinates six orders of magnitude out
- `window_ratio = w / h if h != 0 else 0` → a 450px viewport for a 0px window
- the nine-patch's missing clamp → negative geometry
- (and, from Tier 1, the DI container's swallowed disposal errors)

In every case the crash would have been *easier to diagnose* than the plausible-looking garbage substituted for it. Worth watching for in the remaining subsystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
