### PR TITLE
fix(physics): substep the solver so ordinary speeds stop tunnelling

### DIFF
--- a/pyguara/application/bootstrap.py
+++ b/pyguara/application/bootstrap.py
@@ -301,7 +301,7 @@ def _setup_container(headless: bool = False) -> DIContainer:
     container.register_instance(ResourceManager, res_manager)
 
     # Physics Engine
-    physics_engine = PymunkEngine()
+    physics_engine = PymunkEngine(substeps=config_manager.config.physics.substeps)
     container.register_instance(IPhysicsEngine, physics_engine)  # type: ignore[type-abstract]
 
     # Collision System (bridges pymunk callbacks to PyGuara events)

--- a/pyguara/config/types.py
+++ b/pyguara/config/types.py
@@ -74,6 +74,12 @@ class PhysicsConfig:
     gravity_x: float = 0.0
     gravity_y: float = 0.0
 
+    # Solver steps per physics tick. Chipmunk has no continuous collision
+    # detection, so a body jumps velocity/tick pixels and passes through
+    # anything thinner. Each doubling roughly doubles the speed a thin wall
+    # can stop, at proportional solver cost. 1 disables substepping.
+    substeps: int = 4
+
     @property
     def fixed_dt(self) -> float:
         """The fixed timestep in seconds.

--- a/pyguara/physics/backends/pymunk_impl.py
+++ b/pyguara/physics/backends/pymunk_impl.py
@@ -17,6 +17,12 @@ from pyguara.physics.types import (
     ShapeType,
 )
 
+# One 1/60s step lets a body jump velocity/60 pixels; at 600 px/s that is 10
+# pixels, which clears a 10px wall outright. Four substeps put the threshold
+# above the speeds a platformer reaches under normal gravity, at four times
+# the solver cost -- cheap for the body counts a 2D game runs.
+DEFAULT_SUBSTEPS = 4
+
 
 class PymunkBodyAdapter:
     """Wrapper around pymunk.Body to conform to IPhysicsBody."""
@@ -69,8 +75,28 @@ class PymunkBodyAdapter:
 class PymunkEngine:
     """Pymunk backend implementation."""
 
-    def __init__(self) -> None:
-        """Initialize the Pymunk engine wrapper."""
+    def __init__(self, substeps: int = DEFAULT_SUBSTEPS) -> None:
+        """Initialize the Pymunk engine wrapper.
+
+        Args:
+            substeps: How many solver steps one call to `update()` becomes.
+                Chipmunk has no continuous collision detection, so a body
+                moves `velocity * dt` in a straight jump each step and passes
+                through anything thinner than that jump. Substepping shortens
+                the jump proportionally: each doubling roughly doubles the
+                speed a thin wall can stop.
+
+        Raises:
+            ValueError: If `substeps` is not positive. Zero would step the
+                simulation not at all and negative is meaningless; both are
+                far better caught here than as a frozen world.
+        """
+        if substeps <= 0:
+            raise ValueError(
+                f"substeps must be positive, got {substeps}. It is the number "
+                f"of solver steps per update; 1 disables substepping."
+            )
+        self._substeps = substeps
         self.space: pymunk.Space | None = None
         # Map entity_id -> PymunkBodyAdapter
         self._bodies: dict[int | str, PymunkBodyAdapter] = {}
@@ -244,9 +270,23 @@ class PymunkEngine:
         self._collision_system.on_collision_end(str(entity_a), str(entity_b), is_sensor)
 
     def update(self, delta_time: float) -> None:
-        """Step the physics simulation forward."""
-        if self.space:
-            self.space.step(delta_time)
+        """Step the physics simulation forward.
+
+        Splits the tick into `substeps` equal solver steps. The step size is
+        what decides whether a fast body is caught or passes through a thin
+        collider, and it is deliberately derived from a fixed count rather
+        than from the bodies' speeds: this engine supports deterministic
+        replay, so the number of steps must not depend on the simulation's
+        own state.
+
+        Args:
+            delta_time: Seconds to advance, normally one fixed tick.
+        """
+        if not self.space:
+            return
+        step = delta_time / self._substeps
+        for _ in range(self._substeps):
+            self.space.step(step)
 
     def create_body(
         self,

--- a/tests/integration/test_collision_robustness.py
+++ b/tests/integration/test_collision_robustness.py
@@ -1,0 +1,146 @@
+"""Collision behaviour a 2D engine must get right, through the real ECS path.
+
+These go through EntityManager -> PhysicsSystem -> PymunkEngine, wired the
+way `application/bootstrap.py` wires it, because that is where the behaviour
+a game actually sees is decided. Testing the backend alone would miss the
+wiring, and testing pymunk alone would test pymunk.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyguara.common.components import Transform
+from pyguara.common.types import Vector2
+from pyguara.ecs.entity import Entity
+from pyguara.ecs.manager import EntityManager
+from pyguara.events.dispatcher import EventDispatcher
+from pyguara.physics.backends.pymunk_impl import PymunkEngine
+from pyguara.physics.collision_system import CollisionSystem
+from pyguara.physics.components import Collider, RigidBody
+from pyguara.physics.events import OnCollisionBegin
+from pyguara.physics.physics_system import PhysicsSystem
+from pyguara.physics.types import BodyType, PhysicsMaterial, ShapeType
+
+pytestmark = pytest.mark.integration
+
+DT = 1.0 / 60.0
+
+
+class World:
+    """An ECS world with physics wired as the application bootstrap wires it."""
+
+    def __init__(self, gravity: Vector2, substeps: int | None = None) -> None:
+        """Build the world, optionally overriding the engine's substep count."""
+        self.entities = EntityManager()
+        self.dispatcher = EventDispatcher()
+        engine = PymunkEngine() if substeps is None else PymunkEngine(substeps)
+        engine.set_collision_system(CollisionSystem(self.dispatcher))
+        self.system = PhysicsSystem(
+            engine, self.entities, self.dispatcher, gravity=gravity
+        )
+
+    def add(
+        self,
+        position: Vector2,
+        body_type: BodyType,
+        dimensions: list[float],
+        shape: ShapeType = ShapeType.BOX,
+        material: PhysicsMaterial | None = None,
+    ) -> Entity:
+        """Add a body with a collider at a world position."""
+        entity = self.entities.create_entity()
+        entity.add_component(Transform(position=position))
+        entity.add_component(RigidBody(mass=1.0, body_type=body_type))
+        entity.add_component(
+            Collider(
+                shape_type=shape,
+                dimensions=dimensions,
+                material=material or PhysicsMaterial(),
+            )
+        )
+        return entity
+
+    def run(self, ticks: int) -> None:
+        """Advance the simulation."""
+        for _ in range(ticks):
+            self.system.update(DT)
+
+
+def fire_at_wall(speed: float, wall_thickness: float, substeps: int | None) -> float:
+    """Launch a small body at a wall and return where it ends up.
+
+    Args:
+        speed: Horizontal speed in pixels per second.
+        wall_thickness: Width of the static wall at x=400.
+        substeps: Engine substep count, or None for the default.
+
+    Returns:
+        The body's final x. Greater than 400 means it went through.
+    """
+    world = World(gravity=Vector2(0, 0), substeps=substeps)
+    world.add(Vector2(400, 300), BodyType.STATIC, [wall_thickness, 400.0])
+    bullet = world.add(Vector2(100, 300), BodyType.DYNAMIC, [8.0, 8.0])
+
+    world.run(1)  # one tick creates the bodies
+    bullet.get_component(RigidBody)._body_handle.velocity = Vector2(speed, 0)
+    world.run(120)
+
+    return bullet.get_component(Transform).position.x
+
+
+@pytest.mark.parametrize("speed", [600.0, 900.0, 1200.0])
+def test_a_fast_body_does_not_pass_through_a_thin_wall(speed: float) -> None:
+    """A body at platformer speeds is stopped by a 10px wall.
+
+    600 px/s is not exotic: under the 900 px/s^2 gravity `guara_falcao`
+    uses, a character reaches it after two thirds of a second of falling.
+    With a single solver step per tick it moved 10px per step and cleared a
+    10px wall outright, so a player falling onto a thin platform went
+    straight through it.
+    """
+    assert fire_at_wall(speed, wall_thickness=10.0, substeps=None) < 400.0
+
+
+def test_substepping_is_what_stops_it() -> None:
+    """Pin the mechanism, not just the symptom.
+
+    One step per tick tunnels at a speed four substeps catch. If this ever
+    stops holding, the fix above is being carried by something else and the
+    substep count is no longer doing the work its cost is paying for.
+    """
+    assert fire_at_wall(1200.0, wall_thickness=10.0, substeps=1) > 400.0
+    assert fire_at_wall(1200.0, wall_thickness=10.0, substeps=4) < 400.0
+
+
+def test_substeps_must_be_positive() -> None:
+    """Zero substeps would freeze the simulation rather than fail loudly."""
+    with pytest.raises(ValueError, match="substeps must be positive"):
+        PymunkEngine(0)
+
+
+def test_a_dropped_box_comes_to_rest_on_the_ground() -> None:
+    """Substepping must not disturb ordinary resting contact.
+
+    Ground top is y=480 and the box is 50 tall, so it settles at y=455.
+    """
+    world = World(gravity=Vector2(0, 900))
+    world.add(Vector2(400, 500), BodyType.STATIC, [800.0, 40.0])
+    box = world.add(Vector2(400, 100), BodyType.DYNAMIC, [50.0, 50.0])
+
+    world.run(240)
+
+    assert box.get_component(Transform).position.y == pytest.approx(455, abs=2)
+
+
+def test_a_collision_raises_an_event() -> None:
+    """Contact reaches game code as an OnCollisionBegin."""
+    world = World(gravity=Vector2(0, 900))
+    seen: list[OnCollisionBegin] = []
+    world.dispatcher.subscribe(OnCollisionBegin, seen.append)
+
+    world.add(Vector2(400, 500), BodyType.STATIC, [800.0, 40.0])
+    world.add(Vector2(400, 100), BodyType.DYNAMIC, [50.0, 50.0])
+    world.run(240)
+
+    assert seen, "a box landing on the ground raised no collision event"


