### PR TITLE
tools: let an agent see what the engine draws, and notice when it stops

### DIFF
--- a/.claude/hooks/graphics_render_check.py
+++ b/.claude/hooks/graphics_render_check.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Warn when an edit to the graphics stack stops a demo drawing anything.
+
+PostToolUse hook on Edit|Write. Reads the hook payload on stdin, and for edits
+under `pyguara/graphics/` boots one demo headlessly through its real bootstrap
+and checks the frame is not a single flat colour -- the same check
+`tests/integration/test_demos_render.py` makes, run in about a second so the
+feedback arrives with the edit rather than at the next test run.
+
+It never blocks. A render break is reported into the transcript; what to do
+about it is the agent's decision, not this script's.
+
+Exits 0 unconditionally, including when the check cannot run at all. A hook
+that fails the turn because `uv` is missing is worse than no hook.
+
+Runs on the system interpreter with no third-party imports, so it works before
+the project environment is synced.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+DEMO = "guara_falcao"
+FRAMES = 20
+TIMEOUT_SECONDS = 120
+
+# 0 = drew something, 1 = flat frame, 2 = the demo raised. Any other code
+# (uv absent, timeout, 127) means the instrument is broken, not the engine.
+REPORTABLE = (1, 2)
+
+
+def target_file(payload: dict) -> Path | None:
+    """Pull the edited path out of a hook payload.
+
+    Args:
+        payload: The decoded PostToolUse stdin JSON.
+
+    Returns:
+        The edited file, or None if the payload names none.
+    """
+    raw = payload.get("tool_input", {}).get("file_path") or payload.get(
+        "tool_response", {}
+    ).get("filePath")
+    return Path(raw) if raw else None
+
+
+def main() -> int:
+    """Run the render check if the edit touched graphics, and report."""
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    edited = target_file(payload)
+    if edited is None or "graphics" not in edited.parts:
+        return 0
+    if "pyguara" not in edited.parts[: edited.parts.index("graphics")]:
+        return 0
+
+    repo = Path(__file__).resolve().parent.parent.parent
+    tool = repo / "tools" / "agent_view.py"
+    if not tool.is_file():
+        return 0
+
+    try:
+        result = subprocess.run(
+            ["uv", "run", "python", str(tool), DEMO, "--frames", str(FRAMES)],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return 0
+
+    if result.returncode not in REPORTABLE:
+        return 0
+
+    try:
+        shown = edited.relative_to(repo)
+    except ValueError:
+        shown = edited
+
+    warning = (
+        f"Render check failed after editing {shown}\n\n"
+        f"{(result.stdout + result.stderr).strip()}\n\n"
+        f"Reproduce: uv run python tools/agent_view.py {DEMO} --frames {FRAMES}"
+    )
+    json.dump(
+        {
+            "systemMessage": "Graphics edit broke the render path (see transcript)",
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": warning,
+            },
+        },
+        sys.stdout,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/graphics_render_check.py\"",
+            "timeout": 150,
+            "statusMessage": "Checking the render path..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ screenshots/
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Frames written by tools/agent_view.py
+.agent-view/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,14 +254,15 @@ entity.add_component(Sprite(texture_path="assets/sprite.png"))
 ### Testing
 - Tests are in `tests/` with separate `tests/integration/` for integration tests
 - Use pytest markers to categorize tests (unit, integration, performance, etc.)
-- There are **no** visual regression tests yet. `syrupy` is installed and
-  active as a pytest plugin, so the `snapshot` fixture is ready to use, but
-  no test calls it. Note the `[tool.syrupy]` block in `pyproject.toml` is
-  inert: syrupy reads none of those keys, and writes to a `__snapshots__`
-  directory beside each test file rather than the path it names.
-- `tests/integration/test_demos_render.py` is currently the only test
-  asserting anything about rendered output, and only that a frame is not a
-  single flat colour.
+- Render pipeline snapshots live in `tests/visual/`, using Syrupy. They
+  record the ordered stream of backend calls one `RenderSystem.flush()`
+  produces -- sort order, batching, and the world-to-screen transform --
+  via a recording `IRenderer`. Nothing rasterises, so they are deterministic
+  and carry none of the platform brittleness of image snapshots. Update
+  them with `pytest tests/visual/ --snapshot-update`, and **read the diff**:
+  a changed snapshot is a changed frame.
+- `tests/integration/test_demos_render.py` complements them at the other
+  end, asserting each demo's real rendered frame is not a single flat colour.
 - Conftest fixtures are in `tests/conftest.py`
 
 ### Type Checking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,11 +254,14 @@ entity.add_component(Sprite(texture_path="assets/sprite.png"))
 ### Testing
 - Tests are in `tests/` with separate `tests/integration/` for integration tests
 - Use pytest markers to categorize tests (unit, integration, performance, etc.)
-- There are **no** visual regression tests. `syrupy` is a dev dependency and
-  `[tool.syrupy]` points at `tests/visual/`, but neither that directory nor
-  any snapshot file exists. `tests/integration/test_demos_render.py` is the
-  only thing asserting anything about rendered output, and it only checks a
-  frame is not a single flat colour.
+- There are **no** visual regression tests yet. `syrupy` is installed and
+  active as a pytest plugin, so the `snapshot` fixture is ready to use, but
+  no test calls it. Note the `[tool.syrupy]` block in `pyproject.toml` is
+  inert: syrupy reads none of those keys, and writes to a `__snapshots__`
+  directory beside each test file rather than the path it names.
+- `tests/integration/test_demos_render.py` is currently the only test
+  asserting anything about rendered output, and only that a frame is not a
+  single flat colour.
 - Conftest fixtures are in `tests/conftest.py`
 
 ### Type Checking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,11 @@ entity.add_component(Sprite(texture_path="assets/sprite.png"))
 ### Testing
 - Tests are in `tests/` with separate `tests/integration/` for integration tests
 - Use pytest markers to categorize tests (unit, integration, performance, etc.)
-- Visual regression tests use Syrupy snapshots in `tests/visual/snapshots/`
+- There are **no** visual regression tests. `syrupy` is a dev dependency and
+  `[tool.syrupy]` points at `tests/visual/`, but neither that directory nor
+  any snapshot file exists. `tests/integration/test_demos_render.py` is the
+  only thing asserting anything about rendered output, and it only checks a
+  frame is not a single flat colour.
 - Conftest fixtures are in `tests/conftest.py`
 
 ### Type Checking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,26 @@ pre-commit run --all-files
 ```bash
 # Run default example scene
 python main.py
+
+# Run a tutorial/capstone demo (see games/README.md for the full list)
+uv run python games/guara_falcao/main.py
 ```
+
+### Seeing what the engine draws (for agents)
+
+An agent cannot look at a window. `tools/agent_view.py` boots a demo
+headlessly, drives it, and writes PNG frames to `.agent-view/`:
+
+```bash
+uv run python tools/agent_view.py --list
+uv run python tools/agent_view.py guara_falcao --frames 120 --shot 1 --shot 119
+uv run python tools/agent_view.py guara_falcao --click 400,265@30 --shot 80
+```
+
+A capture proves the **render path** works. It does **not** prove a window
+appears on screen -- those have already diverged here, when vsync silently
+promoted the display to an OpenGL surface that never presented software blits.
+Read `docs/guides/agent-visual-inspection.md` before reporting on either.
 
 ## Branching and Pull Requests
 

--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -129,8 +129,37 @@ Concerns that outgrew this file, or that need a decision rather than a fix:
 | [#9](https://github.com/Wedeueis/pyguara/issues/9) | pygame reaches into the backend-agnostic core (CC-11) — nine non-backend files across five subsystems |
 | [#16](https://github.com/Wedeueis/pyguara/issues/16) | `IFramebuffer`/`IRenderPass` not `runtime_checkable`; `IRenderPass` vs `BaseRenderPass(ABC)` overlap |
 | [#19](https://github.com/Wedeueis/pyguara/issues/19) | ~2,700 lines of GPU-dependent graphics code are read-audited only, with no headless GL coverage |
+| [#23](https://github.com/Wedeueis/pyguara/issues/23) | `camera.rotation` is applied by `Camera2D.world_to_screen` but ignored by the render path; three definitions of world-to-screen disagree |
 
 ---
+
+### Out-of-band: render pipeline snapshots (PR #22)
+
+Not a queued subsystem. Adding Syrupy snapshots of the backend call stream
+`RenderSystem.flush()` produces turned up a live defect on the first run.
+
+**Found:** the batcher added `viewport.position` to `viewport.center_vec`,
+which is already absolute — the viewport origin was counted twice, displacing
+everything by it. Invisible at fullscreen (origin `(0,0)`), so 1514 tests
+passed over it. Pre-existing from `bb5fa03`, unchanged at `35ed7fa`.
+
+**Latent, not shipped:** nothing produces an offset viewport.
+`RenderSystem.flush()` has one call site passing none, `WorldPass._viewport`
+is never set, `Viewport.create_best_fit` has no production callers, and no
+config option letterboxes.
+
+**The deeper defect:** `particles.py` already had the transform right. Two
+copies of one formula had drifted apart, and under a letterboxed viewport
+they disagreed by the viewport origin — which would have presented as
+particles detaching from the sprites emitting them, not as a uniform shift.
+Both now call `Camera2D.screen_offset()`; a test pins them together.
+
+**Pattern, third instance:** the recurring blind spot here is uniform setup,
+not missing coverage. Every existing viewport test used a fullscreen
+viewport, exactly as every query-cache test used `create_entity()` and every
+config test mocked the filesystem.
+
+**Left open:** issue #23, camera rotation.
 
 ## Cross-Cutting Concerns
 

--- a/docs/guides/agent-visual-inspection.md
+++ b/docs/guides/agent-visual-inspection.md
@@ -57,6 +57,17 @@ you nothing. `boot_process` legitimately draws nothing — it only opens a
 window — so a blank frame there is correct, not a defect. Know what the demo
 is supposed to draw before reading the result.
 
+### Run automatically
+
+Two things use this tool without being asked:
+
+- `tests/integration/test_demos_render.py` asserts every demo draws a
+  non-flat frame. It found `physics_integration` crashing on its first run.
+- `.claude/hooks/graphics_render_check.py` — a warn-only `PostToolUse` hook
+  on edits under `pyguara/graphics/`. Boots `guara_falcao` for 20 frames
+  (~0.6s) and reports into the transcript if the frame comes out flat. It
+  never blocks and always exits 0, including when it cannot run at all.
+
 ## What this proves, and what it does not
 
 **It proves the render path works.** Entities were queried, sprites submitted,
@@ -115,6 +126,25 @@ Get-Process msrdc | Where-Object {\$_.MainWindowTitle -ne ''} |
 
 A title containing `[WARN:COPY MODE]` means WSLg's graphics path is degraded;
 windows may never come to the front, whatever the app does.
+
+### Fixes that do not work here
+
+Forcing the SDL drivers is the suggestion this comes up against most often:
+
+```python
+os.environ["SDL_VIDEODRIVER"] = "x11"       # already the default
+os.environ["SDL_RENDER_DRIVER"] = "software"  # nothing to configure
+```
+
+Tested, with a bare pygame window and no PyGuara in it: the window is
+created, X11 lists it, `msrdc` lists it, and it still does not appear on the
+Windows desktop. Neither variable can help —
+
+- pygame already resolves to `x11` here (`pygame.display.get_driver()`), so
+  the first line changes nothing.
+- `SDL_RENDER_DRIVER` configures SDL's `SDL_Renderer` API. This codebase
+  never creates one — the window is a plain `set_mode` surface — so the
+  second line configures a subsystem that is not in use.
 
 ### Always run the control first
 

--- a/docs/guides/agent-visual-inspection.md
+++ b/docs/guides/agent-visual-inspection.md
@@ -110,13 +110,52 @@ powershell.exe -NoProfile -Command "
 Add-Type -AssemblyName System.Windows.Forms,System.Drawing;
 \$b = [System.Windows.Forms.SystemInformation]::VirtualScreen;
 \$bmp = New-Object System.Drawing.Bitmap \$b.Width, \$b.Height;
-[System.Drawing.Graphics]::FromImage(\$bmp).CopyFromScreen(\$b.X, \$b.Y, 0, 0, \$bmp.Size);
-\$bmp.Save('C:\Users\<you>\AppData\Local\Temp\shot.png')"
+\$g = [System.Drawing.Graphics]::FromImage(\$bmp);
+\$g.CopyFromScreen(\$b.X, \$b.Y, 0, 0, \$bmp.Size);
+\$bmp.Save(\"\$env:TEMP\shot.png\", [System.Drawing.Imaging.ImageFormat]::Png);
+\$g.Dispose(); \$bmp.Dispose()"
 ```
 
-Then read `/mnt/c/Users/<you>/AppData/Local/Temp/shot.png`. Find the window
-first — WSLg windows are hosted by `msrdc`, and X11 coordinates do **not** map
-to Windows desktop coordinates:
+Dispose the `Graphics` and give `Save` an explicit format: without both, it
+throws `ExternalException` and writes nothing while still printing whatever
+you echoed after it.
+
+Read it back from `/mnt/c/Users/<windows-user>/AppData/Local/Temp/shot.png`.
+The Windows account name is often **not** your WSL username — ask for it
+rather than guessing:
+
+```bash
+powershell.exe -NoProfile -Command "\$env:TEMP"
+```
+
+### Reading window coordinates
+
+Two traps, both of which have already cost an hour here.
+
+**The virtual screen origin is not (0,0).** With a monitor to the left of the
+primary, it is negative. A window Windows reports at `(528,208)` is at bitmap
+pixel `(528 - originX, 208 - originY)` in the screenshot — with an origin of
+`(-2560,0)`, that is `(3088,208)`, i.e. the *other* monitor. Print the origin
+alongside the rect, and convert, before concluding a window is missing:
+
+```bash
+powershell.exe -NoProfile -Command "
+\$b = [System.Windows.Forms.SystemInformation]::VirtualScreen;
+Write-Output \"origin=(\$(\$b.X),\$(\$b.Y)) size=\$(\$b.Width)x\$(\$b.Height)\""
+```
+
+**`SetForegroundWindow` will not raise a window over a fullscreen app** when
+called from a background process; Windows refuses the foreground change and
+returns without error. Use `SetWindowPos` with `HWND_TOPMOST` (`-1`) to move
+the window somewhere empty and pin it, then `HWND_NOTOPMOST` (`-2`) to
+release it afterwards.
+
+Also beware stale windows: a window belonging to an already-exited process can
+linger in the enumeration at `(-32000,-32000)` with a tiny size, which is
+Windows' canonical position for a minimised window. Confirm the process is
+alive before believing anything you read about its window.
+
+WSLg windows are hosted by `msrdc`:
 
 ```bash
 powershell.exe -NoProfile -Command "
@@ -124,8 +163,47 @@ Get-Process msrdc | Where-Object {\$_.MainWindowTitle -ne ''} |
   Select-Object MainWindowTitle"
 ```
 
-A title containing `[WARN:COPY MODE]` means WSLg's graphics path is degraded;
-windows may never come to the front, whatever the app does.
+### When no window displays at all
+
+A title prefixed `[WARN:COPY MODE]` means WSLg fell back to copying surfaces
+over RDP instead of redirecting them. Windows then register normally — app
+list, taskbar icon, a real rect, `IsWindowVisible` true — while their pixels
+never reach the Windows compositor. Everything you can query says the window
+is fine; it simply never paints.
+
+The cause is in `/mnt/wslg/weston.log`, at WSLg startup:
+
+```
+rdp_allocate_shared_memory: Failed to open
+  "/mnt/shared_memory/{...}" with error: Input/output error
+RDP backend: use_gfxredir = 0
+```
+
+Check those two lines first:
+
+```bash
+grep -n "use_gfxredir\|rdp_allocate_shared_memory" /mnt/wslg/weston.log
+```
+
+`use_gfxredir = 0` is the fault. `use_gfxredir = 1` and no allocation failure
+means the graphics path is healthy and the problem is elsewhere.
+
+**The fix is to restart WSL** — from Windows, not from inside the distro:
+
+```
+wsl --shutdown
+```
+
+then reopen the terminal. The shared-memory device is created by the Windows
+host when the VM starts, so nothing inside Ubuntu can repair it. If it
+survives a restart, `wsl --update` and shut down again.
+
+Confirmed here: before, every window (including `xmessage`, with no SDL in it
+at all) failed to paint; after, `use_gfxredir = 1`, titles lost the prefix,
+and both a bare pygame window and `guara_falcao` displayed correctly.
+
+Note this clears `/tmp`, so anything scratch you left there is gone.
+`.agent-view/` lives in the repo root and survives.
 
 ### Fixes that do not work here
 
@@ -145,6 +223,10 @@ Windows desktop. Neither variable can help —
 - `SDL_RENDER_DRIVER` configures SDL's `SDL_Renderer` API. This codebase
   never creates one — the window is a plain `set_mode` surface — so the
   second line configures a subsystem that is not in use.
+
+When these were tried, the actual fault was WSLg's graphics redirection being
+off (see "When no window displays at all" above). No environment variable
+inside the distro can reach that; the SDL driver was never the problem.
 
 ### Always run the control first
 

--- a/docs/guides/agent-visual-inspection.md
+++ b/docs/guides/agent-visual-inspection.md
@@ -1,0 +1,154 @@
+# Seeing the engine run, as an agent
+
+An agent working on this engine cannot look at a window. This guide covers how
+to see what the engine draws, how to drive it, and — the part that has already
+caught us out once — what that does **not** tell you.
+
+## The tool
+
+```bash
+uv run python tools/agent_view.py --list
+uv run python tools/agent_view.py guara_falcao --frames 120 --shot 1 --shot 119
+```
+
+It boots a demo through its real bootstrap, advances it a fixed number of
+frames, saves PNGs, and exits. Headless by default (SDL dummy driver), so it
+needs no display and behaves the same on CI.
+
+Frames land in `.agent-view/` (gitignored). Open them with the `Read` tool.
+
+### Driving it
+
+Input goes through the real path — `pygame.event.post()`, drained by the
+window backend's `poll_events()`, dispatched by `InputManager` — so it
+exercises the same code a keypress would.
+
+```bash
+# press a key on frame 30
+uv run python tools/agent_view.py guara_falcao --press RETURN@30 --shot 45
+
+# click a point on frame 30
+uv run python tools/agent_view.py guara_falcao --click 400,265@30 --shot 80
+
+# sample the run
+uv run python tools/agent_view.py physics_integration --every 30 --frames 120
+```
+
+Clicking `400,265` on the title screen presses **START GAME** and transitions
+into gameplay — a useful end-to-end check that UI hit-testing, event dispatch
+and scene switching all work.
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Frames captured, at least one had content |
+| 1 | Every captured frame was a single flat colour |
+| 2 | The demo raised; traceback printed |
+
+Blank frames are flagged individually too:
+
+```
+.agent-view/boot_process_0020.png  BLANK - nothing was drawn
+```
+
+That check exists because a blank frame is the usual way this silently tells
+you nothing. `boot_process` legitimately draws nothing — it only opens a
+window — so a blank frame there is correct, not a defect. Know what the demo
+is supposed to draw before reading the result.
+
+## What this proves, and what it does not
+
+**It proves the render path works.** Entities were queried, sprites submitted,
+batches flushed, UI laid out and drawn. If a frame has the right content, the
+engine drew the right thing.
+
+**It does not prove a window appears on screen.** The tool reads the surface
+the renderer blitted onto. Whether that surface reaches a display is a
+separate question with separate failure modes.
+
+Those two have already diverged here. With `display.vsync` enabled, pygame
+silently promoted the display to an **OpenGL** surface, and software blits are
+never presented to an OpenGL surface:
+
+```
+set_mode((1280, 720), 0, vsync=1)  ->  flags=2          OPENGL=True
+set_mode((1280, 720), 0, vsync=0)  ->  flags=16777216   OPENGL=False
+```
+
+Captures looked perfect. The real window was blank. The capture read the
+surface that still held the pixels; nothing was presenting it.
+
+**So: never report "the demo renders correctly" on the strength of a capture
+alone.** Say "the render path produces the expected frame", which is what you
+actually verified.
+
+## Checking that a window really displays
+
+This needs a channel outside WSL. Two things that do **not** work here:
+
+- **`ffmpeg -f x11grab`** — captures black even for a bare pygame window
+  filling the screen red. WSLg composites through Wayland; the XWayland root
+  window does not hold the real pixels.
+- **Playwright / browser tooling** — irrelevant; this is a native SDL window.
+
+What does work is a screenshot from the Windows side:
+
+```bash
+powershell.exe -NoProfile -Command "
+Add-Type -AssemblyName System.Windows.Forms,System.Drawing;
+\$b = [System.Windows.Forms.SystemInformation]::VirtualScreen;
+\$bmp = New-Object System.Drawing.Bitmap \$b.Width, \$b.Height;
+[System.Drawing.Graphics]::FromImage(\$bmp).CopyFromScreen(\$b.X, \$b.Y, 0, 0, \$bmp.Size);
+\$bmp.Save('C:\Users\<you>\AppData\Local\Temp\shot.png')"
+```
+
+Then read `/mnt/c/Users/<you>/AppData/Local/Temp/shot.png`. Find the window
+first — WSLg windows are hosted by `msrdc`, and X11 coordinates do **not** map
+to Windows desktop coordinates:
+
+```bash
+powershell.exe -NoProfile -Command "
+Get-Process msrdc | Where-Object {\$_.MainWindowTitle -ne ''} |
+  Select-Object MainWindowTitle"
+```
+
+A title containing `[WARN:COPY MODE]` means WSLg's graphics path is degraded;
+windows may never come to the front, whatever the app does.
+
+### Always run the control first
+
+Before concluding anything about the engine, run a window with **no PyGuara in
+it at all**:
+
+```python
+import time, pygame
+pygame.init()
+s = pygame.display.set_mode((800, 600))
+pygame.display.set_caption("CONTROL")
+t = time.time()
+while time.time() - t < 20:
+    pygame.event.pump(); s.fill((220, 40, 40)); pygame.display.flip(); time.sleep(0.016)
+```
+
+If that red window does not appear, the engine cannot appear either, and the
+problem is the environment. Skipping this control cost an hour of blaming the
+engine for a WSLg display fault.
+
+## Adding a demo
+
+Add one line to `DEMOS` in `tools/agent_view.py`:
+
+```python
+"my_demo": ("games.my_demo.bootstrap", "games.my_demo.scenes", "MyScene"),
+```
+
+The registry is explicit rather than discovered, so a broken demo names itself
+instead of failing during discovery.
+
+## Related
+
+- `games/validate_demos.py` — boots four capstone demos for 30 frames each and
+  reports pass/fail. Faster than this tool when you only need "does it crash".
+- Issue #19 — GPU-dependent graphics code (framebuffers, passes, materials,
+  effects) has no headless coverage. This tool exercises the pygame path only.

--- a/games/physics_integration/scenes.py
+++ b/games/physics_integration/scenes.py
@@ -57,7 +57,10 @@ class PhysicsScene(Scene):
         box.add_component(Collider(dimensions=[50, 50]))
         box.add_component(BoxSprite(color=Color(255, 0, 0), size=Vector2(50, 50)))
 
-        print(f"Created entities. Gravity set to {physics_engine.gravity}")
+        print(
+            f"Created entities. Gravity set to "
+            f"({physics_config.gravity_x}, {physics_config.gravity_y})"
+        )
 
     def on_exit(self) -> None:
         """Clean up physics."""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
       - Zero to Hero Tutorial: guides/zero_to_hero.md
       - Architecture & Style: guides/Archictecture & Style Guide.md
       - Project Structure: guides/PROJECT_STRUCTURE.md
+      - Visual Inspection (agents): guides/agent-visual-inspection.md
   - Core:
       - Architecture: core/architecture.md
       - Entity Component System: core/ecs.md

--- a/pyguara/graphics/components/camera.py
+++ b/pyguara/graphics/components/camera.py
@@ -205,6 +205,30 @@ class Camera2D:
         """
         self.offset = Vector2(width / 2, height / 2)
 
+    def screen_offset(self, viewport: Rect) -> Vector2:
+        """Compute the translation mapping a zoomed world point into a viewport.
+
+        Screen position is `world * zoom + offset`, so a caller batching many
+        points computes this once and adds it per point.
+
+        `viewport.center_vec` is `(centerx, centery)` and already absolute --
+        it carries the viewport's origin. Adding `viewport.position` on top of
+        it double-counts that origin, which is what the batcher used to do;
+        a fullscreen viewport hid it because its origin is (0, 0).
+
+        Note this deliberately ignores `self.rotation`, because the render
+        path does: neither the batcher nor the particle system rotates. It is
+        therefore *not* equivalent to `world_to_screen`, which does rotate and
+        centres on `self.offset` rather than the viewport.
+
+        Args:
+            viewport: The region being drawn into.
+
+        Returns:
+            The offset to add to every zoomed world position.
+        """
+        return viewport.center_vec - (self.position * self.zoom)
+
     def world_to_screen(self, world_pos: Vector2) -> Vector2:
         """
         Transform a point from World Space to Screen Space.

--- a/pyguara/graphics/components/particles.py
+++ b/pyguara/graphics/components/particles.py
@@ -282,7 +282,7 @@ class ParticleSystem:
         batches: dict[Texture, list[tuple[float, float]]] = {}
         zoom = camera.zoom
 
-        offset_vec = viewport.center_vec - (camera.position * zoom)
+        offset_vec = camera.screen_offset(viewport)
         offset_x, offset_y = offset_vec.x, offset_vec.y
 
         for p in self._pool:

--- a/pyguara/graphics/pipeline/batch.py
+++ b/pyguara/graphics/pipeline/batch.py
@@ -57,9 +57,13 @@ class Batcher:
 
         # Optimization: Pre-calculate viewport offset
         # screen_pos = (world * zoom) + offset
-        offset = (
-            viewport.center_vec - (camera.position * camera.zoom)
-        ) + viewport.position
+        #
+        # `center_vec` is (centerx, centery) -- already absolute, so it
+        # carries the viewport's origin. Adding `viewport.position` on top
+        # counted that origin twice and displaced everything by it, which a
+        # fullscreen viewport hides because its origin is (0, 0). Only a
+        # letterboxed or split-screen viewport ever showed it.
+        offset = viewport.center_vec - (camera.position * camera.zoom)
         zoom = camera.zoom
 
         for cmd in sorted_commands:

--- a/pyguara/graphics/pipeline/batch.py
+++ b/pyguara/graphics/pipeline/batch.py
@@ -55,15 +55,9 @@ class Batcher:
         current_scales: list[tuple[float, float]] = []
         has_transforms = False
 
-        # Optimization: Pre-calculate viewport offset
+        # Optimization: Pre-calculate viewport offset once for the frame.
         # screen_pos = (world * zoom) + offset
-        #
-        # `center_vec` is (centerx, centery) -- already absolute, so it
-        # carries the viewport's origin. Adding `viewport.position` on top
-        # counted that origin twice and displaced everything by it, which a
-        # fullscreen viewport hides because its origin is (0, 0). Only a
-        # letterboxed or split-screen viewport ever showed it.
-        offset = viewport.center_vec - (camera.position * camera.zoom)
+        offset = camera.screen_offset(viewport)
         zoom = camera.zoom
 
         for cmd in sorted_commands:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -339,8 +339,3 @@ deps =
 commands =
     mypy pyguara
 """
-
-# Syrupy Configuration
-[tool.syrupy]
-pytest_snapshot_dir = "tests/visual/snapshots"
-include_paths = ["tests/visual/"]

--- a/tests/integration/test_demos_render.py
+++ b/tests/integration/test_demos_render.py
@@ -1,0 +1,110 @@
+"""Every demo must actually draw something.
+
+`games/validate_demos.py` boots four demos and checks they do not crash. Not
+crashing is a weaker property than rendering: a renderer that silently
+submitted nothing, or cleared to a colour and drew no entities, passes it
+comfortably.
+
+These tests boot each demo headlessly and assert the frame is not a single
+flat colour. That is deliberately a low bar -- it catches "the render path
+produced nothing", not "the render path produced the wrong thing" -- but it is
+the bar nothing was holding.
+
+Scope: this exercises the pygame path only, and it reads the surface the
+renderer blitted onto. It says nothing about whether a window appears on
+screen; see docs/guides/agent-visual-inspection.md for why those differ.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.agent_view import DEMOS, is_blank  # noqa: E402
+
+# boot_process only opens a window and draws nothing; that is its whole point
+# as tutorial module 1, so a flat frame there is correct rather than a defect.
+DEMOS_THAT_DRAW = sorted(set(DEMOS) - {"boot_process"})
+
+FRAMES = 20
+
+
+def render_demo(demo: str):
+    """Boot a demo headlessly and return its last frame.
+
+    Args:
+        demo: Key from `tools.agent_view.DEMOS`.
+
+    Returns:
+        The display surface after `FRAMES` frames.
+    """
+    import pygame
+
+    from pyguara.application.application import Application
+    from pyguara.events.dispatcher import EventDispatcher
+
+    bootstrap_mod, scenes_mod, scene_name = DEMOS[demo]
+    configure = importlib.import_module(bootstrap_mod).configure_game_container
+    scene_class = getattr(importlib.import_module(scenes_mod), scene_name)
+
+    container = configure()
+    app = container.get(Application)
+
+    tick = 0
+    captured: list[pygame.Surface] = []
+    original_render = app._render
+
+    def render_and_capture() -> None:
+        nonlocal tick
+        original_render()
+        tick += 1
+        if tick >= FRAMES:
+            surface = pygame.display.get_surface()
+            if surface is not None:
+                # Copy: the live surface keeps being drawn over after this.
+                captured.append(surface.copy())
+            app._is_running = False
+
+    app._render = render_and_capture  # type: ignore[method-assign]
+
+    dispatcher = (
+        container.get(EventDispatcher)
+        if EventDispatcher in container._services
+        else app._event_dispatcher
+    )
+    app.run(starting_scene=scene_class(dispatcher))
+
+    assert captured, f"{demo} never reached frame {FRAMES}"
+    return captured[0]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("demo", DEMOS_THAT_DRAW)
+def test_the_demo_draws_something(demo: str) -> None:
+    """The demo's frame is not a single flat colour."""
+    surface = render_demo(demo)
+
+    assert not is_blank(surface), (
+        f"{demo} rendered a flat frame after {FRAMES} frames. The render path "
+        f"produced nothing -- entities, sprites or the UI never reached the "
+        f"renderer. Reproduce with: "
+        f"uv run python tools/agent_view.py {demo} --frames {FRAMES}"
+    )
+
+
+@pytest.mark.integration
+def test_a_demo_that_draws_nothing_is_still_detected() -> None:
+    """The check is only worth anything if it can fail.
+
+    boot_process opens a window and draws nothing, so it doubles as the
+    negative control: if this ever stops reading as blank, `is_blank` has
+    become too lax and every assertion above is worthless.
+    """
+    assert is_blank(render_demo("boot_process"))

--- a/tests/test_batching_enhanced.py
+++ b/tests/test_batching_enhanced.py
@@ -294,3 +294,36 @@ def test_batching_performance_transformed_sprites(benchmark):
     assert result[0].transforms_enabled
     assert len(result[0].rotations) == 1000
     assert len(result[0].scales) == 1000
+
+
+@pytest.mark.parametrize(
+    ("x", "y", "width", "height"),
+    [
+        (0, 0, 800, 600),  # fullscreen: origin (0,0) hides the bug
+        (0, 60, 800, 480),  # letterboxed
+        (160, 0, 480, 600),  # pillarboxed
+        (400, 300, 400, 300),  # split-screen, bottom-right quadrant
+    ],
+)
+def test_the_camera_lands_on_the_viewport_centre(x, y, width, height):
+    """A sprite at the camera's position draws at the centre of the viewport.
+
+    The offset used to be `viewport.center_vec + viewport.position`, but
+    `center_vec` is `(centerx, centery)` and already absolute, so the origin
+    was counted twice and every sprite was displaced by it. A fullscreen
+    viewport has origin (0, 0), which hid it from every other test here.
+    """
+    viewport = Viewport(x, y, width, height)
+    camera = Camera2D(width, height)
+    camera.position = Vector2(500, 500)
+
+    command = RenderCommand(
+        texture=MockTexture("centred"),
+        world_position=Vector2(500, 500),
+        layer=0,
+        z_index=0,
+    )
+
+    batches = Batcher().create_batches([command], camera, viewport)
+
+    assert batches[0].destinations[0] == (x + width / 2, y + height / 2)

--- a/tests/test_batching_enhanced.py
+++ b/tests/test_batching_enhanced.py
@@ -327,3 +327,54 @@ def test_the_camera_lands_on_the_viewport_centre(x, y, width, height):
     batches = Batcher().create_batches([command], camera, viewport)
 
     assert batches[0].destinations[0] == (x + width / 2, y + height / 2)
+
+
+@pytest.mark.parametrize(
+    ("x", "y", "width", "height"),
+    [(0, 0, 800, 600), (0, 60, 800, 480), (160, 0, 480, 600), (400, 300, 400, 300)],
+)
+def test_particles_land_where_their_sprites_do(x, y, width, height):
+    """The particle system and the batcher must agree on world-to-screen.
+
+    They are two callers of the same transform. When they disagreed -- the
+    batcher added `viewport.position`, the particle system did not -- the
+    symptom under a letterboxed viewport was not "everything shifted", which
+    is easy to spot. It was particles detaching from the sprites emitting
+    them: smoke drifting off its engine, sparks landing away from the impact.
+
+    Both now go through `Camera2D.screen_offset`; this pins them together so
+    a future change to one cannot silently desynchronise the other.
+    """
+    from pyguara.graphics.components.particles import ParticleSystem
+
+    viewport = Viewport(x, y, width, height)
+    camera = Camera2D(width, height)
+    camera.position = Vector2(120, 340)
+    camera.zoom = 1.5
+
+    world_position = Vector2(500, 500)
+    texture = MockTexture("shared")
+
+    command = RenderCommand(
+        texture=texture, world_position=world_position, layer=0, z_index=0
+    )
+    sprite_destination = Batcher().create_batches([command], camera, viewport)[0]
+
+    system = ParticleSystem(capacity=1)
+    # speed=0 so the particle stays exactly where it was emitted; emit()
+    # otherwise gives it a random velocity, and this test is about the
+    # transform, not the simulation.
+    system.emit(texture, world_position, count=1, speed=0.0)
+
+    recorded: list[tuple[float, float]] = []
+
+    class CaptureBackend:
+        width = 800
+        height = 600
+
+        def render_batch(self, batch):
+            recorded.extend(batch.destinations)
+
+    system.render(CaptureBackend(), camera, viewport)
+
+    assert recorded == sprite_destination.destinations

--- a/tests/visual/__init__.py
+++ b/tests/visual/__init__.py
@@ -1,0 +1,1 @@
+"""Snapshot tests for the rendering pipeline."""

--- a/tests/visual/__snapshots__/test_render_pipeline_snapshots.ambr
+++ b/tests/visual/__snapshots__/test_render_pipeline_snapshots.ambr
@@ -1,0 +1,67 @@
+# serializer version: 1
+# name: test_a_letterboxed_viewport_is_passed_through_verbatim
+  list([
+    'set_viewport x=0 y=60 w=800 h=480',
+    'clear rgba=(0,0,0,255)',
+    'begin_frame',
+    'render_batch hero.png n=1 transforms=off dest=[(400.000,300.000)]',
+    'end_frame',
+  ])
+# ---
+# name: test_an_empty_frame_still_sets_up_and_tears_down
+  list([
+    'set_viewport x=0 y=0 w=800 h=600',
+    'clear rgba=(0,0,0,255)',
+    'begin_frame',
+    'end_frame',
+  ])
+# ---
+# name: test_interleaved_textures_split_into_separate_batches
+  list([
+    'set_viewport x=0 y=0 w=800 h=600',
+    'clear rgba=(0,0,0,255)',
+    'begin_frame',
+    'render_batch hero.png n=1 transforms=off dest=[(400.000,300.000)]',
+    'render_batch tile.png n=1 transforms=off dest=[(432.000,300.000)]',
+    'render_batch hero.png n=1 transforms=off dest=[(464.000,300.000)]',
+    'render_batch tile.png n=1 transforms=off dest=[(496.000,300.000)]',
+    'end_frame',
+  ])
+# ---
+# name: test_one_texture_makes_one_batch
+  list([
+    'set_viewport x=0 y=0 w=800 h=600',
+    'clear rgba=(0,0,0,255)',
+    'begin_frame',
+    'render_batch hero.png n=4 transforms=off dest=[(400.000,300.000), (432.000,300.000), (464.000,300.000), (496.000,300.000)]',
+    'end_frame',
+  ])
+# ---
+# name: test_rotation_and_scale_switch_the_batch_to_the_transform_path
+  list([
+    'set_viewport x=0 y=0 w=800 h=600',
+    'clear rgba=(0,0,0,255)',
+    'begin_frame',
+    'render_batch hero.png n=2 transforms=on dest=[(400.000,300.000), (464.000,300.000)] rot=[45.000, 0.000] scale=[(1.000,1.000), (2.000,0.500)]',
+    'end_frame',
+  ])
+# ---
+# name: test_sprites_are_drawn_back_to_front
+  list([
+    'set_viewport x=0 y=0 w=800 h=600',
+    'clear rgba=(0,0,0,255)',
+    'begin_frame',
+    'render_batch tile.png n=2 transforms=off dest=[(400.000,300.000), (400.000,300.000)]',
+    'render_batch hero.png n=2 transforms=off dest=[(400.000,300.000), (400.000,300.000)]',
+    'end_frame',
+  ])
+# ---
+# name: test_the_camera_transform_reaches_the_batch
+  list([
+    'set_viewport x=0 y=0 w=800 h=600',
+    'clear rgba=(0,0,0,255)',
+    'begin_frame',
+    'render_batch hero.png n=3 transforms=off dest=[(400.000,300.000), (600.000,300.000), (400.000,500.000)]',
+    'end_frame',
+  ])
+# ---

--- a/tests/visual/test_render_pipeline_snapshots.py
+++ b/tests/visual/test_render_pipeline_snapshots.py
@@ -1,0 +1,283 @@
+"""Snapshot the whole backend call stream a frame produces.
+
+The pipeline already has unit tests: the batcher's grouping, the viewport's
+letterbox maths, the queue's ordering. Each asserts its own slice. None
+captures what a *frame* actually turns into -- the ordered sequence of calls
+`RenderSystem.flush()` makes on the backend, with the world-to-screen
+transform already applied.
+
+That sequence is where a refactor's cross-cutting mistakes show up: a sort
+that stops being stable, a camera transform that drifts by half a pixel, a
+batch that silently splits in two, a viewport recomputed when it should be
+reused. A unit test asserting `len(batches) == 1` sails past most of those.
+
+The recording backend below implements `IRenderer` structurally, so these
+also fail if the protocol and the pipeline drift apart.
+
+Why this is deterministic, and safe to snapshot: nothing here rasterises.
+There is no font, no SDL surface, no GPU -- only Python float arithmetic on
+fixed inputs. Positions are rounded to three decimals so a last-bit
+difference cannot flip a snapshot red on its own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyguara.common.types import Color, Rect, Vector2
+from pyguara.graphics.components.camera import Camera2D
+from pyguara.graphics.pipeline.render_system import RenderSystem
+from pyguara.graphics.pipeline.viewport import Viewport
+from pyguara.graphics.types import Layer, RenderBatch
+from pyguara.resources.types import Texture
+
+pytestmark = pytest.mark.integration
+
+
+class FakeTexture(Texture):
+    """A texture with a name and a size, and no pixels behind it."""
+
+    def __init__(self, name: str, width: int = 64, height: int = 64) -> None:
+        """Create a named texture of a fixed size."""
+        super().__init__(f"{name}.png")
+        self._width = width
+        self._height = height
+
+    @property
+    def width(self) -> int:
+        """Width in pixels."""
+        return self._width
+
+    @property
+    def height(self) -> int:
+        """Height in pixels."""
+        return self._height
+
+    @property
+    def native_handle(self) -> None:
+        """No backend object exists for a fake texture."""
+        return None
+
+
+class Sprite:
+    """The minimum a thing needs to satisfy `Renderable`."""
+
+    def __init__(
+        self,
+        texture: Texture,
+        position: Vector2,
+        layer: int,
+        z_index: float,
+        rotation: float = 0.0,
+        scale: Vector2 | None = None,
+    ) -> None:
+        """Create a renderable at a world position on a layer."""
+        self.texture = texture
+        self.position = position
+        self.layer = layer
+        self.z_index = z_index
+        self.rotation = rotation
+        self.scale = scale if scale is not None else Vector2(1, 1)
+        self.material = None
+
+
+def _f(value: float) -> str:
+    """Format a float for the snapshot.
+
+    Three decimals: enough to catch a real transform change, coarse enough
+    that float noise cannot fail a run on its own.
+    """
+    return f"{value:.3f}"
+
+
+class RecordingRenderer:
+    """An `IRenderer` that writes down every call instead of drawing it."""
+
+    def __init__(self, width: int = 800, height: int = 600) -> None:
+        """Create a recorder reporting a fixed surface size."""
+        self._width = width
+        self._height = height
+        self.calls: list[str] = []
+
+    @property
+    def width(self) -> int:
+        """Surface width in pixels."""
+        return self._width
+
+    @property
+    def height(self) -> int:
+        """Surface height in pixels."""
+        return self._height
+
+    def clear(self, color: Color) -> None:
+        """Record a clear."""
+        self.calls.append(f"clear rgba=({color.r},{color.g},{color.b},{color.a})")
+
+    def set_viewport(self, viewport: Rect) -> None:
+        """Record a viewport change."""
+        self.calls.append(
+            f"set_viewport x={viewport.x} y={viewport.y} "
+            f"w={viewport.width} h={viewport.height}"
+        )
+
+    def reset_viewport(self) -> None:
+        """Record a viewport reset."""
+        self.calls.append("reset_viewport")
+
+    def begin_frame(self) -> None:
+        """Record the start of a frame."""
+        self.calls.append("begin_frame")
+
+    def end_frame(self) -> None:
+        """Record the end of a frame."""
+        self.calls.append("end_frame")
+
+    def present(self) -> None:
+        """Record a present."""
+        self.calls.append("present")
+
+    def draw_texture(
+        self,
+        texture: Texture,
+        destination: Vector2,
+        rotation: float = 0.0,
+        scale: Vector2 = Vector2(1, 1),
+    ) -> None:
+        """Record a single texture draw."""
+        self.calls.append(
+            f"draw_texture {texture.path} at=({_f(destination.x)},"
+            f"{_f(destination.y)}) rot={_f(rotation)}"
+        )
+
+    def draw_rect(self, rect: Rect, color: Color, width: int = 0) -> None:
+        """Record a rectangle draw."""
+        self.calls.append(f"draw_rect {rect.x},{rect.y},{rect.width},{rect.height}")
+
+    def draw_circle(
+        self, center: Vector2, radius: float, color: Color, width: int = 0
+    ) -> None:
+        """Record a circle draw."""
+        self.calls.append(f"draw_circle at=({_f(center.x)},{_f(center.y)})")
+
+    def draw_line(
+        self, start: Vector2, end: Vector2, color: Color, width: int = 1
+    ) -> None:
+        """Record a line draw."""
+        self.calls.append("draw_line")
+
+    def render_batch(self, batch: RenderBatch) -> None:
+        """Record a batch, including where every instance landed on screen."""
+        destinations = ", ".join(f"({_f(x)},{_f(y)})" for x, y in batch.destinations)
+        line = (
+            f"render_batch {batch.texture.path} n={len(batch.destinations)} "
+            f"transforms={'on' if batch.transforms_enabled else 'off'} "
+            f"dest=[{destinations}]"
+        )
+        if batch.transforms_enabled:
+            rotations = ", ".join(_f(r) for r in batch.rotations)
+            scales = ", ".join(f"({_f(x)},{_f(y)})" for x, y in batch.scales)
+            line += f" rot=[{rotations}] scale=[{scales}]"
+        self.calls.append(line)
+
+
+def render(
+    sprites: list[Sprite],
+    camera: Camera2D | None = None,
+    viewport: Viewport | None = None,
+) -> list[str]:
+    """Submit sprites, flush one frame, and return the recorded call stream.
+
+    Args:
+        sprites: Renderables to submit, in submission order.
+        camera: Active camera. Defaults to an unmoved 800x600 camera.
+        viewport: Optional explicit viewport.
+
+    Returns:
+        Every call the pipeline made on the backend, in order.
+    """
+    backend = RecordingRenderer()
+    system = RenderSystem(backend)
+    for sprite in sprites:
+        system.submit(sprite)
+    system.flush(camera or Camera2D(800, 600), viewport)
+    return backend.calls
+
+
+HERO = FakeTexture("hero")
+TILE = FakeTexture("tile")
+
+
+def test_an_empty_frame_still_sets_up_and_tears_down(snapshot) -> None:
+    """A frame with nothing in it still clears and brackets itself."""
+    assert render([]) == snapshot
+
+
+def test_sprites_are_drawn_back_to_front(snapshot) -> None:
+    """Submission order must not survive; layer then z_index decides.
+
+    The sprites go in deliberately worst-first: UI before background, and a
+    high z before a low one within the same layer.
+    """
+    sprites = [
+        Sprite(HERO, Vector2(0, 0), Layer.UI, z_index=0),
+        Sprite(TILE, Vector2(0, 0), Layer.BACKGROUND, z_index=0),
+        Sprite(HERO, Vector2(0, 0), Layer.ENTITIES, z_index=99),
+        Sprite(TILE, Vector2(0, 0), Layer.ENTITIES, z_index=1),
+    ]
+    assert render(sprites) == snapshot
+
+
+def test_the_camera_transform_reaches_the_batch(snapshot) -> None:
+    """A moved, zoomed camera must show up in the screen positions."""
+    camera = Camera2D(800, 600)
+    camera.position = Vector2(100, 50)
+    camera.zoom = 2.0
+    sprites = [
+        Sprite(HERO, Vector2(100, 50), Layer.ENTITIES, z_index=0),
+        Sprite(HERO, Vector2(200, 50), Layer.ENTITIES, z_index=1),
+        Sprite(HERO, Vector2(100, 150), Layer.ENTITIES, z_index=2),
+    ]
+    assert render(sprites, camera=camera) == snapshot
+
+
+def test_one_texture_makes_one_batch(snapshot) -> None:
+    """Four sprites sharing a texture must not become four draw calls."""
+    sprites = [
+        Sprite(HERO, Vector2(i * 32, 0), Layer.ENTITIES, z_index=i) for i in range(4)
+    ]
+    assert render(sprites) == snapshot
+
+
+def test_interleaved_textures_split_into_separate_batches(snapshot) -> None:
+    """Alternating textures cannot be merged without reordering them.
+
+    This is the case where a batching change is most likely to go wrong:
+    merging these would be faster and visibly incorrect.
+    """
+    sprites = [
+        Sprite(HERO if i % 2 == 0 else TILE, Vector2(i * 32, 0), Layer.ENTITIES, i)
+        for i in range(4)
+    ]
+    assert render(sprites) == snapshot
+
+
+def test_rotation_and_scale_switch_the_batch_to_the_transform_path(snapshot) -> None:
+    """A rotated or scaled sprite carries its transform through to the batch."""
+    sprites = [
+        Sprite(HERO, Vector2(0, 0), Layer.ENTITIES, 0, rotation=45.0),
+        Sprite(HERO, Vector2(64, 0), Layer.ENTITIES, 1, scale=Vector2(2, 0.5)),
+    ]
+    assert render(sprites) == snapshot
+
+
+def test_a_letterboxed_viewport_is_passed_through_verbatim(snapshot) -> None:
+    """An explicit viewport reaches the backend, and content centres in it.
+
+    The sprite sits at the camera's position, so it must land at the centre
+    of the letterboxed band -- (400, 300) here -- not offset by the band's
+    origin. Generating this snapshot is what exposed that it used to be
+    (400, 360); see `test_the_camera_lands_on_the_viewport_centre`.
+    """
+    viewport = Viewport(0, 60, 800, 480)
+    sprites = [Sprite(HERO, Vector2(0, 0), Layer.ENTITIES, z_index=0)]
+    assert render(sprites, viewport=viewport) == snapshot

--- a/tools/agent_view.py
+++ b/tools/agent_view.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python
+"""Run a PyGuara demo headlessly and save frames, so an agent can see it.
+
+An agent working on this engine cannot look at a window. This boots a demo,
+advances it a fixed number of frames, optionally feeds it input, and writes PNG
+frames it can open.
+
+    uv run python tools/agent_view.py --list
+    uv run python tools/agent_view.py guara_falcao --frames 120 --shot 1 --shot 119
+    uv run python tools/agent_view.py ui_scene_graph --click 400,300@30 --shot 45
+    uv run python tools/agent_view.py physics_integration --every 30 --frames 120
+
+What this proves, and what it does not:
+
+    It reads the surface the renderer drew onto. That proves the *render path*
+    works -- entities queried, sprites submitted, batches flushed, UI laid out.
+
+    It does NOT prove a window appears on screen. Those are different
+    questions, and they have already diverged once here: with `vsync` enabled
+    pygame silently promoted the display to an OpenGL surface, which never
+    presents software blits. Captures looked perfect; the real window was
+    blank.
+
+    To check that a window actually displays, see
+    docs/guides/agent-visual-inspection.md -- it needs a channel outside WSL.
+
+Frames are checked for being a single flat colour and flagged, because a blank
+frame is the most common way this silently tells you nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+# Headless by default: surface capture works identically under the dummy
+# driver, needs no display, and is deterministic on CI. --windowed overrides.
+if "--windowed" not in sys.argv:
+    os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+    os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+import pygame  # noqa: E402  (must follow the driver selection above)
+
+DEFAULT_OUT = REPO_ROOT / ".agent-view"
+
+# name -> (bootstrap module, scene module, scene class). Explicit rather than
+# derived, so a broken demo names itself instead of failing during discovery.
+DEMOS: dict[str, tuple[str, str, str]] = {
+    "asset_pipeline": (
+        "games.asset_pipeline.bootstrap",
+        "games.asset_pipeline.scenes",
+        "AssetScene",
+    ),
+    "boot_process": (
+        "games.boot_process.bootstrap",
+        "games.boot_process.scenes",
+        "BootScene",
+    ),
+    "ecs_mental_model": (
+        "games.ecs_mental_model.bootstrap",
+        "games.ecs_mental_model.scenes",
+        "ECSScene",
+    ),
+    "guara_falcao": (
+        "games.guara_falcao.bootstrap",
+        "games.guara_falcao.scenes",
+        "TitleScene",
+    ),
+    "input_events": (
+        "games.input_events.bootstrap",
+        "games.input_events.scenes",
+        "InputScene",
+    ),
+    "physics_integration": (
+        "games.physics_integration.bootstrap",
+        "games.physics_integration.scenes",
+        "PhysicsScene",
+    ),
+    "protocolo_bandeira": (
+        "games.protocolo_bandeira.bootstrap",
+        "games.protocolo_bandeira.scenes",
+        "MenuScene",
+    ),
+    "true_coral": (
+        "games.true_coral.bootstrap",
+        "games.true_coral.scenes",
+        "MenuScene",
+    ),
+    "ui_scene_graph": (
+        "games.ui_scene_graph.bootstrap",
+        "games.ui_scene_graph.scenes",
+        "MenuScene",
+    ),
+}
+
+
+@dataclass
+class Script:
+    """What to do on which frame."""
+
+    frames: int = 120
+    shots: set[int] = field(default_factory=set)
+    keys: list[tuple[int, int]] = field(default_factory=list)
+    clicks: list[tuple[int, int, int]] = field(default_factory=list)
+
+
+def parse_at(value: str, what: str) -> tuple[str, int]:
+    """Split a `payload@tick` argument.
+
+    Args:
+        value: The raw argument, e.g. `"SPACE@30"` or `"400,300@45"`.
+        what: Argument name, for the error message.
+
+    Returns:
+        The payload and the tick it applies to. Tick defaults to 1.
+
+    Raises:
+        SystemExit: If the tick is not an integer.
+    """
+    payload, _, tick = value.partition("@")
+    if not tick:
+        return payload, 1
+    if not tick.isdigit():
+        raise SystemExit(f"--{what}: '{tick}' is not a frame number in {value!r}")
+    return payload, int(tick)
+
+
+def resolve_key(name: str) -> int:
+    """Turn a key name into a pygame key code.
+
+    Args:
+        name: A pygame key name, with or without the `K_` prefix -- `SPACE`,
+            `K_SPACE` and `space` all work.
+
+    Returns:
+        The pygame key constant.
+
+    Raises:
+        SystemExit: If no such key exists.
+    """
+    candidate = name if name.startswith("K_") else f"K_{name.upper()}"
+    code = getattr(pygame, candidate, None)
+    if not isinstance(code, int):
+        raise SystemExit(f"--press: unknown key {name!r} (tried pygame.{candidate})")
+    return code
+
+
+def is_blank(surface: pygame.Surface) -> bool:
+    """Report whether a frame is a single flat colour.
+
+    A blank frame is the usual way this tool silently tells you nothing, so it
+    is worth flagging rather than leaving for the reader to notice.
+
+    Args:
+        surface: The captured frame.
+
+    Returns:
+        True if every sampled pixel is identical.
+    """
+    width, height = surface.get_size()
+    if width == 0 or height == 0:
+        return True
+    step_x = max(1, width // 32)
+    step_y = max(1, height // 32)
+    first = surface.get_at((0, 0))
+    for y in range(0, height, step_y):
+        for x in range(0, width, step_x):
+            if surface.get_at((x, y)) != first:
+                return False
+    return True
+
+
+def run(demo: str, script: Script, out_dir: Path) -> int:
+    """Boot a demo, drive it, and write the requested frames.
+
+    Args:
+        demo: Key from `DEMOS`.
+        script: Frames to run, frames to capture, input to inject.
+        out_dir: Directory for the PNGs.
+
+    Returns:
+        A process exit code: 0 if frames were captured and none were blank,
+        1 if every capture was blank, 2 if the demo raised.
+    """
+    from pyguara.application.application import Application
+    from pyguara.events.dispatcher import EventDispatcher
+
+    bootstrap_mod, scenes_mod, scene_name = DEMOS[demo]
+    configure = importlib.import_module(bootstrap_mod).configure_game_container
+    scene_class = getattr(importlib.import_module(scenes_mod), scene_name)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    container = configure()
+    app = container.get(Application)
+
+    tick = 0
+    saved: list[tuple[Path, bool]] = []
+    original_render = app._render
+
+    def render_and_capture() -> None:
+        nonlocal tick
+        tick += 1
+
+        for at, key in script.keys:
+            if at == tick:
+                pygame.event.post(pygame.event.Event(pygame.KEYDOWN, key=key))
+        for at, x, y in script.clicks:
+            if at == tick:
+                pygame.event.post(
+                    pygame.event.Event(pygame.MOUSEBUTTONDOWN, pos=(x, y), button=1)
+                )
+                pygame.event.post(
+                    pygame.event.Event(pygame.MOUSEBUTTONUP, pos=(x, y), button=1)
+                )
+
+        original_render()
+
+        if tick in script.shots:
+            surface = pygame.display.get_surface()
+            if surface is not None:
+                path = out_dir / f"{demo}_{tick:04d}.png"
+                pygame.image.save(surface, str(path))
+                saved.append((path, is_blank(surface)))
+
+        if tick >= script.frames:
+            app._is_running = False
+
+    app._render = render_and_capture  # type: ignore[method-assign]
+
+    dispatcher = (
+        container.get(EventDispatcher)
+        if EventDispatcher in container._services
+        else app._event_dispatcher
+    )
+
+    try:
+        app.run(starting_scene=scene_class(dispatcher))
+    except Exception as error:  # noqa: BLE001 - the report is the product here
+        print(f"\nFAILED: {demo} raised {type(error).__name__}: {error}")
+        import traceback
+
+        traceback.print_exc()
+        return 2
+
+    print(f"\n{demo}: ran {tick} frames, captured {len(saved)}")
+    for path, blank in saved:
+        marker = "  BLANK - nothing was drawn" if blank else ""
+        print(f"    {path}{marker}")
+
+    if saved and all(blank for _, blank in saved):
+        print(
+            "\nEvery captured frame is a single flat colour. The render path "
+            "produced nothing; this is not a display problem."
+        )
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and run one demo.
+
+    Args:
+        argv: Argument list, defaulting to `sys.argv[1:]`.
+
+    Returns:
+        A process exit code.
+    """
+    parser = argparse.ArgumentParser(
+        description="Run a PyGuara demo headlessly and save frames to look at.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "examples:\n"
+            "  agent_view.py --list\n"
+            "  agent_view.py guara_falcao --frames 120 --shot 1 --shot 119\n"
+            "  agent_view.py guara_falcao --press RETURN@20 --shot 40\n"
+            "  agent_view.py ui_scene_graph --click 400,300@30 --shot 45\n"
+            "  agent_view.py physics_integration --every 30\n"
+        ),
+    )
+    parser.add_argument("demo", nargs="?", help="demo name; see --list")
+    parser.add_argument("--list", action="store_true", help="list demo names and exit")
+    parser.add_argument("--frames", type=int, default=120, help="frames to run (120)")
+    parser.add_argument(
+        "--shot",
+        action="append",
+        type=int,
+        default=[],
+        metavar="TICK",
+        help="capture this frame; repeatable",
+    )
+    parser.add_argument("--every", type=int, metavar="N", help="capture every N frames")
+    parser.add_argument(
+        "--press",
+        action="append",
+        default=[],
+        metavar="KEY@TICK",
+        help="press a key on a frame, e.g. SPACE@30; repeatable",
+    )
+    parser.add_argument(
+        "--click",
+        action="append",
+        default=[],
+        metavar="X,Y@TICK",
+        help="click a point on a frame, e.g. 400,300@30; repeatable",
+    )
+    parser.add_argument(
+        "--out", type=Path, default=DEFAULT_OUT, help=f"output dir ({DEFAULT_OUT.name})"
+    )
+    parser.add_argument(
+        "--windowed",
+        action="store_true",
+        help="use a real window instead of the dummy driver",
+    )
+    args = parser.parse_args(argv)
+
+    if args.list:
+        print("demos:")
+        for name, (_, _, scene) in sorted(DEMOS.items()):
+            print(f"  {name:<22} starts in {scene}")
+        return 0
+
+    if not args.demo:
+        parser.error("give a demo name, or --list")
+    if args.demo not in DEMOS:
+        parser.error(f"unknown demo {args.demo!r}. Known: {', '.join(sorted(DEMOS))}")
+
+    script = Script(frames=args.frames, shots=set(args.shot))
+    if args.every:
+        script.shots.update(range(args.every, args.frames + 1, args.every))
+    if not script.shots:
+        # Capture something rather than nothing: the last frame is the most
+        # informative single frame for a run nobody scripted.
+        script.shots = {args.frames}
+
+    for raw in args.press:
+        name, at = parse_at(raw, "press")
+        script.keys.append((at, resolve_key(name)))
+    for raw in args.click:
+        point, at = parse_at(raw, "click")
+        try:
+            x_str, y_str = point.split(",")
+            script.clicks.append((at, int(x_str), int(y_str)))
+        except ValueError:
+            raise SystemExit(f"--click: expected X,Y@TICK, got {raw!r}") from None
+
+    return run(args.demo, script, args.out)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

An agent working on this engine cannot look at a window, so "does it still render?" was unanswerable without asking a human. This adds a way to look, a test that looks on every run, and a hook that looks on every graphics edit.

It found a real defect on its first run.

## What's here

| Commit | |
| --- | --- |
| `cc1c784` | `tools/agent_view.py` — boots a demo headlessly, drives it (`--press`, `--click`), saves PNGs, flags flat frames |
| `62a720c` | **fix**: `physics_integration` crashed on entry |
| `a03dbf4` | **test**: every demo must draw a non-flat frame |
| `1e4044b` | **hook**: warn-only `PostToolUse` check on graphics edits |
| `e0e3a9e` | **docs**: what runs automatically, and one popular fix that does not work |

## The defect the test found

```
AttributeError: 'PymunkEngine' object has no attribute 'gravity'
  games/physics_integration/scenes.py:60
```

Pre-existing, not introduced by the audit: it fails identically at `35ed7fa`, and `git log -S "def gravity"` finds no commit that ever added or removed that attribute. The demo has been dead its whole life. Nothing caught it because `validate_demos.py` boots four demos and this is not one of them.

## The test

`validate_demos.py` checks demos do not crash. Not crashing is weaker than rendering — a renderer that submitted nothing passes it comfortably. The new test asserts the frame is not a single flat colour. Deliberately a low bar (it catches "produced nothing", not "produced the wrong thing"), but it is the bar nothing was holding.

`boot_process` draws nothing by design, so it is the negative control: if it ever stops reading as blank, `is_blank` has gone too lax and every other assertion is worthless.

## The hook

`PostToolUse` on `Edit|Write`, scoped to `pyguara/graphics/`. Boots `guara_falcao` for 20 frames (~0.6s) and reports a flat frame into the transcript. **Warn only** — reports via `additionalContext`, always exits 0, including when the check cannot run. A hook that fails your turn because `uv` is missing is worse than no hook.

The first draft used `jq`, which is not installed on this machine. It parsed nothing, matched nothing and exited 0 on every edit — a hook that silently does nothing. The pipe-test caught it; the rewrite has no third-party imports and runs on the system interpreter.

Verified: fires on a real Edit, silent on a healthy tree, silent on non-graphics files, and emits the warning JSON when the check reports a flat frame.

## What a capture does not prove

It reads the surface the renderer drew onto. That proves the render path works. It does **not** prove a window appears — those have already diverged here (the `vsync` → OpenGL promotion in #21). The guide says so, and the tool's docstring says so.

Relatedly, the guide now records `SDL_VIDEODRIVER=x11` / `SDL_RENDER_DRIVER=software` as tested and rejected: pygame already resolves to `x11` here, and this codebase creates no `SDL_Renderer` for the second variable to configure. A bare pygame window with both set still does not display on this WSLg host.

## Verification

Full suite from the committed state, in a clean `git worktree` rather than the working tree: **1514 passed**. `ruff check`, `ruff format`, `mypy` clean via pre-commit on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)