### PR TITLE
fix(graphics): vsync silently opened a blank OpenGL window

### DIFF
--- a/pyguara/graphics/backends/pygame/pygame_window.py
+++ b/pyguara/graphics/backends/pygame/pygame_window.py
@@ -8,6 +8,9 @@ import pygame
 from pyguara.common.types import Color
 from pyguara.config.types import WindowConfig
 from pyguara.graphics.backends.pygame.conversions import to_pygame_color
+from pyguara.log import get_logger
+
+logger = get_logger(__name__)
 
 
 class PygameWindow:
@@ -20,23 +23,66 @@ class PygameWindow:
         self._is_open = False
 
     def open(self, config: WindowConfig) -> bool:
-        """Create a Pygame display surface."""
-        # Standard Pygame setup
-        # flags = pygame.DOUBLEBUF | pygame.HWSURFACE
-        # For Linux WSL
+        """Create the display surface.
+
+        Args:
+            config: Window settings to open with.
+
+        Returns:
+            True once the surface exists.
+        """
         flags = 0
         self._default_color = config.default_color
         if config.fullscreen:
             flags |= pygame.FULLSCREEN
 
-        self._screen = pygame.display.set_mode(
-            (config.screen_width, config.screen_height),
-            flags,
-            vsync=1 if config.vsync else 0,
+        size = (config.screen_width, config.screen_height)
+        screen: pygame.Surface = pygame.display.set_mode(
+            size, flags, vsync=1 if config.vsync else 0
         )
+
+        if config.vsync and not (flags & pygame.OPENGL):
+            screen = self._drop_vsync_if_promoted_to_opengl(screen, size, flags)
+        self._screen = screen
+
         pygame.display.set_caption(config.title)
         self._is_open = True
         return True
+
+    def _drop_vsync_if_promoted_to_opengl(
+        self, screen: pygame.Surface, size: tuple[int, int], flags: int
+    ) -> pygame.Surface:
+        """Drop vsync if honouring it turned the display into an OpenGL surface.
+
+        SDL can only vsync a hardware-presented surface, so on drivers without
+        a software vsync path pygame quietly adds `pygame.OPENGL` to satisfy
+        the request. This renderer draws by blitting to the display surface,
+        and blits to an OpenGL display surface are never presented -- the
+        window opens, appears in the taskbar, and stays blank forever, with no
+        error anywhere.
+
+        A visible window without vsync beats an invisible one with it, so the
+        surface is recreated without the request and the trade is logged.
+
+        Args:
+            screen: The surface `set_mode` just returned.
+            size: Window size in pixels.
+            flags: The flags originally requested.
+
+        Returns:
+            The display surface to use.
+        """
+        if not screen.get_flags() & pygame.OPENGL:
+            return screen
+
+        logger.warning(
+            "This driver cannot vsync a software surface, so pygame promoted "
+            "the window to OpenGL -- which this renderer cannot draw to, "
+            "leaving the window blank. Recreating it without vsync. Set "
+            "display.vsync = false to silence this."
+        )
+        replacement: pygame.Surface = pygame.display.set_mode(size, flags, vsync=0)
+        return replacement
 
     @property
     def width(self) -> int:

--- a/tests/test_window_boundary.py
+++ b/tests/test_window_boundary.py
@@ -166,3 +166,53 @@ class TestLifecycle:
         window.clear(Color(1, 2, 3))
 
         assert backend.cleared_with == [None, Color(1, 2, 3)]
+
+
+class TestVsyncDoesNotBlankTheWindow:
+    """SDL can only vsync a hardware-presented surface.
+
+    On a driver with no software vsync path, pygame quietly satisfies
+    `vsync=1` by adding `pygame.OPENGL` to the display. This renderer draws by
+    blitting to the display surface, and blits to an OpenGL display surface are
+    never presented -- so the window opens, appears in the taskbar and stays
+    blank, with no error logged anywhere. Reproduced on WSLg/XWayland, where
+    `set_mode((1280, 720), 0, vsync=1)` returns a surface with OPENGL set.
+    """
+
+    def test_the_display_is_never_left_as_an_opengl_surface(self) -> None:
+        import pygame
+
+        from pyguara.graphics.backends.pygame.pygame_window import PygameWindow
+
+        pygame.init()
+        window = PygameWindow()
+        try:
+            window.open(WindowConfig(screen_width=320, screen_height=240, vsync=True))
+            surface = pygame.display.get_surface()
+
+            assert surface is not None
+            assert not surface.get_flags() & pygame.OPENGL, (
+                "the renderer blits to the display surface, which an OpenGL "
+                "surface never presents"
+            )
+        finally:
+            pygame.display.quit()
+            pygame.quit()
+
+    def test_the_surface_is_still_usable_with_vsync_off(self) -> None:
+        import pygame
+
+        from pyguara.graphics.backends.pygame.pygame_window import PygameWindow
+
+        pygame.init()
+        window = PygameWindow()
+        try:
+            window.open(WindowConfig(screen_width=320, screen_height=240, vsync=False))
+            surface = pygame.display.get_surface()
+
+            assert surface is not None
+            assert not surface.get_flags() & pygame.OPENGL
+            assert (window.width, window.height) == (320, 240)
+        finally:
+            pygame.display.quit()
+            pygame.quit()


### PR DESCRIPTION
Reported from running `games/guara_falcao/main.py`: the window appeared in the taskbar, drew nothing, and clicking it did nothing. The log showed a normal startup and the loop ran fine.

## Root cause

SDL can only vsync a **hardware-presented** surface. On a driver with no software vsync path, pygame satisfies `vsync=1` by quietly adding `pygame.OPENGL` to the display:

```
set_mode((1280, 720), 0, vsync=1)  ->  flags=2          OPENGL=True
set_mode((1280, 720), 0, vsync=0)  ->  flags=16777216   OPENGL=False
```

This renderer draws by **blitting to the display surface**, and blits to an OpenGL display surface are never presented. So a request for smoother frames produced *no* frames — and nothing to point at: `set_mode` succeeded, the window existed, no error was logged.

`display.vsync` defaults to `True`, so this affects every demo on an affected driver. `pygame.SCALED` doesn't help — this one promotes to OpenGL either way.

## Why the earlier verification missed it

I ran these demos and posted screenshots showing them rendering correctly. Those screenshots came from `pygame.image.save(pygame.display.get_surface())` — which reads the surface the engine blitted onto. Under OpenGL that surface still holds the right pixels; it just never reaches the screen.

**So my verification proved the renderer draws, not that the window shows anything.** The one check that would have caught it — looking at the actual window — is the one I couldn't do from here. Worth recording: capturing a frame from inside the app is not the same as seeing the app.

## The fix

The window checks whether it was handed an OpenGL surface it never asked for, and if so recreates without vsync and logs the trade:

```
WARNING This driver cannot vsync a software surface, so pygame promoted the
window to OpenGL -- which this renderer cannot draw to, leaving the window
blank. Recreating it without vsync. Set display.vsync = false to silence this.
```

A visible window without vsync beats an invisible one with it.

## Not from the audit

`git log -S` dates the line to **9bdcccd, 2026-01-05** — months before this effort. It survived because nothing in the suite opens a real window, and the manual check read the surface rather than the screen.

## Tests

Two regression tests asserting the display is never left as an OpenGL surface. Confirmed they discriminate — without the fix, `set_mode(..., vsync=1)` returns `OPENGL=True` in this environment.

**1487 pass**, ruff clean, mypy clean.

## Immediate workaround

Before this merges, either edit `config/game_config.json` → `"vsync": false`, or run with the software driver:

```bash
SDL_RENDER_DRIVER=software uv run python games/guara_falcao/main.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