### PR DESCRIPTION
## The symptom

Collision was reported as "working really poorly". It reproduces: **a body moving 600 px/s passes straight through a 10px wall.**

That is not an exotic speed. Under the 900 px/s² gravity `guara_falcao` uses, a character reaches 600 px/s after two thirds of a second of falling — so a player dropping onto a thin platform goes through it.

## Why

Chipmunk has no continuous collision detection. One 1/60s step moves a body `velocity/60` pixels in a straight jump, and anything thinner than that jump is never sampled. Measured before the fix:

| speed | px/step | 10px wall | 32px wall | 64px wall |
| --- | --- | --- | --- | --- |
| 600 px/s | 10.0 | **THROUGH** | stopped | stopped |
| 1800 px/s | 30.0 | **THROUGH** | **THROUGH** | stopped |
| 2400 px/s | 40.0 | **THROUGH** | stopped | stopped |
| 3000 px/s | 50.0 | **THROUGH** | **THROUGH** | **THROUGH** |

Note 1800 clears a 32px wall while 2400 does not. Whether a wall is hit depends on where the step boundaries happen to fall — which is exactly why this presents as collision being *unreliable* rather than plainly broken.

**The app loop is not at fault** and is unchanged. Its fixed-timestep accumulator correctly prevents tunnelling caused by long frames; this is tunnelling inside a single well-formed step, which an accumulator cannot address. (The docstring claiming the accumulator "prevents physics tunneling" is true only of the lag-spike case.)

## The fix

Split each tick into N solver steps. The measured threshold scales exactly with N:

| substeps | tunnels from |
| --- | --- |
| 1 (before) | 600 px/s |
| 2 | 1200 px/s |
| 4 (**new default**) | 2400 px/s |
| 8 | 4800 px/s |

Exposed as `physics.substeps`. The count is **fixed rather than derived from body speeds**, because the engine supports deterministic replay — the step schedule must not depend on the simulation's own state.

## It is not free

Per tick, on this machine:

| bodies | 1 step | 4 substeps | ratio | % of a 60Hz frame |
| --- | --- | --- | --- | --- |
| 50 | 0.61ms | 2.00ms | 3.3x | 12% |
| 200 | 4.03ms | 8.33ms | 2.1x | 50% |
| 500 | 13.20ms | 27.94ms | 2.1x | **168%** |

500 dynamic bodies was already marginal at 79% before this. Scenes that dense should lower `physics.substeps` and keep colliders thick. Happy to drop the default to 2 if you'd rather protect the budget than the thin walls — one line.

## Tests

`tests/integration/test_collision_robustness.py`, through the real ECS → PhysicsSystem → engine path wired as `bootstrap.py` wires it. Reverting the default to 1 fails exactly the three tunnelling cases and nothing else. Also pins resting contact, collision events firing, the mechanism itself (1 substep tunnels where 4 does not), and that `substeps=0` raises rather than silently freezing the world.

1510 passing on this branch, verified in a clean worktree; ruff and mypy clean.

## Not in this PR

While reproducing, my first harness showed *zero* collision events — but that was my harness omitting `engine.set_collision_system(...)`, which every real bootstrap does. Events work. Worth noting the engine silently emits nothing when that wiring is missed; that is a separate hardening question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)