### PR TITLE
fix(physics): switch platformer characters to CharacterMover

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -53,7 +53,13 @@ how the subject is *constructed*, not just what is asserted.
 
 ## Active Subsystem
 
-`pyguara/graphics` — **split across several iterations**; all five slices done; slice 5 (assets & effects) in review. **Tier 3 continues with `physics`.**
+`pyguara/physics` — **in progress** (PR #24, branch
+`fix/physics-collision-tunnelling`). Symptom-driven so far: four defects
+found and fixed from reported bad collision behaviour. The systematic pass
+over `collision_system`, `trigger_volume`/`trigger_system` and `joints` is
+still outstanding, as are Phase B and C.
+
+`pyguara/graphics` — all five slices done (PR #22 in review).
 
 **Tier 2 is complete:** `config`, `application`, `scene`, `systems`.
 
@@ -301,6 +307,61 @@ convert to explicit `is None` checks as each subsystem is audited.
 ---
 
 ## Iteration Log
+
+### `pyguara/physics` — IN PROGRESS (PR #24, branch `fix/physics-collision-tunnelling`)
+
+Driven by a report that collision "works really poorly", with a brief to
+judge the layer as **game** physics: Chipmunk simulates rigid bodies and
+knows nothing about characters, ground or jumping, so everything that makes
+a platformer feel right is PyGuara's own and is what was audited.
+
+Four defects, each reproduced before being touched:
+
+1. **Tunnelling from 600 px/s** through a 10px wall — one solver step per
+   tick moves a body `velocity/60` px in a straight jump. Not exotic: 600
+   px/s is two thirds of a second of falling under the demo's own gravity.
+   Fixed by substepping (`physics.substeps`, default 4). Same root cause as
+   the reported *sinking*: landing penetrated 11.2px and took 24 frames to
+   resolve; now 0.9px and 0 visible frames from a typical fall.
+
+2. **No render interpolation reachable from a custom renderer.** The engine
+   had the whole mechanism -- `render_alpha`, `previous_position`
+   snapshotting, a lerp in `scene/base.py` -- but only on the
+   Sprite/RenderSystem path, so a scene drawing its own rects got none of it
+   and had no supported way in. Drawn raw at 75Hz a body moves 0-5px per
+   frame where every frame should be 4. `Transform.render_position(alpha)`
+   plus automatic opt-in by `PhysicsSystem`.
+
+3. **Every character detected itself as ground.** The ground ray starts 1px
+   below the collider, but a Chipmunk segment query is a swept circle whose
+   radius reaches back inside. `is_grounded` was True in mid-air and with no
+   ground in the world at all. Coyote time never started, jump buffering had
+   nothing to buffer, and the landing reset never fired -- a character could
+   jump twice and then never again until it died. `raycast()` gained
+   `ignore_entity_id`.
+
+4. **`fixed_rotation` and `gravity_scale` were inert.** Declared on
+   RigidBody, documented, read by nothing.
+
+**The pattern, fourth instance.** Uniform setup again, not missing coverage:
+every viewport test used a fullscreen viewport, every collision test a slow
+body, every platformer test a character already resting on the floor. Each
+defect lived in the case no test set up.
+
+**A second pattern worth naming: options that are declared but not wired.**
+`fixed_rotation`, `gravity_scale`, and the interpolation machinery reachable
+only from one render path. A game sets them, nothing happens, and there is
+no signal distinguishing "inert" from "wrong value". Worth grepping other
+subsystems for the same shape.
+
+**Not yet done:** `collision_system.py`, `trigger_volume.py`,
+`trigger_system.py`, `joints.py`; Phase B (test assessment) and Phase C
+(docs). Two game-layer gaps recorded, not built: no one-way platforms and no
+moving-platform support, both staples of the genre the demos target.
+
+**Left open for a decision:** faster penetration recovery (measured, stack-
+stable, cuts visible sinking 11 frames to 4) and whether `physics.substeps`
+should default to 4 or 2 (4 costs 50% of a 60Hz frame at 200 bodies).
 
 ### `pyguara/ecs` — CLOSED 2026-09-06 (PR #1, branch `refactor/ecs-audit`)
 

--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -53,17 +53,22 @@ how the subject is *constructed*, not just what is asserted.
 
 ## Active Subsystem
 
-`pyguara/physics` — **in progress** (PR #24, branch
-`fix/physics-collision-tunnelling`). Symptom-driven so far: six defects
-found and fixed from reported bad collision behaviour, plus one-way
-platforms, a collider debug overlay and a swept character mover. The
+`pyguara/physics` — **in progress** (branch
+`fix/physics-collision-tunnelling`, unmerged; only its first commit went out
+as PR #24). Symptom-driven so far: six defects found and fixed from reported
+bad collision behaviour, plus one-way platforms, a collider debug overlay, a
+swept character mover, and — this iteration — the switch itself. The
 systematic pass over `collision_system`, `trigger_volume`/`trigger_system`
 and `joints` is still outstanding, as are Phase B and C.
 
-**One decision is waiting**, and it is the big one: whether to move
-characters off dynamic rigid bodies onto `CharacterMover`. It is the root of
-the sinking/seam/wall-creep family of bugs. Read
-`docs/physics/character-movement.md` before resuming here.
+**The big decision — move characters off dynamic rigid bodies onto
+`CharacterMover` — is resolved and built.** Full physical parity (knockback,
+platform riding, crate pushing), on Celeste's model. See
+`docs/physics/character-movement.md` for the shape it took; the summary:
+`CharacterBody` replaces `RigidBody` for a character (no engine shape at
+all), `SolidMover`/`SolidSystem` carry and push actors for moving platforms
+and crates, `apply_knockback()` gives `Hazard.knockback_force` something to
+consume. `guara_falcao` has a demo patrolling platform and a pushable crate.
 
 `pyguara/graphics` — all five slices done (PR #22 in review).
 
@@ -378,12 +383,15 @@ checked by reverting it and watching the new test fail.
 - **`overlap_box`** — the first of pymunk's spatial queries beyond `raycast`
   that this engine exposes.
 - **`CharacterMover`** (`physics/character_mover.py`) — swept
-  collide-and-slide. **Built and tested, deliberately not wired in.**
+  collide-and-slide. **Built and tested, deliberately not wired in at the
+  time.** Wired in below.
 
 **Moving platforms already worked.** Measured before building: a kinematic
 platform moving 200px carried its rider 187.6px, the rest being friction
 slip. Undocumented gotcha: a kinematic body is position-synced *from* its
 Transform, so a game moves one by advancing the Transform, not its velocity.
+Superseded below: character riding no longer goes through Chipmunk friction
+at all.
 
 **The open decision — see `docs/physics/character-movement.md`.** Assigning
 velocity to a dynamic body and letting the solver sort out the overlap is
@@ -393,6 +401,39 @@ stops being a physics body, so knockback, platform carrying and crate
 pushing all need re-expressing. That document records the cost and the
 recommendation; it needs a decision on what a character should still be able
 to do physically before the conversion starts.
+
+**Resolved — full parity built, on Celeste's model.** Checked against the
+actual code before deciding: none of the three (knockback, riding, pushing)
+existed as working features — `Hazard.knockback_force` was declared and read
+by nothing, crates weren't implemented in `guara_falcao` at all, moving
+platforms had no system driving them. Decision made: build full parity
+anyway, using Celeste's integer-position-plus-remainder model (Maddy
+Thorson's "Celeste and TowerFall Physics") rather than Chipmunk friction or
+a continuous bisection sweep.
+
+What shipped: `CharacterMover` rewritten to whole-pixel stepping with a
+remainder accumulator (no more `MAX_STEP`/bisection — the last free whole
+pixel is the answer directly), plus a `probe()` primitive that replaced
+ground detection's raycast with a one-pixel overlap test (Celeste's
+`OnGround()`). `CharacterBody` replaces `RigidBody` for a character —
+literally no shape registered with the engine, which makes the ground-ray
+self-detection bug class (defect 3, above) structurally impossible rather
+than guarded against. `SolidMover`/`SolidSystem` (new) carry and push actors
+for `MovingSolid` entities, built on `Solid.MoveHExact`/`MoveVExact` — a
+direct placement plus a squish check, not a swept move, which is what a
+first attempt using a swept carry got wrong for a platform closing in on a
+resting rider (the platform's already-synced destination shape reads as
+overlapping the rider mid-sweep, before it catches up). `Pushable` marks a
+crate; `PlatformerSystem` asks `SolidMover.try_move()` to shove one when
+blocked by it, excluding the pushing character from the reactive
+carry/push pass — without that exclusion a pushed crate immediately shoves
+back at whoever pushed it. `apply_knockback()` overrides velocity and
+suppresses input control for a short window, decaying underneath continuing
+gravity; `guara_falcao`'s `HazardSystem` now calls it.
+`PhysicsSystem.sync_kinematic_transforms()` was split out of `update()` so
+`SolidSystem`/`PlatformerSystem` can query a solid's current-tick position
+before the simulation step runs. `guara_falcao` gets a demo patrolling
+platform and a pushable crate for manual verification.
 
 **Patterns, now four and five instances deep**
 

--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -54,10 +54,16 @@ how the subject is *constructed*, not just what is asserted.
 ## Active Subsystem
 
 `pyguara/physics` — **in progress** (PR #24, branch
-`fix/physics-collision-tunnelling`). Symptom-driven so far: four defects
-found and fixed from reported bad collision behaviour. The systematic pass
-over `collision_system`, `trigger_volume`/`trigger_system` and `joints` is
-still outstanding, as are Phase B and C.
+`fix/physics-collision-tunnelling`). Symptom-driven so far: six defects
+found and fixed from reported bad collision behaviour, plus one-way
+platforms, a collider debug overlay and a swept character mover. The
+systematic pass over `collision_system`, `trigger_volume`/`trigger_system`
+and `joints` is still outstanding, as are Phase B and C.
+
+**One decision is waiting**, and it is the big one: whether to move
+characters off dynamic rigid bodies onto `CharacterMover`. It is the root of
+the sinking/seam/wall-creep family of bugs. Read
+`docs/physics/character-movement.md` before resuming here.
 
 `pyguara/graphics` — all five slices done (PR #22 in review).
 
@@ -166,6 +172,257 @@ viewport, exactly as every query-cache test used `create_entity()` and every
 config test mocked the filesystem.
 
 **Left open:** issue #23, camera rotation.
+
+## Cross-Cutting Concerns
+
+Architectural issues that span subsystems. Do **not** fix these inside a
+single-subsystem iteration; schedule a dedicated pass.
+
+### CC-1 — RESOLVED 2026-09-06 — Ruff `target-version` was `py39`
+`pyproject.toml` pins `target-version = "py39"` while `requires-python` is
+3.12+. Ruff therefore refuses modernisation fixes engine-wide, which is the
+root cause of the legacy `typing.Dict`/`Optional[X]` style found in every
+module audited so far. **Fix:** bump to `py312` and enable the `UP`
+(pyupgrade), `B` (bugbear) and `D` (pydocstyle, `convention = "google"`) rule
+sets in one deliberate formatting commit, so per-subsystem diffs stay
+reviewable.
+Bumped to `py312` and enabled `UP`, `B`, `I`, `SIM`. 1455 findings fixed
+mechanically, the rest by hand. Surfaced one real defect: a mutable `Color`
+shared as a default argument in `WorldPass`.
+*Discovered in:* `ecs`. *Status:* **resolved**.
+
+### CC-2 — RESOLVED 2026-09-06 — Lint rule set was minimal
+No pydocstyle, no bugbear, no pyupgrade, no complexity ceiling. Google-style
+docstrings (mandated by this refactor) are therefore unenforced and will drift
+straight back.
+Resolved with CC-1. Ruff's `D` rules stay off deliberately: pydocstyle runs as
+its own hook, and two tools disagreeing about docstring style is worse than one
+enforcing it. That hook was also found to be mis-scoped -- it used a `match:`
+key pre-commit does not recognise, so it had been linting the whole repository
+instead of `pyguara/`.
+*Discovered in:* `ecs`. *Status:* **resolved**.
+
+### CC-3 — Internal ticket ids leak into public docstrings
+Strings like `P1-008` appear in user-facing API docstrings (`EntityManager
+.register_cached_query`, `QueryCache` module header) and in test module
+docstrings. Tracker ids are not documentation. **Fix:** sweep
+`grep -rn "P[0-9]-[0-9]" pyguara/ tests/` once the per-subsystem passes are
+done.
+*Discovered in:* `ecs` (removed there). *Status:* open elsewhere.
+
+### CC-4 — Unverifiable benchmark numbers embedded in docstrings
+Hard-coded claims ("~8ms for 10,000 entities", "8x faster") sit in docstrings
+with no benchmark backing them in CI. They are untestable and rot silently.
+**Fix:** move to `.benchmarks/` with an actual `pytest-benchmark` run, and
+reference the benchmark rather than restating a number.
+*Discovered in:* `ecs` (removed there). *Status:* open elsewhere.
+
+### CC-5 — `EntityManager` internals reached into from outside the package
+**Removal hook: RESOLVED (2026-09-06).** `_on_entity_removed` was a single
+callback slot assigned directly by `pyguara/scene/base.py`, so any second
+observer would have silently displaced the scene's `EntityDestroyed` dispatch.
+Replaced with `subscribe_entity_removed()` / `unsubscribe_entity_removed()`,
+which fan out to every subscriber, dedupe by equality (so a bound method
+subscribed twice notifies once), and tolerate unsubscription during
+notification. `Scene`, `tests/test_ecs.py` and `tests/test_physics.py` migrated;
+no references to the private attribute remain anywhere in the tree.
+
+**Still open:** `Entity._components` and `_on_component_added` are read across
+module boundaries — by `EntityManager` itself (acceptable, same package) and by
+serialisation and prefab code (not). Audit when `persistence` and `prefabs` come
+up; the likely fix is a public read-only components view.
+*Discovered in:* `ecs`. *Status:* partially resolved.
+
+### CC-6 — Component data-purity is advisory, not enforced
+`BaseComponent` only *warns* on logic methods; `StrictComponent` errors but is
+opt-in and, at the time of the `ecs` audit, had no adopters outside tests.
+**Named offender:** `common.Transform` sets `_allow_methods = True` and carries
+the whole parent hierarchy, world-transform caching and coordinate conversion
+(~330 lines). It is the largest violation in the engine and the one a
+`TransformSystem` would have to absorb; every other subsystem touches it, so it
+is deliberately not attempted piecemeal. **Fix:** once `physics`, `ui` and `ai`
+are audited and the true extent is known, migrate the tree to `StrictComponent`
+and consider making it the default.
+*Discovered in:* `ecs`; offender identified in `common`. *Status:* parked.
+
+### CC-10 — RESOLVED 2026-09-06 — Documentation described APIs that do not exist
+`docs/core/logging.md` documented `pyguara.log.config.setup_logging()` and
+`pyguara.log.config.get_logger()`. Neither the module nor the function exists
+anywhere in the tree; every code sample on the page raised
+`ModuleNotFoundError`. Nothing catches this, because docs are never executed.
+**Fix:** enable `pytest --doctest-glob='*.md'` over `docs/`, or add a smoke
+test that imports every symbol the docs reference. Until then, treat "verify
+the documented API actually exists" as an explicit Phase C step in every
+iteration.
+`tests/test_docs_api.py` now extracts every `pyguara...` import and backticked
+dotted reference from the Markdown under `docs/` and asserts it resolves. It
+immediately found two more: `docs/core/application.md` documented an entire
+error hierarchy (`pyguara.error`, `EngineException`, `@safe_execute`, `@retry`)
+that has never existed, and `PROJECT_STRUCTURE.md` referenced
+`create_application_container` instead of `create_application`. Both fixed.
+*Discovered in:* `log`. *Status:* **resolved**.
+
+### CC-9 — RESOLVED 2026-09-06 — `ErrorHandlingStrategy` was defined twice
+`pyguara/di/types.py` and `pyguara/events/types.py` each declare their own enum
+of the same name with identical members (LOG / RAISE / IGNORE) and identical
+semantics. They are not interchangeable -- `di.RAISE != events.RAISE` -- so
+passing one where the other is expected fails a comparison silently rather than
+loudly. **Fix:** hoist a single definition to a shared home once more
+subsystems are audited and the full set of consumers is known; `di` must not
+import `events` (see CC-8) so it cannot simply re-export.
+Hoisted to a new top-level `pyguara/errors.py`, which imports nothing from the
+engine and so cannot cycle. `di/types.py` and `events/types.py` re-export it, so
+existing import paths keep working. `di.RAISE == events.RAISE` is now True.
+*Discovered in:* `di`. *Status:* **resolved**.
+
+### CC-11 — pygame reaches into the backend-agnostic core
+**Tracked as GitHub issue #9.**
+CLAUDE.md states the engine is backend-agnostic and that code should never
+import pygame directly, but `Application` uses `pygame.time.Clock` for all
+frame timing, compares against `pygame.QUIT`, calls `pygame.event.pump()` and
+catches `pygame.error`. `SandboxApplication` uses `pygame.K_F1`-style constants
+for its tool hotkeys. The ModernGL path therefore still depends on pygame for
+timing and quit detection.
+Not fixed in the `application` pass because the fix belongs on the other side
+of the boundary: `Window.poll_events()` would have to yield engine events
+rather than raw SDL ones, and a `Clock` protocol would have to join the
+graphics protocols. **Fix:** take it with the `graphics` audit, so the protocol
+and both backends move together. `WindowResizeEvent` is defined and never
+dispatched for the same reason -- nothing detects the resize.
+*Discovered in:* `application`. *Status:* parked until `graphics`.
+
+### CC-8 — Package `__init__.py` files export nothing
+Most subsystem packages have a docstring-only `__init__.py`, so callers reach
+into submodules (`from pyguara.events.dispatcher import ...`). Beyond the
+ergonomics, it actively hides import cycles: adding re-exports to
+`events/__init__.py` immediately exposed a latent `log` <-> `events` deadlock
+(fixed in that pass). Every package still lacking exports may be hiding the
+same thing. **Fix:** add a curated `__all__` per package as each is audited,
+and treat any cycle it reveals as a finding rather than a reason to revert.
+*Discovered in:* `events`. *Status:* open.
+
+### CC-7 — `x or default` used with falsy value types
+`pymunk.Vec2d` defines `__bool__`, so `Vector2(0, 0)` is falsy. `Transform
+.__init__` used `scale or Vector2(1, 1)`, which silently rewrote an explicitly
+requested zero scale to unit scale. Fixed there, but the idiom is common and
+the same trap applies to any zero vector, `Color(0,0,0,0)`, an empty `Rect`, or
+`0.0` defaults. **Fix:** sweep `grep -rn "or Vector2(\\|or Color(" pyguara/` and
+convert to explicit `is None` checks as each subsystem is audited.
+*Discovered in:* `common`. *Status:* open.
+
+---
+
+## Iteration Log
+
+### `pyguara/physics` — IN PROGRESS (PR #24, branch `fix/physics-collision-tunnelling`)
+
+Driven by a report that collision "works really poorly", with a brief to
+judge the layer as **game** physics: Chipmunk simulates rigid bodies and
+knows nothing about characters, ground or jumping, so everything that makes
+a platformer feel right is PyGuara's own and is what was audited.
+
+Every defect below was reproduced before being touched, and each fix was
+checked by reverting it and watching the new test fail.
+
+**Defects found and fixed**
+
+1. **Tunnelling from 600 px/s** through a 10px wall — one solver step moves a
+   body `velocity/60` px in a straight jump. Fixed by substepping
+   (`physics.substeps`, default 4). Same cause as the reported *sinking on
+   landing*: 11.2px deep for 24 frames before, 0.9px and no visible frames
+   after.
+
+2. **No render interpolation reachable from a custom renderer.** The engine
+   had `render_alpha`, `previous_position` snapshotting and a lerp in
+   `scene/base.py`, but only on the Sprite/RenderSystem path. Drawn raw at
+   75Hz a body moves 0–5px per frame where every frame should be 4.
+   `Transform.render_position(alpha)`, plus automatic opt-in by
+   `PhysicsSystem` — a blanket default is wrong, since interpolating a
+   variable-rate-moved transform *adds* judder (measured). `Transform.teleport()`
+   covers respawns and screen wraps, which would otherwise streak.
+
+3. **Every character detected itself as ground.** The ground ray starts 1px
+   below the collider, but a Chipmunk segment query is a swept circle whose
+   radius reaches back inside. `is_grounded` was True in mid-air and with no
+   ground in the world at all, so coyote time never started, jump buffering
+   had nothing to buffer, and the landing reset never fired — a character
+   could jump twice and then never again until it died. `raycast()` gained
+   `ignore_entity_id`.
+
+4. **`fixed_rotation` and `gravity_scale` were inert** — declared on
+   RigidBody, documented, read by nothing.
+
+5. **pymunk 7 ignores a collision callback's return value**, so every
+   `return False` in the backend did nothing — including `CollisionSystem`
+   returning False to mean "report but do not resolve physically", which is
+   how a non-sensor trigger is meant to work. Now expressed through
+   `arbiter.process_collision`.
+
+6. **Walking sank the character 8px permanently.** A floor of separate tile
+   colliders has interior faces; a character rests `collision_slop` (0.1px)
+   deep, so its leading bottom corner strikes the vertical faces of the tiles
+   ahead. Traced: at a tile boundary it was flung upward at 47 px/s, hopped,
+   landed 8.4px deep and stayed. `pyguara/physics/tilemap.py` merges solid
+   tiles into as few rectangles as a greedy pass finds; sprites stay per-tile.
+   Walking then holds 0.10px throughout. Pre-existing — main measures the same.
+
+**Features added** (all absent, all genre staples Chipmunk cannot provide)
+
+- **One-way platforms** (`Collider.one_way`, `one_way_normal`) — decided on
+  the contact normal, not velocity (velocity is zero at a jump's apex, which
+  flips the surface solid mid-overlap and ejects the character), and
+  re-decided every step, not latched at first contact.
+- **Collider debug draw** (`physics/debug_draw.py`, F1 in `guara_falcao`) —
+  outlines every collider and the platformer's probe rays. Defect 3 would
+  have been obvious in one frame of it.
+- **`overlap_box`** — the first of pymunk's spatial queries beyond `raycast`
+  that this engine exposes.
+- **`CharacterMover`** (`physics/character_mover.py`) — swept
+  collide-and-slide. **Built and tested, deliberately not wired in.**
+
+**Moving platforms already worked.** Measured before building: a kinematic
+platform moving 200px carried its rider 187.6px, the rest being friction
+slip. Undocumented gotcha: a kinematic body is position-synced *from* its
+Transform, so a game moves one by advancing the Transform, not its velocity.
+
+**The open decision — see `docs/physics/character-movement.md`.** Assigning
+velocity to a dynamic body and letting the solver sort out the overlap is
+the root of this whole family of bugs: sinking, seam catching, wall creep,
+tunnelling. `CharacterMover` removes it by construction, but the character
+stops being a physics body, so knockback, platform carrying and crate
+pushing all need re-expressing. That document records the cost and the
+recommendation; it needs a decision on what a character should still be able
+to do physically before the conversion starts.
+
+**Patterns, now four and five instances deep**
+
+- **Uniform test setup, not missing coverage.** Every viewport test used a
+  fullscreen viewport, every collision test a slow body, every platformer
+  test a character already resting on the floor. Each defect lived in the
+  case no test set up.
+- **Declared and wired to nothing.** `fixed_rotation`, `gravity_scale`, the
+  `return False` collision contract, interpolation reachable from one render
+  path only. A game sets them, nothing happens, and there is no signal
+  distinguishing an inert option from a wrong value. Worth a deliberate sweep
+  of other subsystems for this shape.
+
+**Reference comparison — mechanisms still missing.** Of pymunk's six spatial
+queries the engine now exposes two (`raycast`, `overlap_box`); `point_query`,
+`bb_query`, `shape_query` and multi-hit `segment_query` are unexposed, which
+rules out click-picking, explosion radii, melee hitboxes and "can I fit here".
+Also absent: `surface_velocity` (conveyors), slope handling (no max-slope
+angle; a ramp will launch a character), variable jump height (releasing early
+does not cut the jump), corner correction, and body sleeping (every idle body
+is simulated forever).
+
+**Still not audited:** `collision_system.py`, `trigger_volume.py`,
+`trigger_system.py`, `joints.py`; Phase B (test assessment) and Phase C
+(docs) for the subsystem as a whole. Given finding 5, the trigger files are
+the most suspicious place to resume.
+
+**Also left open:** whether `physics.substeps` should default to 4 or 2 —
+4 costs about half a 60Hz frame at 200 dynamic bodies.
+
 
 ## Cross-Cutting Concerns
 

--- a/docs/physics/character-movement.md
+++ b/docs/physics/character-movement.md
@@ -1,0 +1,101 @@
+# Character movement: two approaches, and a pending switch
+
+PyGuara currently moves platformer characters as **dynamic rigid bodies with
+assigned velocity**. `pyguara/physics/character_mover.py` implements the
+other approach, **swept collide-and-slide**, and is not yet wired in. This
+document records why, what it would change, and what has to be rewritten if
+we go through with it.
+
+## Where we are
+
+`PlatformerSystem` reads input, works out a desired velocity, and assigns it
+to the body:
+
+```python
+rigidbody.handle.velocity = Vector2(new_velocity_x, new_velocity_y)
+```
+
+Chipmunk then steps the world and resolves whatever overlaps result. That is
+the source of a family of bugs, because a character pressed into geometry is
+*inside* it until the solver pushes it back out.
+
+Measured in `guara_falcao`, jumping while running:
+
+| | |
+| --- | --- |
+| depth reached | 8.95px into the floor |
+| recovery rate | ~0.04px per tick |
+| time visibly sunk | over 3 seconds |
+
+Two mitigations are in place and both help without fixing the cause:
+
+- `physics.substeps` (default 4) shortens the jump a body makes per solver
+  step, so it penetrates less far and cannot pass through thin walls at
+  ordinary speeds.
+- `physics.penetration_recovery` (default 0.3) raises Chipmunk's overlap
+  correction from its own 10% per tick, which loses to gravity.
+
+A third fix was structural rather than a tuning knob: solid tiles are merged
+into as few colliders as possible (`pyguara/physics/tilemap.py`), because a
+floor of separate tiles has interior faces that a character's leading corner
+catches on. That removed the walking case entirely. Jumping while moving
+still penetrates.
+
+## Where the mover would take us
+
+`CharacterMover.move()` advances the character in steps of at most 4px,
+testing each candidate position with `IPhysicsEngine.overlap_box`, and stops
+it flush at the first blocked step. Axes resolve one at a time, which is
+what makes it slide rather than stick.
+
+The property that matters: **penetration cannot occur**, so there is nothing
+to recover from. Walking 200 steps across a deliberately tiled floor stays
+within 0.1px, and a 3000 px/s move is still stopped by a 4px wall.
+
+Two details worth keeping in mind, both already handled:
+
+- A box resting exactly flush counts as overlapping — a touching contact is
+  an overlap. Without an allowance every candidate position looks blocked
+  and the character freezes. `SKIN` (0.05px, what Unity calls skin width) is
+  that allowance.
+- Tests have to assert geometry rather than the boolean overlap query, since
+  that query cannot tell "resting on" from "inside".
+
+## What switching would cost
+
+The character stops being a physics body, and everything that relied on it
+being one has to be re-expressed:
+
+- **Knockback and explosions** currently apply impulses to the body. They
+  would become velocity the mover consumes.
+- **Moving platforms** currently carry the character through friction, which
+  measurably works (a platform moving 200px took its rider 187.6px). A
+  kinematic character is not carried by friction; it has to sample the
+  platform's motion and add it.
+- **Pushing dynamic bodies** — crates, debris — stops happening for free.
+  The mover does not push what it hits.
+- **Slopes** are unhandled either way, but a mover makes them our problem
+  explicitly rather than the solver's implicitly.
+- **Ground detection** could stop being a raycast: the mover already knows
+  whether downward motion was blocked, which is a better answer than a probe
+  ray and cannot detect the character itself.
+
+## Recommendation
+
+Do it, but as its own change with its own verification, and keep the dynamic
+path for non-character bodies. The mover is the reference approach for a
+reason: every bug in this family — sinking, seam catching, wall creep,
+tunnelling — comes from asking a rigid-body solver to move something that is
+not really a rigid body.
+
+Before starting, decide what a character should still be able to do
+physically (be knocked back? push crates?), because that determines how much
+has to be rebuilt rather than deleted.
+
+## Related
+
+- `pyguara/physics/character_mover.py` — the mover
+- `pyguara/physics/tilemap.py` — collider merging, and why interior faces matter
+- `pyguara/physics/debug_draw.py` — collider and probe-ray overlay (F1 in `guara_falcao`)
+- `tests/integration/test_character_mover.py` — the no-penetration property
+- `tests/integration/test_platformer_feel.py` — coyote time, jump reuse, one-way platforms

--- a/docs/physics/character-movement.md
+++ b/docs/physics/character-movement.md
@@ -1,23 +1,23 @@
-# Character movement: two approaches, and a pending switch
+# Character movement: the switch to CharacterMover, resolved
 
-PyGuara currently moves platformer characters as **dynamic rigid bodies with
-assigned velocity**. `pyguara/physics/character_mover.py` implements the
-other approach, **swept collide-and-slide**, and is not yet wired in. This
-document records why, what it would change, and what has to be rewritten if
-we go through with it.
+PyGuara used to move platformer characters as **dynamic rigid bodies with
+assigned velocity**. That is no longer true: characters are now moved by
+**`CharacterMover`**, a swept collide-and-slide mover, and carry no physics
+body at all. This document records why the old approach was replaced, the
+decision that unblocked the switch, and the shape the engine ended up with.
 
-## Where we are
+## Where we were
 
-`PlatformerSystem` reads input, works out a desired velocity, and assigns it
+`PlatformerSystem` read input, worked out a desired velocity, and assigned it
 to the body:
 
 ```python
 rigidbody.handle.velocity = Vector2(new_velocity_x, new_velocity_y)
 ```
 
-Chipmunk then steps the world and resolves whatever overlaps result. That is
-the source of a family of bugs, because a character pressed into geometry is
-*inside* it until the solver pushes it back out.
+Chipmunk then stepped the world and resolved whatever overlaps resulted.
+That was the source of a whole family of bugs, because a character pressed
+into geometry is *inside* it until the solver pushes it back out.
 
 Measured in `guara_falcao`, jumping while running:
 
@@ -27,75 +27,112 @@ Measured in `guara_falcao`, jumping while running:
 | recovery rate | ~0.04px per tick |
 | time visibly sunk | over 3 seconds |
 
-Two mitigations are in place and both help without fixing the cause:
+Substepping, a raised penetration-recovery rate, and merging tile colliders
+all helped without fixing the cause; jumping while moving still penetrated.
+Every bug in this family — sinking, seam catching, wall creep, tunnelling —
+came from asking a rigid-body solver to move something that was not really a
+rigid body.
 
-- `physics.substeps` (default 4) shortens the jump a body makes per solver
-  step, so it penetrates less far and cannot pass through thin walls at
-  ordinary speeds.
-- `physics.penetration_recovery` (default 0.3) raises Chipmunk's overlap
-  correction from its own 10% per tick, which loses to gravity.
+## The decision that unblocked the switch
 
-A third fix was structural rather than a tuning knob: solid tiles are merged
-into as few colliders as possible (`pyguara/physics/tilemap.py`), because a
-floor of separate tiles has interior faces that a character's leading corner
-catches on. That removed the walking case entirely. Jumping while moving
-still penetrates.
+Before wiring the mover in, one question had to be answered: what should a
+character still be able to do physically (be knocked back? push crates? ride
+platforms?), because that decides how much of the dynamic-body world had to
+be rebuilt rather than deleted. Checked against the actual code at the time:
+**none of the three existed as working features** — `Hazard.knockback_force`
+was declared and read by nothing, crates weren't implemented in
+`guara_falcao` at all (GDD-only), and moving platforms had no system driving
+them. The decision made: build full physical parity anyway — knockback,
+platform riding, and crate pushing — using **Celeste's model** as the
+reference (Maddy Thorson's "Celeste and TowerFall Physics"): integer-pixel
+positions with a float remainder accumulator, and solids that explicitly
+carry/push the actors touching them, rather than leaning on Chipmunk
+friction or a continuous bisection sweep.
 
-## Where the mover would take us
+## What shipped
 
-`CharacterMover.move()` advances the character in steps of at most 4px,
-testing each candidate position with `IPhysicsEngine.overlap_box`, and stops
-it flush at the first blocked step. Axes resolve one at a time, which is
-what makes it slide rather than stick.
+**`CharacterMover`** (`pyguara/physics/character_mover.py`) sweeps a
+character one whole pixel at a time. A float `remainder` accumulates
+sub-pixel motion every call (gravity at 900px/s² is rarely a whole number of
+pixels per tick); only the whole-pixel part is ever stepped, and every pixel
+stepped is tested, so tunnelling is impossible and there is nothing to
+bisect for — the last free whole pixel *is* the resting position.
+`CharacterMover.probe()` is the same overlap primitive used one pixel off in
+a direction, without moving: Celeste's `OnGround()` is exactly
+`CollideCheck(Position + Vector2.UnitY)`, not a raycast, and it's what ground
+detection uses now.
 
-The property that matters: **penetration cannot occur**, so there is nothing
-to recover from. Walking 200 steps across a deliberately tiled floor stays
-within 0.1px, and a 3000 px/s move is still stopped by a 4px wall.
+**`CharacterBody`** (`pyguara/physics/components.py`) replaces `RigidBody`
+for a character: velocity, ground state, and knockback state, with *no
+shape registered with the physics engine at all*. That is what makes the
+old ground-ray self-detection bug class structurally impossible rather than
+guarded against — the character has nothing to detect.
 
-Two details worth keeping in mind, both already handled:
+**`SolidMover`/`SolidSystem`** (`pyguara/physics/solid_mover.py`,
+`solid_system.py`) are the other half: how the *world* moves a character
+that isn't driving. Built on Celeste's `Solid.MoveHExact`/`MoveVExact`
+rather than a swept move — a rider or a pushed actor is placed directly at
+the position a solid's motion dictates (the solid already decided exactly
+where it's going), then checked for whether that position is clear of
+everything *except* the solid that moved it. If not, it's squished:
+flagged on `CharacterBody.squished` and reported via `OnActorSquished`,
+since what a squish means (damage, death, nothing) is a game decision, not
+a physics one. A `MovingSolid` is still an ordinary `RigidBody`/`Collider`
+as far as Chipmunk is concerned, so genuinely dynamic bodies keep colliding
+with it normally.
 
-- A box resting exactly flush counts as overlapping — a touching contact is
-  an overlap. Without an allowance every candidate position looks blocked
-  and the character freezes. `SKIN` (0.05px, what Unity calls skin width) is
-  that allowance.
-- Tests have to assert geometry rather than the boolean overlap query, since
-  that query cannot tell "resting on" from "inside".
+**Pushing** is `Pushable`, a marker on a `MovingSolid`: when
+`CharacterMover`'s sweep is blocked by one, `PlatformerSystem` asks
+`SolidMover.try_move()` to shove it by the distance the block left
+untravelled, retrying the character's own move once if the shove succeeds.
+`try_move()` excludes the pushing character from the reactive carry/push
+pass that follows — without that, a pushed crate immediately shoves back at
+whoever just pushed it, which is exactly the shape a first version of the
+test for this caught.
 
-## What switching would cost
+**Knockback** is `apply_knockback()` (`pyguara/physics/platformer_system.py`):
+consumed as velocity, not an impulse. It overrides `CharacterBody.velocity`
+directly and suppresses input control for a short window, during which the
+velocity decays back toward zero and gravity keeps acting underneath it —
+an ordinary hit-stun. `games/guara_falcao`'s `HazardSystem` now calls it,
+which is what finally gives `Hazard.knockback_force` something to do.
 
-The character stops being a physics body, and everything that relied on it
-being one has to be re-expressed:
+**System ordering** (`GameplayScene.fixed_update()` in `guara_falcao`)
+became: whatever authors a solid's motion (a patrol script) → sync kinematic
+transforms into the engine, so a query this same tick sees where a solid
+already is → `SolidSystem` carries/pushes whatever a solid touched →
+`PlatformerSystem` moves the character against that now-current geometry →
+`PhysicsSystem` steps whatever is still a genuine Chipmunk dynamic body.
+`PhysicsSystem.sync_kinematic_transforms()` was split out of `update()` to
+make the middle of that sequence possible.
 
-- **Knockback and explosions** currently apply impulses to the body. They
-  would become velocity the mover consumes.
-- **Moving platforms** currently carry the character through friction, which
-  measurably works (a platform moving 200px took its rider 187.6px). A
-  kinematic character is not carried by friction; it has to sample the
-  platform's motion and add it.
-- **Pushing dynamic bodies** — crates, debris — stops happening for free.
-  The mover does not push what it hits.
-- **Slopes** are unhandled either way, but a mover makes them our problem
-  explicitly rather than the solver's implicitly.
-- **Ground detection** could stop being a raycast: the mover already knows
-  whether downward motion was blocked, which is a better answer than a probe
-  ray and cannot detect the character itself.
+Two details worth keeping in mind, both handled:
 
-## Recommendation
-
-Do it, but as its own change with its own verification, and keep the dynamic
-path for non-character bodies. The mover is the reference approach for a
-reason: every bug in this family — sinking, seam catching, wall creep,
-tunnelling — comes from asking a rigid-body solver to move something that is
-not really a rigid body.
-
-Before starting, decide what a character should still be able to do
-physically (be knocked back? push crates?), because that determines how much
-has to be rebuilt rather than deleted.
+- A box resting exactly flush counts as overlapping in Chipmunk's
+  `shape_query` — a touching contact is an overlap. `SKIN` (0.05px) is the
+  allowance applied to every query box so a resting contact doesn't poison
+  the next step's query; it never changes where anything actually settles.
+- Ground/wall detection, riding, and pushing all assert exact pixel
+  positions in tests now, not `pytest.approx(..., abs=0.1)` — there is no
+  bisection settling near the answer any more, so there's no reason to
+  tolerate one.
 
 ## Related
 
-- `pyguara/physics/character_mover.py` — the mover
-- `pyguara/physics/tilemap.py` — collider merging, and why interior faces matter
-- `pyguara/physics/debug_draw.py` — collider and probe-ray overlay (F1 in `guara_falcao`)
-- `tests/integration/test_character_mover.py` — the no-penetration property
-- `tests/integration/test_platformer_feel.py` — coyote time, jump reuse, one-way platforms
+- `pyguara/physics/character_mover.py` — the character's own movement
+- `pyguara/physics/solid_mover.py`, `solid_system.py` — how the world moves a
+  character
+- `pyguara/physics/components.py` — `CharacterBody`, `MovingSolid`, `Pushable`
+- `pyguara/physics/platformer_system.py` — wiring, gravity integration,
+  `apply_knockback()`
+- `pyguara/physics/tilemap.py` — collider merging, and why interior faces
+  mattered even before the mover
+- `pyguara/physics/debug_draw.py` — collider and probe overlay (F1 in
+  `guara_falcao`)
+- `tests/integration/test_character_mover.py` — the no-penetration property,
+  exact-pixel resting positions
+- `tests/integration/test_solid_mover.py` — riding, pushing, squish,
+  pushable crates end to end
+- `tests/integration/test_knockback.py` — override, decay, control handback
+- `tests/integration/test_platformer_feel.py` — coyote time, jump reuse,
+  one-way platforms

--- a/games/asset_pipeline/systems.py
+++ b/games/asset_pipeline/systems.py
@@ -27,7 +27,10 @@ class MovementSystem:
 
             transform.position = Vector2(new_x, new_y)
 
+            # teleport(), not a plain assignment: the renderer interpolates
+            # between ticks, so assigning here would draw the sprite streaking
+            # back across the whole screen on the wrapping frame.
             if transform.position.x > 800:
-                transform.position = Vector2(0, transform.position.y)
+                transform.teleport(Vector2(0, transform.position.y))
             if transform.position.y > 600:
-                transform.position = Vector2(transform.position.x, 0)
+                transform.teleport(Vector2(transform.position.x, 0))

--- a/games/ecs_mental_model/systems.py
+++ b/games/ecs_mental_model/systems.py
@@ -33,8 +33,11 @@ class MovementSystem:
 
             transform.position = Vector2(new_x, new_y)
 
-            # Simple bounds check to wrap around screen (assuming 800x600)
+            # Wrap around the screen. teleport(), not a plain assignment:
+            # the renderer interpolates between ticks, so an assignment here
+            # would draw the sprite streaking back across the whole screen on
+            # the wrapping frame.
             if transform.position.x > 800:
-                transform.position = Vector2(0, transform.position.y)
+                transform.teleport(Vector2(0, transform.position.y))
             if transform.position.y > 600:
-                transform.position = Vector2(transform.position.x, 0)
+                transform.teleport(Vector2(transform.position.x, 0))

--- a/games/guara_falcao/components.py
+++ b/games/guara_falcao/components.py
@@ -157,3 +157,31 @@ class Score(BaseComponent):
         """Add coins and update score."""
         self.coins_collected += amount
         self.value += amount * 100
+
+
+@dataclass
+class PatrolMotion(BaseComponent):
+    """Moves a MovingSolid back and forth between two points.
+
+    Demo content for the CharacterMover switch: a `MovingSolid` needs
+    something to author its Transform's motion, and this game had nothing
+    that did. Its only job is to move the Transform -- SolidSystem is what
+    turns that displacement into carrying/pushing whatever touches it.
+
+    Attributes:
+        start: One end of the patrol, in world space.
+        end: The other end.
+        speed: Travel speed in pixels/second.
+    """
+
+    start: Vector2 = field(default_factory=lambda: Vector2(0, 0))
+    end: Vector2 = field(default_factory=lambda: Vector2(0, 0))
+    speed: float = 60.0
+
+    # Which end the patrol is currently headed toward: +1.0 is end, -1.0
+    # is start. Internal state PatrolSystem owns.
+    _direction: float = field(default=1.0, repr=False)
+
+    def __post_init__(self) -> None:
+        """Initialize the component."""
+        super().__init__()

--- a/games/guara_falcao/level_builder.py
+++ b/games/guara_falcao/level_builder.py
@@ -247,10 +247,8 @@ class LevelBuilder:
 
         player = entity_manager.create_entity("player")
 
-        # Transform. interpolate=True so the renderer can draw between fixed
-        # ticks: physics runs at 60Hz while frames present at the display's
-        # rate, and without it the player is drawn in uneven jumps.
-        player.add_component(Transform(position=spawn_pos, interpolate=True))
+        # PhysicsSystem sets interpolate on this when it creates the body.
+        player.add_component(Transform(position=spawn_pos))
 
         # Physics
         player.add_component(RigidBody(body_type=BodyType.DYNAMIC, mass=1.0))

--- a/games/guara_falcao/level_builder.py
+++ b/games/guara_falcao/level_builder.py
@@ -12,6 +12,7 @@ from games.guara_falcao.components import (
     Collectible,
     Hazard,
     Health,
+    PatrolMotion,
     PlatformSprite,
     PlayerState,
     Score,
@@ -20,7 +21,13 @@ from games.guara_falcao.components import (
 from pyguara.common.components import Transform
 from pyguara.common.types import Color, Rect, Vector2
 from pyguara.ecs.manager import EntityManager
-from pyguara.physics.components import CharacterBody, Collider, RigidBody
+from pyguara.physics.components import (
+    CharacterBody,
+    Collider,
+    MovingSolid,
+    Pushable,
+    RigidBody,
+)
 from pyguara.physics.platformer_controller import PlatformerController
 from pyguara.physics.tilemap import merge_tile_rects
 from pyguara.physics.types import BodyType
@@ -61,6 +68,9 @@ class LevelBuilder:
             "collectibles": [[8, 14], [12, 12], [18, 10], [25, 14]],
             "checkpoints": [[15, 14]],
             "goal": [38, 14],
+            # Patrols in tile columns between 5 and 10, at row 13.
+            "moving_platform": {"start": [5, 13], "end": [10, 13], "speed": 60.0},
+            "crate": [20, 14],
         }
 
         # Create tilemap (20 rows, 40 columns)
@@ -151,6 +161,16 @@ class LevelBuilder:
         if goal_pos:
             self._create_goal(entity_manager, goal_pos[0], goal_pos[1])
 
+        # Demo content for the CharacterMover switch -- a rideable, patrolling
+        # platform and a crate the player can shove. See
+        # docs/physics/character-movement.md.
+        moving_platform = level_data.get("moving_platform")
+        if moving_platform:
+            self._create_moving_platform(entity_manager, moving_platform)
+        crate_pos = level_data.get("crate")
+        if crate_pos:
+            self._create_crate(entity_manager, crate_pos[0], crate_pos[1])
+
         return self._spawn_point
 
     def _create_solid_tile_sprite(
@@ -193,6 +213,60 @@ class LevelBuilder:
         entity.add_component(RigidBody(body_type=BodyType.STATIC))
         entity.add_component(
             Collider(dimensions=[float(rect.width), float(rect.height)])
+        )
+
+    def _create_moving_platform(
+        self, entity_manager: EntityManager, spec: dict[str, Any]
+    ) -> None:
+        """Create a rideable platform that patrols between two tile positions.
+
+        Args:
+            entity_manager: Manager to create the entity in.
+            spec: `{"start": [gx, gy], "end": [gx, gy], "speed": px/s}`.
+        """
+        entity = entity_manager.create_entity("moving_platform")
+
+        start = Vector2(
+            *(coord * TILE_SIZE + TILE_SIZE // 2 for coord in spec["start"])
+        )
+        end = Vector2(*(coord * TILE_SIZE + TILE_SIZE // 2 for coord in spec["end"]))
+        dimensions = [TILE_SIZE * 3.0, TILE_SIZE / 2]
+
+        entity.add_component(Transform(position=start))
+        entity.add_component(RigidBody(body_type=BodyType.KINEMATIC))
+        entity.add_component(Collider(dimensions=dimensions))
+        entity.add_component(MovingSolid())
+        entity.add_component(
+            PatrolMotion(start=start, end=end, speed=float(spec.get("speed", 60.0)))
+        )
+        entity.add_component(
+            PlatformSprite(
+                color=Color(150, 110, 200), size=Vector2(dimensions[0], dimensions[1])
+            )
+        )
+
+    def _create_crate(self, entity_manager: EntityManager, gx: int, gy: int) -> None:
+        """Create a crate the player can push (but not carry).
+
+        Args:
+            entity_manager: Manager to create the entity in.
+            gx: Tile column.
+            gy: Tile row.
+        """
+        entity = entity_manager.create_entity(f"crate_{gx}_{gy}")
+
+        world_x = gx * TILE_SIZE + TILE_SIZE // 2
+        world_y = gy * TILE_SIZE + TILE_SIZE // 2
+
+        entity.add_component(Transform(position=Vector2(world_x, world_y)))
+        entity.add_component(RigidBody(body_type=BodyType.KINEMATIC))
+        entity.add_component(Collider(dimensions=[float(TILE_SIZE), float(TILE_SIZE)]))
+        entity.add_component(MovingSolid())
+        entity.add_component(Pushable())
+        entity.add_component(
+            PlatformSprite(
+                color=Color(160, 120, 60), size=Vector2(TILE_SIZE, TILE_SIZE)
+            )
         )
 
     def _create_hazard(self, entity_manager: EntityManager, gx: int, gy: int) -> None:

--- a/games/guara_falcao/level_builder.py
+++ b/games/guara_falcao/level_builder.py
@@ -18,10 +18,11 @@ from games.guara_falcao.components import (
     ZoneTrigger,
 )
 from pyguara.common.components import Transform
-from pyguara.common.types import Color, Vector2
+from pyguara.common.types import Color, Rect, Vector2
 from pyguara.ecs.manager import EntityManager
 from pyguara.physics.components import Collider, RigidBody
 from pyguara.physics.platformer_controller import PlatformerController
+from pyguara.physics.tilemap import merge_tile_rects
 from pyguara.physics.types import BodyType
 
 # Tile size in pixels
@@ -121,13 +122,21 @@ class LevelBuilder:
         spawn = level_data.get("player_spawn", [4, 14])
         self._spawn_point = Vector2(spawn[0] * TILE_SIZE, spawn[1] * TILE_SIZE)
 
-        # Process tilemap
+        # Process tilemap. Sprites stay per-tile so the grid still reads as a
+        # grid, but collision is built from merged rectangles: a floor made of
+        # separate tile colliders has interior faces between them, and a
+        # walking character's leading corner catches on them and is flung
+        # upward. See pyguara/physics/tilemap.py.
         for y, row in enumerate(tiles):
             for x, tile in enumerate(row):
                 if tile == TILE_SOLID:
-                    self._create_solid_tile(entity_manager, x, y)
+                    self._create_solid_tile_sprite(entity_manager, x, y)
                 elif tile == TILE_HAZARD:
                     self._create_hazard(entity_manager, x, y)
+
+        solid = [[tile == TILE_SOLID for tile in row] for row in tiles]
+        for index, rect in enumerate(merge_tile_rects(solid, TILE_SIZE)):
+            self._create_solid_body(entity_manager, index, rect)
 
         # Create collectibles
         for pos in level_data.get("collectibles", []):
@@ -144,20 +153,46 @@ class LevelBuilder:
 
         return self._spawn_point
 
-    def _create_solid_tile(
+    def _create_solid_tile_sprite(
         self, entity_manager: EntityManager, gx: int, gy: int
     ) -> None:
-        """Create a solid tile entity."""
+        """Create the visual for one solid tile. Collision is merged separately.
+
+        Args:
+            entity_manager: Manager to create the entity in.
+            gx: Tile column.
+            gy: Tile row.
+        """
         entity = entity_manager.create_entity(f"tile_{gx}_{gy}")
 
         world_x = gx * TILE_SIZE + TILE_SIZE // 2
         world_y = gy * TILE_SIZE + TILE_SIZE // 2
 
         entity.add_component(Transform(position=Vector2(world_x, world_y)))
-        entity.add_component(RigidBody(body_type=BodyType.STATIC))
-        entity.add_component(Collider(dimensions=[TILE_SIZE, TILE_SIZE]))
         entity.add_component(
             PlatformSprite(color=Color(70, 80, 90), size=Vector2(TILE_SIZE, TILE_SIZE))
+        )
+
+    def _create_solid_body(
+        self, entity_manager: EntityManager, index: int, rect: Rect
+    ) -> None:
+        """Create one static collider covering a merged run of solid tiles.
+
+        Args:
+            entity_manager: Manager to create the entity in.
+            index: Sequence number, for a readable entity id.
+            rect: World-space area to cover.
+        """
+        entity = entity_manager.create_entity(f"solid_{index}")
+
+        entity.add_component(
+            Transform(
+                position=Vector2(rect.x + rect.width / 2, rect.y + rect.height / 2)
+            )
+        )
+        entity.add_component(RigidBody(body_type=BodyType.STATIC))
+        entity.add_component(
+            Collider(dimensions=[float(rect.width), float(rect.height)])
         )
 
     def _create_hazard(self, entity_manager: EntityManager, gx: int, gy: int) -> None:

--- a/games/guara_falcao/level_builder.py
+++ b/games/guara_falcao/level_builder.py
@@ -247,8 +247,10 @@ class LevelBuilder:
 
         player = entity_manager.create_entity("player")
 
-        # Transform
-        player.add_component(Transform(position=spawn_pos))
+        # Transform. interpolate=True so the renderer can draw between fixed
+        # ticks: physics runs at 60Hz while frames present at the display's
+        # rate, and without it the player is drawn in uneven jumps.
+        player.add_component(Transform(position=spawn_pos, interpolate=True))
 
         # Physics
         player.add_component(RigidBody(body_type=BodyType.DYNAMIC, mass=1.0))

--- a/games/guara_falcao/level_builder.py
+++ b/games/guara_falcao/level_builder.py
@@ -20,7 +20,7 @@ from games.guara_falcao.components import (
 from pyguara.common.components import Transform
 from pyguara.common.types import Color, Rect, Vector2
 from pyguara.ecs.manager import EntityManager
-from pyguara.physics.components import Collider, RigidBody
+from pyguara.physics.components import CharacterBody, Collider, RigidBody
 from pyguara.physics.platformer_controller import PlatformerController
 from pyguara.physics.tilemap import merge_tile_rects
 from pyguara.physics.types import BodyType
@@ -285,16 +285,16 @@ class LevelBuilder:
         # PhysicsSystem sets interpolate on this when it creates the body.
         player.add_component(Transform(position=spawn_pos))
 
-        # Physics
-        player.add_component(RigidBody(body_type=BodyType.DYNAMIC, mass=1.0))
+        # Physics -- CharacterBody, not RigidBody: the player is swept by
+        # CharacterMover, not simulated by Chipmunk. See
+        # docs/physics/character-movement.md.
+        player.add_component(CharacterBody())
         player.add_component(Collider(dimensions=[24, 40]))
 
         # Platformer controller with game-feel tuning.
-        # The detection rays start at the collider's edge, not its centre, so
-        # these are clearances beyond the character's own outline. They used to
-        # be set to half the character's size on the belief that the ray began
-        # at the centre, which reported ground while a full body-height above
-        # it.
+        # wall_check_distance is a clearance beyond the character's own
+        # outline, not from its centre. Ground has no equivalent: it's a
+        # one-pixel overlap probe now, not a configurable-length ray.
         player.add_component(
             PlatformerController(
                 move_speed=180.0,
@@ -307,7 +307,6 @@ class LevelBuilder:
                 wall_slide_enabled=False,  # Disabled for now to debug gravity issues
                 wall_slide_speed=60.0,
                 wall_jump_enabled=False,
-                ground_check_distance=6.0,  # clearance below the feet
                 wall_check_distance=4.0,  # clearance beyond each side
             )
         )

--- a/games/guara_falcao/level_builder.py
+++ b/games/guara_falcao/level_builder.py
@@ -254,9 +254,12 @@ class LevelBuilder:
         player.add_component(RigidBody(body_type=BodyType.DYNAMIC, mass=1.0))
         player.add_component(Collider(dimensions=[24, 40]))
 
-        # Platformer controller with game-feel tuning
-        # Note: ground_check_distance must be > half player height (20) to detect ground
-        # from the player's center position
+        # Platformer controller with game-feel tuning.
+        # The detection rays start at the collider's edge, not its centre, so
+        # these are clearances beyond the character's own outline. They used to
+        # be set to half the character's size on the belief that the ray began
+        # at the centre, which reported ground while a full body-height above
+        # it.
         player.add_component(
             PlatformerController(
                 move_speed=180.0,
@@ -269,8 +272,8 @@ class LevelBuilder:
                 wall_slide_enabled=False,  # Disabled for now to debug gravity issues
                 wall_slide_speed=60.0,
                 wall_jump_enabled=False,
-                ground_check_distance=25.0,  # Must exceed half player height (20) + margin
-                wall_check_distance=16.0,  # Must exceed half player width (12) + margin
+                ground_check_distance=6.0,  # clearance below the feet
+                wall_check_distance=4.0,  # clearance beyond each side
             )
         )
 

--- a/games/guara_falcao/scenes.py
+++ b/games/guara_falcao/scenes.py
@@ -39,7 +39,7 @@ from pyguara.input.events import OnActionEvent
 from pyguara.input.keys import ESCAPE, F1, LEFT, RIGHT, SPACE, UP, R
 from pyguara.input.manager import InputManager
 from pyguara.input.types import ActionType, InputDevice
-from pyguara.physics.components import RigidBody
+from pyguara.physics.components import CharacterBody
 from pyguara.physics.debug_draw import ColliderDebugRenderer
 from pyguara.physics.physics_system import PhysicsSystem
 from pyguara.physics.platformer_controller import PlatformerController
@@ -183,6 +183,7 @@ class GameScene(Scene):
         self._platformer_system = PlatformerSystem(
             entity_manager=self.entity_manager,
             physics_engine=physics_engine,
+            gravity=Vector2(physics_config.gravity_x, physics_config.gravity_y),
         )
 
         # Initialize game systems
@@ -302,7 +303,7 @@ class GameScene(Scene):
             if player:
                 transform = player.get_component(Transform)
                 health = player.get_component(Health)
-                rigidbody = player.get_component(RigidBody)
+                body = player.get_component(CharacterBody)
                 controller = player.get_component(PlatformerController)
 
                 if transform:
@@ -311,10 +312,10 @@ class GameScene(Scene):
                     # across the level for a frame.
                     transform.teleport(spawn)
 
-                # Also update physics body position and reset velocity
-                if rigidbody and rigidbody.handle:
-                    rigidbody.handle.position = spawn
-                    rigidbody.handle.velocity = Vector2.zero()
+                # Reset velocity so the fall that killed the player doesn't
+                # carry over into the respawn.
+                if body:
+                    body.velocity = Vector2.zero()
 
                 if health:
                     health.current = health.max_health

--- a/games/guara_falcao/scenes.py
+++ b/games/guara_falcao/scenes.py
@@ -510,7 +510,12 @@ class GameScene(Scene):
                 health = player.get_component(Health)
 
                 if transform and sprite:
-                    screen_pos = transform.position - camera_offset
+                    # render_position, not position: drawing the raw fixed-tick
+                    # position makes motion stutter whenever the display rate
+                    # is not locked to the 60Hz physics rate.
+                    screen_pos = (
+                        transform.render_position(self.render_alpha) - camera_offset
+                    )
 
                     # Flash when invincible
                     color = sprite.color

--- a/games/guara_falcao/scenes.py
+++ b/games/guara_falcao/scenes.py
@@ -299,7 +299,10 @@ class GameScene(Scene):
                 controller = player.get_component(PlatformerController)
 
                 if transform:
-                    transform.position = spawn
+                    # teleport(), not assignment: a respawn is not motion, and
+                    # interpolating it would draw the player sliding back
+                    # across the level for a frame.
+                    transform.teleport(spawn)
 
                 # Also update physics body position and reset velocity
                 if rigidbody and rigidbody.handle:

--- a/games/guara_falcao/scenes.py
+++ b/games/guara_falcao/scenes.py
@@ -27,6 +27,7 @@ from games.guara_falcao.systems import (
     CollectibleSystem,
     HazardSystem,
     HealthSystem,
+    PatrolSystem,
     PlayerControlSystem,
 )
 from pyguara.common.components import Transform
@@ -45,6 +46,8 @@ from pyguara.physics.physics_system import PhysicsSystem
 from pyguara.physics.platformer_controller import PlatformerController
 from pyguara.physics.platformer_system import PlatformerSystem
 from pyguara.physics.protocols import IPhysicsEngine
+from pyguara.physics.solid_mover import SolidMover
+from pyguara.physics.solid_system import SolidSystem
 from pyguara.scene.base import Scene
 from pyguara.scene.manager import SceneManager
 from pyguara.scripting.coroutines import CoroutineManager, wait_for_seconds
@@ -129,6 +132,8 @@ class GameScene(Scene):
         # Systems
         self._physics_system: PhysicsSystem | None = None
         self._platformer_system: PlatformerSystem | None = None
+        self._solid_system: SolidSystem | None = None
+        self._patrol_system: PatrolSystem | None = None
         self._collider_debug: ColliderDebugRenderer | None = None
         self._show_colliders = False
         self._player_control: PlayerControlSystem | None = None
@@ -180,11 +185,17 @@ class GameScene(Scene):
             gravity=Vector2(physics_config.gravity_x, physics_config.gravity_y),
         )
 
+        solid_mover = SolidMover(
+            self.entity_manager, physics_engine, self.event_dispatcher
+        )
         self._platformer_system = PlatformerSystem(
             entity_manager=self.entity_manager,
             physics_engine=physics_engine,
             gravity=Vector2(physics_config.gravity_x, physics_config.gravity_y),
+            solid_mover=solid_mover,
         )
+        self._solid_system = SolidSystem(self.entity_manager, solid_mover)
+        self._patrol_system = PatrolSystem(self.entity_manager)
 
         # Initialize game systems
         self._player_control = PlayerControlSystem(
@@ -375,11 +386,28 @@ class GameScene(Scene):
         # Reset jump flag after it's been consumed
         self._jump_pressed = False
 
-        # Platformer system must run at fixed rate with physics
+        # 1. Whatever authors a solid's motion (patrol, here) runs first.
+        if self._patrol_system:
+            self._patrol_system.update(fixed_dt)
+
+        # 2. Push those Transform changes into the engine before anything
+        #    queries it this tick -- solids are still ordinary Chipmunk
+        #    kinematic bodies, so raycasts/overlap queries against them
+        #    need to see where they already are.
+        if self._physics_system:
+            self._physics_system.sync_kinematic_transforms()
+
+        # 3. Solids carry/push whatever they touched.
+        if self._solid_system:
+            self._solid_system.update(fixed_dt)
+
+        # 4. The character's own movement, swept by CharacterMover against
+        #    this tick's (already current) geometry.
         if self._platformer_system:
             self._platformer_system.update(fixed_dt)
 
-        # Physics simulation step
+        # 5. Step the simulation, for whatever is still a genuine Chipmunk
+        #    dynamic body -- nothing character-adjacent is, any more.
         if self._physics_system:
             self._physics_system.update(fixed_dt)
 

--- a/games/guara_falcao/scenes.py
+++ b/games/guara_falcao/scenes.py
@@ -36,10 +36,11 @@ from pyguara.events.dispatcher import EventDispatcher
 from pyguara.graphics.components.camera import Camera2D
 from pyguara.graphics.protocols import IRenderer, UIRenderer
 from pyguara.input.events import OnActionEvent
-from pyguara.input.keys import ESCAPE, LEFT, RIGHT, SPACE, UP, R
+from pyguara.input.keys import ESCAPE, F1, LEFT, RIGHT, SPACE, UP, R
 from pyguara.input.manager import InputManager
 from pyguara.input.types import ActionType, InputDevice
 from pyguara.physics.components import RigidBody
+from pyguara.physics.debug_draw import ColliderDebugRenderer
 from pyguara.physics.physics_system import PhysicsSystem
 from pyguara.physics.platformer_controller import PlatformerController
 from pyguara.physics.platformer_system import PlatformerSystem
@@ -128,6 +129,8 @@ class GameScene(Scene):
         # Systems
         self._physics_system: PhysicsSystem | None = None
         self._platformer_system: PlatformerSystem | None = None
+        self._collider_debug: ColliderDebugRenderer | None = None
+        self._show_colliders = False
         self._player_control: PlayerControlSystem | None = None
         self._animation_fsm: AnimationFSMSystem | None = None
         self._camera_follow: CameraFollowSystem | None = None
@@ -239,6 +242,7 @@ class GameScene(Scene):
         im.register_action("jump", ActionType.PRESS)
         im.register_action("restart", ActionType.PRESS)
         im.register_action("back", ActionType.PRESS)
+        im.register_action("toggle_colliders", ActionType.PRESS)
 
         im.bind_input(InputDevice.KEYBOARD, LEFT, "move_left")
         im.bind_input(InputDevice.KEYBOARD, RIGHT, "move_right")
@@ -246,6 +250,7 @@ class GameScene(Scene):
         im.bind_input(InputDevice.KEYBOARD, UP, "jump")
         im.bind_input(InputDevice.KEYBOARD, R, "restart")
         im.bind_input(InputDevice.KEYBOARD, ESCAPE, "back")
+        im.bind_input(InputDevice.KEYBOARD, F1, "toggle_colliders")
 
         # Subscribe to action events
         self.event_dispatcher.subscribe(OnActionEvent, self._on_action)
@@ -266,6 +271,8 @@ class GameScene(Scene):
             self._restart_level()
         elif action == "back" and is_pressed:
             self.container.get(SceneManager).pop_scene()
+        elif action == "toggle_colliders" and is_pressed:
+            self._show_colliders = not self._show_colliders
 
     def _setup_hud(self) -> None:
         """Create HUD elements."""
@@ -273,7 +280,7 @@ class GameScene(Scene):
 
         # Instructions
         instructions = Label(
-            "Arrows/Space: Move & Jump | R: Restart | ESC: Menu",
+            "Arrows/Space: Move & Jump | R: Restart | F1: Colliders | ESC: Menu",
             position=Vector2(20, 560),
         )
         ui_manager.add_element(instructions)
@@ -549,6 +556,11 @@ class GameScene(Scene):
                             8,
                         )
                         world_renderer.draw_rect(indicator_rect, Color(255, 200, 150))
+
+        if self._show_colliders:
+            if self._collider_debug is None:
+                self._collider_debug = ColliderDebugRenderer(self.entity_manager)
+            self._collider_debug.render(world_renderer, camera_offset)
 
         # Render HUD
         self._render_hud(world_renderer)

--- a/games/guara_falcao/systems.py
+++ b/games/guara_falcao/systems.py
@@ -8,6 +8,7 @@ from games.guara_falcao.components import (
     Collectible,
     Hazard,
     Health,
+    PatrolMotion,
     PlayerAnimState,
     PlayerState,
     Score,
@@ -434,3 +435,35 @@ class HazardSystem:
             knockback,
             self.KNOCKBACK_DURATION,
         )
+
+
+class PatrolSystem:
+    """Moves every PatrolMotion entity back and forth between two points.
+
+    Demo content for the CharacterMover switch: `MovingSolid` needs
+    something to author its Transform's motion, and this is the simplest
+    thing that could -- a straight line, reversing at each end. Its only
+    job is to move the Transform; SolidSystem (run right after this, before
+    PlatformerSystem, in GameplayScene.fixed_update) is what turns that
+    displacement into carrying or pushing whatever touches it.
+    """
+
+    def __init__(self, entity_manager: EntityManager) -> None:
+        """Initialize the system."""
+        self._em = entity_manager
+
+    def update(self, dt: float) -> None:
+        """Advance every patrol by one tick."""
+        for entity in self._em.get_entities_with(PatrolMotion, Transform):
+            motion = entity.get_component(PatrolMotion)
+            transform = entity.get_component(Transform)
+
+            target = motion.end if motion._direction > 0 else motion.start
+            to_target = target - transform.position
+            step = motion.speed * dt
+
+            if to_target.magnitude <= step:
+                transform.position = target
+                motion._direction *= -1.0
+            else:
+                transform.position = transform.position + to_target.normalize() * step

--- a/games/guara_falcao/systems.py
+++ b/games/guara_falcao/systems.py
@@ -27,11 +27,13 @@ from pyguara.ecs.entity import Entity
 from pyguara.ecs.manager import EntityManager
 from pyguara.events.dispatcher import EventDispatcher
 from pyguara.graphics.components.camera import Camera2D, CameraFollowConstraints
+from pyguara.physics.components import CharacterBody
 from pyguara.physics.platformer_controller import (
     PlatformerController,
     PlatformerInput,
     PlatformerState,
 )
+from pyguara.physics.platformer_system import apply_knockback
 
 
 class PlayerControlSystem:
@@ -355,6 +357,8 @@ class HazardSystem:
     """Handles hazard collision detection and damage."""
 
     HAZARD_DISTANCE = 20.0  # Distance to trigger hazard damage
+    KNOCKBACK_DURATION = 0.25  # Seconds input control stays suppressed
+    KNOCKBACK_LIFT = 0.5  # Fraction of knockback_force added upward
 
     def __init__(
         self, entity_manager: EntityManager, event_dispatcher: EventDispatcher
@@ -393,6 +397,7 @@ class HazardSystem:
             if distance < self.HAZARD_DISTANCE:
                 # Apply damage
                 alive = player_health.take_damage(hazard.damage)
+                self._apply_knockback(hazard, player_transform, transform)
 
                 self._dispatcher.dispatch(
                     PlayerDamagedEvent(
@@ -403,3 +408,29 @@ class HazardSystem:
                 if not alive:
                     self._dispatcher.dispatch(PlayerDeathEvent())
                 break  # Only one hazard can damage per frame
+
+    def _apply_knockback(
+        self, hazard: Hazard, player_transform: Transform, hazard_transform: Transform
+    ) -> None:
+        """Shove the player away from a hazard that just hit it.
+
+        Wires up Hazard.knockback_force, declared on the component from
+        the start but never consumed by anything until now -- there was
+        no velocity for a dynamic-body player to receive it as that didn't
+        also fight PlatformerSystem's own control every tick. A
+        CharacterBody has a real place for it: apply_knockback() overrides
+        velocity and suppresses input control for a short window instead.
+        """
+        if not self._player or not self._player.has_component(CharacterBody):
+            return
+
+        away = (player_transform.position - hazard_transform.position).normalize()
+        knockback = Vector2(
+            away.x * hazard.knockback_force,
+            -hazard.knockback_force * self.KNOCKBACK_LIFT,
+        )
+        apply_knockback(
+            self._player.get_component(CharacterBody),
+            knockback,
+            self.KNOCKBACK_DURATION,
+        )

--- a/pyguara/application/bootstrap.py
+++ b/pyguara/application/bootstrap.py
@@ -301,7 +301,11 @@ def _setup_container(headless: bool = False) -> DIContainer:
     container.register_instance(ResourceManager, res_manager)
 
     # Physics Engine
-    physics_engine = PymunkEngine(substeps=config_manager.config.physics.substeps)
+    physics_config = config_manager.config.physics
+    physics_engine = PymunkEngine(
+        substeps=physics_config.substeps,
+        penetration_recovery=physics_config.penetration_recovery,
+    )
     container.register_instance(IPhysicsEngine, physics_engine)  # type: ignore[type-abstract]
 
     # Collision System (bridges pymunk callbacks to PyGuara events)

--- a/pyguara/common/components.py
+++ b/pyguara/common/components.py
@@ -72,9 +72,16 @@ class Transform(BaseComponent):
         most of the engine, so it is not attempted piecemeal.
 
     Attributes:
-        interpolate: Opt in to fixed-timestep render interpolation.
+        interpolate: Whether the renderer draws this between fixed ticks.
+            Set automatically by `PhysicsSystem` for bodies it creates, which
+            are the transforms that need it: they advance at the fixed rate,
+            so drawing the raw tick position stutters on any display not
+            locked to it. Leave it off for a transform a system moves every
+            frame in variable-rate `update()` -- that is already frame-exact,
+            and interpolating it mixes two clocks and adds judder instead of
+            removing it. Use `teleport()` for moves that are not motion.
         previous_position: Position at the previous fixed tick, maintained by
-            `SceneManager.fixed_update()` when `interpolate` is set.
+            `SceneManager.fixed_update()` while `interpolate` is set.
     """
 
     _allow_methods = True  # See the note above: hierarchy math lives here.
@@ -92,7 +99,8 @@ class Transform(BaseComponent):
             position: Local position. Defaults to the origin.
             rotation: Local rotation in radians.
             scale: Local scale. Defaults to `(1, 1)`.
-            interpolate: Opt in to fixed-timestep render interpolation.
+            interpolate: Draw between fixed ticks. Physics-driven
+                transforms get this automatically; see the class docstring.
         """
         super().__init__()
 
@@ -118,6 +126,24 @@ class Transform(BaseComponent):
         # render_alpha instead of using the current position directly.
         self.interpolate = interpolate
         self.previous_position: Vector2 = self._local_position
+
+    def teleport(self, position: Vector2) -> None:
+        """Move without drawing the journey.
+
+        A normal position change is interpolated, so the renderer draws the
+        entity partway between where it was and where it now is. That is what
+        makes ordinary motion smooth, and exactly wrong for a move that is not
+        motion: a respawn, a level load, wrapping around a screen edge. Those
+        would be drawn as a streak across everything in between for one frame.
+
+        This sets both the current and previous position, leaving nothing to
+        interpolate across.
+
+        Args:
+            position: Where to place the transform.
+        """
+        self.position = position
+        self.previous_position = self.position
 
     def render_position(self, alpha: float) -> Vector2:
         """Return where this transform should be drawn between two ticks.

--- a/pyguara/common/components.py
+++ b/pyguara/common/components.py
@@ -119,6 +119,34 @@ class Transform(BaseComponent):
         self.interpolate = interpolate
         self.previous_position: Vector2 = self._local_position
 
+    def render_position(self, alpha: float) -> Vector2:
+        """Return where this transform should be drawn between two ticks.
+
+        Physics advances at a fixed rate while frames are presented at the
+        display's rate, so drawing `position` directly shows the last
+        completed tick. When those rates are not locked together some frames
+        show no movement and the next shows two ticks' worth -- motion that
+        reads as stutter even though the simulation is perfectly regular.
+        At 60Hz physics on a 75Hz display, a body moving 300 px/s is drawn
+        in steps of 0 to 5 pixels where every step should be 4.
+
+        Interpolating between the previous tick and the current one, by how
+        far the frame sits between them, removes that. It costs one tick of
+        latency, which is why it is opt-in through `interpolate`; a transform
+        that has not opted in is drawn where it is, and `previous_position`
+        is not maintained for it.
+
+        Args:
+            alpha: Progress through the current tick, 0.0 to 1.0. The
+                application hands this to `Scene.render` as `render_alpha`.
+
+        Returns:
+            The position to draw at.
+        """
+        if not self.interpolate:
+            return self.position
+        return self.previous_position.lerp(self.position, alpha)
+
     # --- Properties ---
 
     @property

--- a/pyguara/config/types.py
+++ b/pyguara/config/types.py
@@ -80,6 +80,12 @@ class PhysicsConfig:
     # can stop, at proportional solver cost. 1 disables substepping.
     substeps: int = 4
 
+    # Fraction of any remaining collider overlap resolved per 1/60s.
+    # Chipmunk's own default of 0.1 loses to gravity: a character that lands
+    # inside the floor climbs out at a fraction of a pixel per tick and looks
+    # stuck in the ground for seconds.
+    penetration_recovery: float = 0.3
+
     @property
     def fixed_dt(self) -> float:
         """The fixed timestep in seconds.

--- a/pyguara/physics/backends/pymunk_impl.py
+++ b/pyguara/physics/backends/pymunk_impl.py
@@ -27,6 +27,13 @@ DEFAULT_SUBSTEPS = 4
 # widens what the ray can touch, including the caster's own collider.
 RAYCAST_RADIUS = 1.0
 
+# Fraction of any remaining overlap Chipmunk removes per 1/60s. Its own
+# default is 10%, which loses to gravity: a character that lands 9px inside
+# the floor comes out at about 0.04px a tick, so it sits visibly sunk for
+# seconds. 30% clears it in a few frames and leaves a stack of boxes just as
+# steady -- measured, no jitter and no drift at 30% or even 50%.
+DEFAULT_PENETRATION_RECOVERY = 0.3
+
 
 def _one_way_allows_contact(
     arbiter: pymunk.Arbiter, shape_a: pymunk.Shape, shape_b: pymunk.Shape
@@ -146,10 +153,18 @@ class PymunkBodyAdapter:
 class PymunkEngine:
     """Pymunk backend implementation."""
 
-    def __init__(self, substeps: int = DEFAULT_SUBSTEPS) -> None:
+    def __init__(
+        self,
+        substeps: int = DEFAULT_SUBSTEPS,
+        penetration_recovery: float = DEFAULT_PENETRATION_RECOVERY,
+    ) -> None:
         """Initialize the Pymunk engine wrapper.
 
         Args:
+            penetration_recovery: Fraction of remaining overlap removed per
+                1/60s, between 0 and 1. Chipmunk's own 10% is too weak to
+                beat continuous gravity, leaving a landed character visibly
+                sunk; too high and stacks jitter.
             substeps: How many solver steps one call to `update()` becomes.
                 Chipmunk has no continuous collision detection, so a body
                 moves `velocity * dt` in a straight jump each step and passes
@@ -160,8 +175,17 @@ class PymunkEngine:
         Raises:
             ValueError: If `substeps` is not positive. Zero would step the
                 simulation not at all and negative is meaningless; both are
-                far better caught here than as a frozen world.
+                far better caught here than as a frozen world. Also if
+                `penetration_recovery` is outside (0, 1]: zero never separates
+                overlapping bodies at all.
         """
+        if not 0.0 < penetration_recovery <= 1.0:
+            raise ValueError(
+                f"penetration_recovery must be within (0, 1], got "
+                f"{penetration_recovery}. It is the fraction of overlap "
+                f"removed per 1/60s."
+            )
+        self._penetration_recovery = penetration_recovery
         if substeps <= 0:
             raise ValueError(
                 f"substeps must be positive, got {substeps}. It is the number "
@@ -178,6 +202,8 @@ class PymunkEngine:
         """Initialize the physics space with gravity."""
         self.space = pymunk.Space()
         self.space.gravity = (gravity.x, gravity.y)
+        # Chipmunk expresses this as the error *remaining* after one second.
+        self.space.collision_bias = pow(1.0 - self._penetration_recovery, 60)
 
         # Setup collision handlers if collision system is already registered
         if self._collision_system:
@@ -610,6 +636,39 @@ class PymunkEngine:
             distance=start.distance_to(point),
             entity_id=getattr(query.shape.body, "entity_id", None),
         )
+
+    def overlap_box(
+        self,
+        centre: Vector2,
+        half_extents: Vector2,
+        ignore_entity_id: int | str | None = None,
+    ) -> bool:
+        """Report whether an axis-aligned box overlaps any solid shape.
+
+        Args:
+            centre: Box centre in world space.
+            half_extents: Half width and half height.
+            ignore_entity_id: Body to disregard, normally the mover itself.
+
+        Returns:
+            True if the box would overlap a solid, non-sensor shape.
+        """
+        if not self.space:
+            return False
+
+        probe_body = pymunk.Body(body_type=pymunk.Body.KINEMATIC)
+        probe_body.position = (centre.x, centre.y)
+        probe = pymunk.Poly.create_box(
+            probe_body, (half_extents.x * 2, half_extents.y * 2)
+        )
+
+        for hit in self.space.shape_query(probe):
+            if hit.shape is None or hit.shape.sensor:
+                continue
+            if getattr(hit.shape.body, "entity_id", None) == ignore_entity_id:
+                continue
+            return True
+        return False
 
     def create_joint(
         self,

--- a/pyguara/physics/backends/pymunk_impl.py
+++ b/pyguara/physics/backends/pymunk_impl.py
@@ -642,8 +642,8 @@ class PymunkEngine:
         centre: Vector2,
         half_extents: Vector2,
         ignore_entity_id: int | str | None = None,
-    ) -> bool:
-        """Report whether an axis-aligned box overlaps any solid shape.
+    ) -> int | str | None:
+        """Report which entity's solid shape an axis-aligned box overlaps.
 
         Args:
             centre: Box centre in world space.
@@ -651,10 +651,11 @@ class PymunkEngine:
             ignore_entity_id: Body to disregard, normally the mover itself.
 
         Returns:
-            True if the box would overlap a solid, non-sensor shape.
+            The entity id of the first solid, non-sensor shape found
+            overlapping, or None if the box is clear.
         """
         if not self.space:
-            return False
+            return None
 
         probe_body = pymunk.Body(body_type=pymunk.Body.KINEMATIC)
         probe_body.position = (centre.x, centre.y)
@@ -665,10 +666,11 @@ class PymunkEngine:
         for hit in self.space.shape_query(probe):
             if hit.shape is None or hit.shape.sensor:
                 continue
-            if getattr(hit.shape.body, "entity_id", None) == ignore_entity_id:
+            entity_id = getattr(hit.shape.body, "entity_id", None)
+            if entity_id == ignore_entity_id:
                 continue
-            return True
-        return False
+            return entity_id
+        return None
 
     def create_joint(
         self,

--- a/pyguara/physics/backends/pymunk_impl.py
+++ b/pyguara/physics/backends/pymunk_impl.py
@@ -23,6 +23,10 @@ from pyguara.physics.types import (
 # the solver cost -- cheap for the body counts a 2D game runs.
 DEFAULT_SUBSTEPS = 4
 
+# Ray queries are swept circles in Chipmunk. Keep the radius small: it
+# widens what the ray can touch, including the caster's own collider.
+RAYCAST_RADIUS = 1.0
+
 
 class PymunkBodyAdapter:
     """Wrapper around pymunk.Body to conform to IPhysicsBody."""
@@ -397,27 +401,66 @@ class PymunkEngine:
             return shape
 
     def raycast(
-        self, start: Vector2, end: Vector2, mask: int = 0xFFFFFFFF
+        self,
+        start: Vector2,
+        end: Vector2,
+        mask: int = 0xFFFFFFFF,
+        ignore_entity_id: int | str | None = None,
     ) -> RaycastHit | None:
-        """Perform a raycast query."""
+        """Perform a raycast query.
+
+        Args:
+            start: Ray origin in world space.
+            end: Ray end in world space.
+            mask: Collision mask; shapes outside it are ignored.
+            ignore_entity_id: Skip hits on this entity's own body.
+
+        Returns:
+            The nearest hit that is not excluded, or None.
+        """
         if not self.space:
             return None
 
-        query = self.space.segment_query_first(
-            (start.x, start.y),
-            (end.x, end.y),
-            1.0,  # Radius
-            pymunk.ShapeFilter(mask=mask),
-        )
+        shape_filter = pymunk.ShapeFilter(mask=mask)
 
-        if query:
-            return RaycastHit(
-                position=Vector2(query.point.x, query.point.y),
-                normal=Vector2(query.normal.x, query.normal.y),
-                distance=start.distance_to(Vector2(query.point.x, query.point.y)),
-                entity_id=getattr(query.shape.body, "entity_id", None),
+        if ignore_entity_id is None:
+            query = self.space.segment_query_first(
+                (start.x, start.y), (end.x, end.y), RAYCAST_RADIUS, shape_filter
             )
+            return self._to_hit(query, start)
+
+        # segment_query_first cannot exclude one body, so take every hit and
+        # return the nearest that is not the caster's own. A character casting
+        # for the ground under its feet starts the ray at its own edge, and a
+        # self-hit reads as permanently grounded.
+        hits = self.space.segment_query(
+            (start.x, start.y), (end.x, end.y), RAYCAST_RADIUS, shape_filter
+        )
+        for hit in sorted(hits, key=lambda h: h.alpha):
+            if getattr(hit.shape.body, "entity_id", None) != ignore_entity_id:
+                return self._to_hit(hit, start)
         return None
+
+    @staticmethod
+    def _to_hit(query: Any, start: Vector2) -> RaycastHit | None:
+        """Convert a pymunk query result into a `RaycastHit`.
+
+        Args:
+            query: A pymunk segment query result, or None.
+            start: The ray origin, for computing distance.
+
+        Returns:
+            The hit, or None when the query found nothing.
+        """
+        if not query:
+            return None
+        point = Vector2(query.point.x, query.point.y)
+        return RaycastHit(
+            position=point,
+            normal=Vector2(query.normal.x, query.normal.y),
+            distance=start.distance_to(point),
+            entity_id=getattr(query.shape.body, "entity_id", None),
+        )
 
     def create_joint(
         self,

--- a/pyguara/physics/backends/pymunk_impl.py
+++ b/pyguara/physics/backends/pymunk_impl.py
@@ -28,6 +28,30 @@ DEFAULT_SUBSTEPS = 4
 RAYCAST_RADIUS = 1.0
 
 
+def _scaled_gravity(scale: float) -> Any:
+    """Build a velocity callback applying scaled gravity to one body.
+
+    Chipmunk has no per-body gravity multiplier; the integration callback is
+    the supported place to vary it. Everything else about the default
+    integration -- damping, the mass term -- is left alone.
+
+    Args:
+        scale: Multiplier on world gravity for this body.
+
+    Returns:
+        A callback suitable for `pymunk.Body.velocity_func`.
+    """
+
+    def velocity_func(
+        body: pymunk.Body, gravity: Any, damping: float, dt: float
+    ) -> None:
+        pymunk.Body.update_velocity(
+            body, (gravity[0] * scale, gravity[1] * scale), damping, dt
+        )
+
+    return velocity_func
+
+
 class PymunkBodyAdapter:
     """Wrapper around pymunk.Body to conform to IPhysicsBody."""
 
@@ -298,8 +322,23 @@ class PymunkEngine:
         body_type: BodyType,
         position: Vector2,
         mass: float = 1.0,
+        fixed_rotation: bool = False,
+        gravity_scale: float = 1.0,
     ) -> IPhysicsBody:
-        """Create and register a new physics body."""
+        """Create and register a new physics body.
+
+        Args:
+            entity_id: Owning entity, stored on the body for collision routing.
+            body_type: Static, kinematic or dynamic.
+            position: World position.
+            mass: Mass for dynamic bodies.
+            fixed_rotation: Stop the body rotating. A character box that can
+                tip over is almost never wanted; this is how you keep one
+                upright without freezing its position.
+            gravity_scale: Multiplier on world gravity for this body alone.
+                0.0 floats, 2.0 falls twice as fast -- the usual way to give
+                a character a floaty jump or a fast fall.
+        """
         if not self.space:
             raise RuntimeError(
                 "Physics engine not initialized. Call initialize(gravity) first."
@@ -321,6 +360,17 @@ class PymunkEngine:
             body = pymunk.Body(body_type=pm_type)
 
         body.position = (position.x, position.y)
+
+        if pm_type == pymunk.Body.DYNAMIC:
+            if fixed_rotation:
+                # Infinite moment of inertia: torque produces no angular
+                # acceleration, so the body cannot be turned. Recorded on the
+                # body as well, because attaching a shape re-derives mass and
+                # moment from its density and would undo this.
+                body.moment = float("inf")
+            body.pyguara_fixed_rotation = fixed_rotation
+            if gravity_scale != 1.0:
+                body.velocity_func = _scaled_gravity(gravity_scale)
 
         # Store entity ID on body for collisions
         body.entity_id = entity_id
@@ -398,6 +448,13 @@ class PymunkEngine:
             shape.filter = filter
 
             self.space.add(shape)
+
+            # Setting density makes Chipmunk recompute the body's mass and
+            # moment from its shapes, which silently discards the infinite
+            # moment that fixed_rotation asked for.
+            if getattr(body, "pyguara_fixed_rotation", False):
+                body.moment = float("inf")
+
             return shape
 
     def raycast(

--- a/pyguara/physics/backends/pymunk_impl.py
+++ b/pyguara/physics/backends/pymunk_impl.py
@@ -28,6 +28,49 @@ DEFAULT_SUBSTEPS = 4
 RAYCAST_RADIUS = 1.0
 
 
+def _one_way_allows_contact(
+    arbiter: pymunk.Arbiter, shape_a: pymunk.Shape, shape_b: pymunk.Shape
+) -> bool:
+    """Decide whether a one-way surface should resist this contact.
+
+    Rejected per step from the pass-through side, rather than switched off
+    once at first contact: a character that jumps up through a platform and
+    lands on it never separates in between, so a one-shot decision would keep
+    letting it fall through the top.
+
+    The test is the contact normal, not the body's velocity. Velocity is zero
+    at the apex of a jump, so a velocity test flips to solid while the
+    character still overlaps the platform and ejects it.
+
+    Args:
+        arbiter: The pymunk arbiter for this contact.
+        shape_a: First shape in the pair.
+        shape_b: Second shape.
+
+    Returns:
+        True to let the contact resolve normally, False to pass through. The
+        caller suppresses the response via `arbiter.process_collision`, which
+        is what pymunk 7 honours -- a callback's return value is ignored.
+    """
+    for shape, sign in ((shape_a, 1.0), (shape_b, -1.0)):
+        solid = getattr(shape, "pyguara_one_way_normal", None)
+        if solid is None:
+            continue
+
+        # The arbiter normal runs from the first shape to the second, so it
+        # already points platform -> other body when the platform is first,
+        # and must be flipped when it is second.
+        normal = arbiter.contact_point_set.normal
+        towards_other_x = normal.x * sign
+        towards_other_y = normal.y * sign
+
+        # Positive means the other body sits on the solid face.
+        if towards_other_x * solid[0] + towards_other_y * solid[1] <= 0:
+            return False
+
+    return True
+
+
 def _scaled_gravity(scale: float) -> Any:
     """Build a velocity callback applying scaled gravity to one body.
 
@@ -206,10 +249,17 @@ class PymunkEngine:
         Returns:
             True to process collision, False to ignore.
         """
+        shape_a, shape_b = arbiter.shapes
+
+        if not _one_way_allows_contact(arbiter, shape_a, shape_b):
+            # pymunk 7 ignores the callback's return value; `process_collision`
+            # is what actually suppresses the response.
+            arbiter.process_collision = False
+            return False
+
         if not self._collision_system:
             return True
 
-        shape_a, shape_b = arbiter.shapes
         entity_a = getattr(shape_a.body, "entity_id", None)
         entity_b = getattr(shape_b.body, "entity_id", None)
 
@@ -229,9 +279,18 @@ class PymunkEngine:
         impulse = arbiter.total_impulse.length
         is_sensor = shape_a.sensor or shape_b.sensor
 
-        return self._collision_system.on_collision_begin(  # type: ignore[no-any-return]
+        process = self._collision_system.on_collision_begin(
             str(entity_a), str(entity_b), point, normal, impulse, is_sensor
         )
+
+        # The collision system returns False to mean "report this but do not
+        # resolve it physically" -- how a trigger that is not a sensor is meant
+        # to work. pymunk 7 ignores a callback's return value, so that has to
+        # be expressed through the arbiter or it does nothing at all.
+        if not process:
+            arbiter.process_collision = False
+
+        return bool(process)
 
     def _on_pymunk_persist(
         self, arbiter: pymunk.Arbiter, space: pymunk.Space, data: dict
@@ -269,9 +328,18 @@ class PymunkEngine:
         impulse = arbiter.total_impulse.length
         is_sensor = shape_a.sensor or shape_b.sensor
 
-        return self._collision_system.on_collision_persist(  # type: ignore[no-any-return]
+        process = self._collision_system.on_collision_persist(
             str(entity_a), str(entity_b), point, normal, impulse, is_sensor
         )
+
+        # The collision system returns False to mean "report this but do not
+        # resolve it physically" -- how a trigger that is not a sensor is meant
+        # to work. pymunk 7 ignores a callback's return value, so that has to
+        # be expressed through the arbiter or it does nothing at all.
+        if not process:
+            arbiter.process_collision = False
+
+        return bool(process)
 
     def _on_pymunk_end(
         self, arbiter: pymunk.Arbiter, space: pymunk.Space, data: dict
@@ -411,8 +479,26 @@ class PymunkEngine:
         material: PhysicsMaterial,
         collision_layer: CollisionLayer,
         is_sensor: bool,
+        one_way: bool = False,
+        one_way_normal: Vector2 | None = None,
     ) -> Any:
-        """Attach a collision shape to a body."""
+        """Attach a collision shape to a body.
+
+        Args:
+            body_handle: The body to attach to.
+            shape_type: Circle, box, segment or polygon.
+            dimensions: Radius, or width and height.
+            offset: Local offset from the body's centre.
+            material: Friction, restitution and density.
+            collision_layer: Category, mask and group filtering.
+            is_sensor: Detect overlaps without blocking.
+            one_way: Solid from one side only.
+            one_way_normal: Which side is solid, in world space. Defaults to
+                `(0, -1)` when `one_way` is set.
+
+        Returns:
+            The pymunk shape, or None if there is no space or shape type.
+        """
         if not self.space:
             return None
 
@@ -446,6 +532,12 @@ class PymunkEngine:
                 group=collision_layer.group,
             )
             shape.filter = filter
+
+            # Recorded on the shape so the pre-solve handler can find it: it
+            # sees pymunk shapes, not PyGuara components.
+            if one_way:
+                solid = one_way_normal if one_way_normal is not None else Vector2(0, -1)
+                shape.pyguara_one_way_normal = (solid.x, solid.y)
 
             self.space.add(shape)
 

--- a/pyguara/physics/character_mover.py
+++ b/pyguara/physics/character_mover.py
@@ -1,0 +1,183 @@
+"""Move a character by sweeping it and stopping flush against what it hits.
+
+The engine's platformer characters are dynamic rigid bodies whose velocity is
+assigned each tick. That works until the character is pressed into geometry:
+the solver is left to push it back out, and while it does, the character is
+*inside* the world. Measured in guara_falcao, a character that jumped while
+running landed 8px inside the floor and climbed out at 0.04px a tick -- it
+reads as sinking into the ground.
+
+This is the other approach, and the one platformers generally use (Godot's
+`move_and_slide`, Unity's `CharacterController`, Celeste's actors): move the
+character yourself, in steps small enough to never skip a surface, and stop
+it flush the moment the next step would overlap something. Penetration is
+not resolved after the fact because it never happens.
+
+What this deliberately does not do: rotate, push dynamic bodies, or handle
+slopes. It is an axis-aligned mover for characters, not a physics solver.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pyguara.common.types import Vector2
+from pyguara.physics.protocols import IPhysicsEngine
+
+# A step no larger than this is taken before testing for overlap. It bounds
+# how far the character can move without being checked, so it is also what
+# stops a fast character from stepping over a thin wall entirely.
+MAX_STEP = 4.0
+
+# Halvings used to settle against a surface. Eight brings a 4px step within
+# ~0.016px, far below anything a 2D game can show.
+BISECTIONS = 8
+
+# The probe box is shrunk by this much on each side. Without it a character
+# resting exactly flush on the floor reads as overlapping it -- a touching
+# contact counts -- and then every candidate position looks blocked and the
+# character cannot move at all. Unity calls the same allowance skin width.
+# It is well under a pixel, and under Chipmunk's own 0.1px collision slop.
+SKIN = 0.05
+
+
+@dataclass(frozen=True)
+class MoveResult:
+    """What a move ran into.
+
+    Attributes:
+        position: Where the character ended up.
+        hit_x: True if horizontal motion was stopped by something.
+        hit_y: True if vertical motion was stopped by something.
+        grounded: True if downward motion was stopped -- the character is
+            resting on a surface rather than merely touching one.
+    """
+
+    position: Vector2
+    hit_x: bool
+    hit_y: bool
+    grounded: bool
+
+
+class CharacterMover:
+    """Sweeps a character's box through the world one axis at a time.
+
+    Axes are resolved separately, which is what produces sliding: a character
+    walking into a wall keeps its vertical motion, and one landing while
+    running keeps its horizontal motion.
+    """
+
+    def __init__(self, engine: IPhysicsEngine) -> None:
+        """Store the engine used for overlap queries.
+
+        Args:
+            engine: Physics engine providing `overlap_box`.
+        """
+        self._engine = engine
+
+    def move(
+        self,
+        position: Vector2,
+        half_extents: Vector2,
+        delta: Vector2,
+        entity_id: int | str | None = None,
+    ) -> MoveResult:
+        """Move as far along `delta` as the world allows.
+
+        Args:
+            position: Current centre of the character's box.
+            half_extents: Half width and half height of that box.
+            delta: Desired movement this tick, in pixels.
+            entity_id: The character, excluded from overlap tests so it does
+                not detect its own collider.
+
+        Returns:
+            The final position and what stopped it.
+        """
+        x, hit_x = self._sweep_axis(
+            position, half_extents, delta.x, horizontal=True, entity_id=entity_id
+        )
+        position = Vector2(x, position.y)
+
+        y, hit_y = self._sweep_axis(
+            position, half_extents, delta.y, horizontal=False, entity_id=entity_id
+        )
+
+        return MoveResult(
+            position=Vector2(x, y),
+            hit_x=hit_x,
+            hit_y=hit_y,
+            grounded=hit_y and delta.y > 0,
+        )
+
+    def _sweep_axis(
+        self,
+        position: Vector2,
+        half_extents: Vector2,
+        distance: float,
+        horizontal: bool,
+        entity_id: int | str | None,
+    ) -> tuple[float, bool]:
+        """Advance along one axis until blocked, then settle flush.
+
+        Args:
+            position: Starting centre.
+            half_extents: Half size of the character's box.
+            distance: Signed distance to travel on this axis.
+            horizontal: True for x, False for y.
+            entity_id: Body to ignore.
+
+        Returns:
+            The coordinate reached on this axis, and whether something
+            stopped it short.
+        """
+        current = position.x if horizontal else position.y
+        if distance == 0.0:
+            return current, False
+
+        direction = 1.0 if distance > 0 else -1.0
+        remaining = abs(distance)
+
+        while remaining > 0.0:
+            step = direction * min(MAX_STEP, remaining)
+            if not self._overlaps(
+                position, half_extents, current + step, horizontal, entity_id
+            ):
+                current += step
+                remaining -= abs(step)
+                continue
+
+            # Blocked within this step: bisect for the last free position, so
+            # the character finishes touching the surface rather than inside
+            # it or short of it by a visible gap.
+            free, blocked = 0.0, step
+            for _ in range(BISECTIONS):
+                midpoint = (free + blocked) / 2
+                if self._overlaps(
+                    position, half_extents, current + midpoint, horizontal, entity_id
+                ):
+                    blocked = midpoint
+                else:
+                    free = midpoint
+            return current + free, True
+
+        return current, False
+
+    def _overlaps(
+        self,
+        position: Vector2,
+        half_extents: Vector2,
+        coordinate: float,
+        horizontal: bool,
+        entity_id: int | str | None,
+    ) -> bool:
+        """Test the character's box at one candidate coordinate."""
+        centre = (
+            Vector2(coordinate, position.y)
+            if horizontal
+            else Vector2(position.x, coordinate)
+        )
+        probe = Vector2(
+            max(half_extents.x - SKIN, 0.01), max(half_extents.y - SKIN, 0.01)
+        )
+        return self._engine.overlap_box(centre, probe, entity_id)

--- a/pyguara/physics/character_mover.py
+++ b/pyguara/physics/character_mover.py
@@ -8,13 +8,23 @@ running landed 8px inside the floor and climbed out at 0.04px a tick -- it
 reads as sinking into the ground.
 
 This is the other approach, and the one platformers generally use (Godot's
-`move_and_slide`, Unity's `CharacterController`, Celeste's actors): move the
-character yourself, in steps small enough to never skip a surface, and stop
+`move_and_slide`, Unity's `CharacterController`, and -- the model this
+follows -- Celeste's `Actor`/`Solid`): move the character yourself, and stop
 it flush the moment the next step would overlap something. Penetration is
 not resolved after the fact because it never happens.
 
-What this deliberately does not do: rotate, push dynamic bodies, or handle
-slopes. It is an axis-aligned mover for characters, not a physics solver.
+Position is kept to whole pixels. A float `remainder` accumulates whatever
+motion didn't add up to a whole pixel yet -- gravity at 900px/s^2 is 15px a
+tick at 60Hz but rarely a whole number of pixels -- so nothing is lost to
+rounding and nothing drifts: the same input produces the same motion
+regardless of how the sub-pixel amounts happened to fall. Only whole pixels
+are ever stepped, and every one of them is tested, which is what makes
+tunnelling impossible without a bisection to settle where the character
+actually stops -- the last free whole pixel *is* the answer.
+
+What this deliberately does not do: rotate, or handle slopes. It is an
+axis-aligned mover for characters, not a physics solver. Pushing other
+boxes and being carried by moving ones is `SolidMover`, built on top of this.
 """
 
 from __future__ import annotations
@@ -24,20 +34,15 @@ from dataclasses import dataclass
 from pyguara.common.types import Vector2
 from pyguara.physics.protocols import IPhysicsEngine
 
-# A step no larger than this is taken before testing for overlap. It bounds
-# how far the character can move without being checked, so it is also what
-# stops a fast character from stepping over a thin wall entirely.
-MAX_STEP = 4.0
-
-# Halvings used to settle against a surface. Eight brings a 4px step within
-# ~0.016px, far below anything a 2D game can show.
-BISECTIONS = 8
-
-# The probe box is shrunk by this much on each side. Without it a character
-# resting exactly flush on the floor reads as overlapping it -- a touching
-# contact counts -- and then every candidate position looks blocked and the
-# character cannot move at all. Unity calls the same allowance skin width.
-# It is well under a pixel, and under Chipmunk's own 0.1px collision slop.
+# The probe box is shrunk by this much on each side before every overlap
+# query. Without it, a character resting exactly flush against a surface
+# would read as overlapping it -- Chipmunk's `shape_query` counts an exact
+# touch as an overlap -- and the very next whole-pixel step in the same
+# direction would report blocked a pixel early. SKIN is applied only to the
+# query box, never to the position a character actually occupies, so it
+# does not change where anything ends up settling; it only keeps a resting
+# contact from poisoning the next step's query. Unity calls the same
+# allowance skin width. It is well under a pixel.
 SKIN = 0.05
 
 
@@ -46,21 +51,32 @@ class MoveResult:
     """What a move ran into.
 
     Attributes:
-        position: Where the character ended up.
+        position: Where the character ended up. Always whole pixels.
+        remainder: Sub-pixel motion not yet spent, to be passed back into
+            the next call so it accumulates rather than being discarded.
         hit_x: True if horizontal motion was stopped by something.
         hit_y: True if vertical motion was stopped by something.
-        grounded: True if downward motion was stopped -- the character is
-            resting on a surface rather than merely touching one.
+        blocking_x: Entity that stopped horizontal motion, or None.
+        blocking_y: Entity that stopped vertical motion, or None.
+        grounded: True if this call's downward motion was stopped -- the
+            character landed or is resting against something below it.
+            False on a tick where nothing moved it downward at all (e.g.
+            already resting, with velocity clamped to zero), even though
+            it may still be on the ground; continuous "is grounded" state
+            is `probe()`'s job, not this field's.
     """
 
     position: Vector2
+    remainder: Vector2
     hit_x: bool
     hit_y: bool
+    blocking_x: int | str | None
+    blocking_y: int | str | None
     grounded: bool
 
 
 class CharacterMover:
-    """Sweeps a character's box through the world one axis at a time.
+    """Sweeps a character's box through the world one whole pixel at a time.
 
     Axes are resolved separately, which is what produces sliding: a character
     walking into a wall keeps its vertical motion, and one landing while
@@ -80,88 +96,146 @@ class CharacterMover:
         position: Vector2,
         half_extents: Vector2,
         delta: Vector2,
+        remainder: Vector2 = Vector2(0.0, 0.0),
         entity_id: int | str | None = None,
     ) -> MoveResult:
         """Move as far along `delta` as the world allows.
 
         Args:
-            position: Current centre of the character's box.
+            position: Current centre of the character's box, whole pixels.
             half_extents: Half width and half height of that box.
-            delta: Desired movement this tick, in pixels.
+            delta: Desired movement this tick, in pixels -- typically
+                `velocity * dt`, and rarely a whole number.
+            remainder: Sub-pixel motion carried over from the previous call.
+                Pass `MoveResult.remainder` back in every tick; the zero
+                default is only for a character's first move.
             entity_id: The character, excluded from overlap tests so it does
                 not detect its own collider.
 
         Returns:
-            The final position and what stopped it.
+            The final position, the leftover remainder, and what stopped it.
         """
-        x, hit_x = self._sweep_axis(
-            position, half_extents, delta.x, horizontal=True, entity_id=entity_id
+        x, rem_x, hit_x, block_x = self._move_axis(
+            position.x,
+            half_extents,
+            delta.x,
+            remainder.x,
+            position,
+            horizontal=True,
+            entity_id=entity_id,
         )
         position = Vector2(x, position.y)
 
-        y, hit_y = self._sweep_axis(
-            position, half_extents, delta.y, horizontal=False, entity_id=entity_id
+        y, rem_y, hit_y, block_y = self._move_axis(
+            position.y,
+            half_extents,
+            delta.y,
+            remainder.y,
+            position,
+            horizontal=False,
+            entity_id=entity_id,
         )
 
         return MoveResult(
             position=Vector2(x, y),
+            remainder=Vector2(rem_x, rem_y),
             hit_x=hit_x,
             hit_y=hit_y,
+            blocking_x=block_x,
+            blocking_y=block_y,
             grounded=hit_y and delta.y > 0,
         )
 
-    def _sweep_axis(
+    def probe(
         self,
         position: Vector2,
         half_extents: Vector2,
-        distance: float,
-        horizontal: bool,
-        entity_id: int | str | None,
-    ) -> tuple[float, bool]:
-        """Advance along one axis until blocked, then settle flush.
+        direction: Vector2,
+        entity_id: int | str | None = None,
+    ) -> int | str | None:
+        """Report what, if anything, is one pixel away in `direction`.
+
+        A contact check that does not move or depend on velocity -- Celeste's
+        `OnGround()` is exactly `CollideCheck(Position + Vector2.UnitY)`, an
+        overlap test one pixel below, not a raycast. Ground/wall detection
+        built on a raycast has to work around the query's own geometry (a
+        swept circle can reach back into the caster); a probe built from the
+        same overlap primitive as `move()` can't have that problem, because
+        it is the same test a step would make.
 
         Args:
-            position: Starting centre.
+            position: The character's current centre.
+            half_extents: Half width and half height of its box.
+            direction: Which side to probe; only each axis's sign matters,
+                so `Vector2(0, 1)` probes one pixel below and
+                `Vector2(-1, 0)` probes one pixel to the left.
+            entity_id: The character, excluded from the test.
+
+        Returns:
+            The entity id found there, or None if that pixel is clear.
+        """
+        offset = Vector2(
+            1.0 if direction.x > 0 else -1.0 if direction.x < 0 else 0.0,
+            1.0 if direction.y > 0 else -1.0 if direction.y < 0 else 0.0,
+        )
+        centre = Vector2(position.x + offset.x, position.y + offset.y)
+        probe_half = Vector2(
+            max(half_extents.x - SKIN, 0.01), max(half_extents.y - SKIN, 0.01)
+        )
+        return self._engine.overlap_box(centre, probe_half, entity_id)
+
+    def _move_axis(
+        self,
+        current: float,
+        half_extents: Vector2,
+        distance: float,
+        remainder: float,
+        position: Vector2,
+        horizontal: bool,
+        entity_id: int | str | None,
+    ) -> tuple[float, float, bool, int | str | None]:
+        """Advance along one axis by whole pixels, banking the remainder.
+
+        Args:
+            current: Starting coordinate on this axis.
             half_extents: Half size of the character's box.
-            distance: Signed distance to travel on this axis.
+            distance: Signed distance requested on this axis this tick.
+            remainder: Unspent sub-pixel motion from previous ticks.
+            position: The character's full position, for the axis held
+                fixed while this one is swept.
             horizontal: True for x, False for y.
             entity_id: Body to ignore.
 
         Returns:
-            The coordinate reached on this axis, and whether something
-            stopped it short.
+            The coordinate reached, the new remainder, whether something
+            stopped it short, and what that was.
         """
-        current = position.x if horizontal else position.y
-        if distance == 0.0:
-            return current, False
+        remainder += distance
+        amount = round(remainder)
+        remainder -= amount
 
-        direction = 1.0 if distance > 0 else -1.0
-        remaining = abs(distance)
+        if amount == 0:
+            return current, remainder, False, None
 
-        while remaining > 0.0:
-            step = direction * min(MAX_STEP, remaining)
-            if not self._overlaps(
-                position, half_extents, current + step, horizontal, entity_id
-            ):
-                current += step
-                remaining -= abs(step)
-                continue
+        step = 1 if amount > 0 else -1
+        blocking: int | str | None = None
+        while amount != 0:
+            candidate = current + step
+            blocker = self._overlaps(
+                position, half_extents, candidate, horizontal, entity_id
+            )
+            if blocker is not None:
+                blocking = blocker
+                # Discard the banked remainder for the distance that
+                # couldn't be travelled -- otherwise the moment the
+                # obstruction clears, the character lurches forward by
+                # everything gravity or input piled up while it was stuck.
+                remainder = 0.0
+                break
+            current = candidate
+            amount -= step
 
-            # Blocked within this step: bisect for the last free position, so
-            # the character finishes touching the surface rather than inside
-            # it or short of it by a visible gap.
-            free, blocked = 0.0, step
-            for _ in range(BISECTIONS):
-                midpoint = (free + blocked) / 2
-                if self._overlaps(
-                    position, half_extents, current + midpoint, horizontal, entity_id
-                ):
-                    blocked = midpoint
-                else:
-                    free = midpoint
-            return current + free, True
-
-        return current, False
+        return current, remainder, blocking is not None, blocking
 
     def _overlaps(
         self,
@@ -170,7 +244,7 @@ class CharacterMover:
         coordinate: float,
         horizontal: bool,
         entity_id: int | str | None,
-    ) -> bool:
+    ) -> int | str | None:
         """Test the character's box at one candidate coordinate."""
         centre = (
             Vector2(coordinate, position.y)

--- a/pyguara/physics/components.py
+++ b/pyguara/physics/components.py
@@ -70,3 +70,86 @@ class RigidBody(BaseComponent):
     def handle(self) -> IPhysicsBody | None:
         """Access the underlying physics body interface."""
         return self._body_handle
+
+
+@dataclass
+class CharacterBody(BaseComponent):
+    """A character moved by `CharacterMover`, not the Chipmunk solver.
+
+    Replaces `RigidBody` for a platformer character: there is no shape
+    registered with the physics engine at all, so the character cannot
+    detect its own collider (the self-detection bug class this audit found
+    for ground rays becomes structurally impossible rather than guarded
+    against) and Chipmunk friction is never asked to carry or push it --
+    `SolidSystem`/`SolidMover` do that explicitly instead.
+
+    Attributes:
+        velocity: Current velocity in pixels/second. `PlatformerSystem`
+            integrates gravity into this itself, since nothing else does
+            for an entity with no physics body.
+        grounded: Whether the character is currently resting on something.
+            Set every tick from `CharacterMover.probe()`, not from
+            `MoveResult.grounded` -- a resting character often has zero
+            vertical velocity, and a move of zero distance never attempts
+            a step to report blocked.
+        riding: Entity id of the `MovingSolid` currently carrying this
+            character, or None. Lets `SolidSystem` recognise the same
+            platform across ticks rather than re-detecting a rider fresh
+            every frame.
+        squished: Set when a solid pushed this character somewhere with no
+            free space at all. The game decides what that means; nothing
+            here clears it automatically.
+        external_velocity: A knockback velocity overriding normal input
+            control while `external_velocity_timer` is running.
+        external_velocity_timer: Seconds remaining on the current
+            knockback. Ticks down to zero in `PlatformerSystem.update()`.
+    """
+
+    velocity: Vector2 = field(default_factory=lambda: Vector2(0, 0))
+    grounded: bool = field(default=False, init=False)
+    riding: int | str | None = field(default=None, init=False)
+    squished: bool = field(default=False, init=False)
+
+    external_velocity: Vector2 = field(
+        default_factory=lambda: Vector2(0, 0), init=False
+    )
+    external_velocity_timer: float = field(default=0.0, init=False)
+
+    # Celeste-style sub-pixel accumulator, round-tripped through
+    # CharacterMover.move() every tick. Never read by game code.
+    _remainder: Vector2 = field(default_factory=lambda: Vector2(0, 0), repr=False)
+
+    def __post_init__(self) -> None:
+        """Initialize base component state."""
+        super().__init__()
+
+
+@dataclass
+class MovingSolid(BaseComponent):
+    """Marks an entity whose motion should carry and push actors.
+
+    A `MovingSolid` is still an ordinary `RigidBody`/`Collider` as far as
+    Chipmunk is concerned (so genuinely dynamic bodies -- debris, ragdolls
+    -- keep colliding with it normally); `SolidSystem` additionally moves
+    any `CharacterBody` resting on or in the way of it by the same delta
+    each tick it moves, using `SolidMover`.
+    """
+
+    def __post_init__(self) -> None:
+        """Initialize base component state."""
+        super().__init__()
+
+
+@dataclass
+class Pushable(BaseComponent):
+    """Marks a `MovingSolid` a character can shove, not just ride or block on.
+
+    When `CharacterMover` finds its sweep blocked by a `Pushable` entity,
+    it asks `SolidMover` to move that entity by the remaining delta first:
+    if the pushable can move, the character continues behind it; if the
+    pushable is itself blocked, the character stops too.
+    """
+
+    def __post_init__(self) -> None:
+        """Initialize base component state."""
+        super().__init__()

--- a/pyguara/physics/components.py
+++ b/pyguara/physics/components.py
@@ -17,6 +17,14 @@ class Collider(BaseComponent):
         shape_type: Geometric shape.
         dimensions: Dimensions [radius] for circle, or [width, height] for box.
         offset: Local offset from the RigidBody center.
+        one_way: Solid from one side only. A character jumping from below
+            passes through and then lands on top -- the drop-through platform
+            every 2D platformer has. Chipmunk has no notion of this; the
+            contact is rejected per step when the other body is on the
+            pass-through side.
+        one_way_normal: Which side is solid, in world space. Defaults to
+            `(0, -1)`: up the screen, i.e. a platform you land on from above.
+            Ignored unless `one_way` is set.
     """
 
     shape_type: ShapeType = ShapeType.BOX
@@ -25,6 +33,8 @@ class Collider(BaseComponent):
     material: PhysicsMaterial = field(default_factory=PhysicsMaterial)
     layer: CollisionLayer = field(default_factory=CollisionLayer)
     is_sensor: bool = False
+    one_way: bool = False
+    one_way_normal: Vector2 = field(default_factory=lambda: Vector2(0, -1))
 
     def __post_init__(self) -> None:
         """Initialize base component state."""

--- a/pyguara/physics/debug_draw.py
+++ b/pyguara/physics/debug_draw.py
@@ -86,10 +86,14 @@ class ColliderDebugRenderer:
     def _draw_probe_rays(
         self, renderer: IRenderer, entity: object, offset: Vector2
     ) -> None:
-        """Draw the ground and wall rays exactly where the system casts them.
+        """Draw the wall probes, and a marker at the ground probe's pixel.
 
-        The ray is where a grounding bug shows itself: too long and the
-        character is grounded while it floats, too short and it never lands.
+        Ground detection is a one-pixel overlap test now (Celeste's model),
+        not a variable-length ray, so there is no length to draw -- the
+        marker sits exactly on the pixel `CharacterMover.probe()` checks.
+        Colour is where a grounding bug shows itself: green while the
+        character floats reads as a false positive just as clearly as a
+        ray drawn too long used to.
         """
         transform = entity.get_component(Transform)  # type: ignore[attr-defined]
         collider = entity.get_component(Collider)  # type: ignore[attr-defined]
@@ -100,10 +104,8 @@ class ColliderDebugRenderer:
         position = transform.position - offset
 
         colour = GROUNDED if controller.is_grounded else AIRBORNE
-        start = position + Vector2(0, half_height + 1)
-        renderer.draw_line(
-            start, start + Vector2(0, controller.ground_check_distance), colour, width=2
-        )
+        foot = position + Vector2(0, half_height)
+        renderer.draw_line(foot + Vector2(-4, 1), foot + Vector2(4, 1), colour, width=2)
 
         for direction in (-1.0, 1.0):
             side_start = position + Vector2(direction * (half_width + 2), -10)

--- a/pyguara/physics/debug_draw.py
+++ b/pyguara/physics/debug_draw.py
@@ -1,0 +1,130 @@
+"""Draw physics colliders on top of the world, to see what the solver sees.
+
+A sprite and the collider under it are separate pieces of data that nothing
+forces to agree. When they disagree, the symptom is visual -- a character
+that looks like it is standing inside the floor, or floating above it -- and
+no amount of reading component values tells you which of the two is wrong.
+This draws the colliders so the two can be compared directly.
+
+It draws outlines only, through `IRenderer`, so it works on any backend and
+needs no debug support from one.
+"""
+
+from __future__ import annotations
+
+from pyguara.common.components import Transform
+from pyguara.common.types import Color, Rect, Vector2
+from pyguara.ecs.manager import EntityManager
+from pyguara.graphics.protocols import IRenderer
+from pyguara.physics.components import Collider, RigidBody
+from pyguara.physics.platformer_controller import PlatformerController
+from pyguara.physics.types import BodyType, ShapeType
+
+STATIC = Color(80, 220, 120)
+DYNAMIC = Color(80, 200, 255)
+KINEMATIC = Color(255, 180, 60)
+SENSOR = Color(240, 230, 90)
+ONE_WAY = Color(230, 120, 240)
+GROUNDED = Color(120, 255, 120)
+AIRBORNE = Color(255, 110, 110)
+
+
+class ColliderDebugRenderer:
+    """Draws collider outlines, and the rays the platformer casts.
+
+    Attributes:
+        entity_manager: Source of entities to draw.
+    """
+
+    def __init__(self, entity_manager: EntityManager) -> None:
+        """Store the entity source.
+
+        Args:
+            entity_manager: The manager to query each frame.
+        """
+        self._entity_manager = entity_manager
+
+    def render(self, renderer: IRenderer, camera_offset: Vector2 | None = None) -> None:
+        """Draw every collider, and each platformer's ground and wall rays.
+
+        Args:
+            renderer: Target renderer; only primitive draws are used.
+            camera_offset: World-to-screen offset to subtract, matching
+                whatever the scene applies to its own sprites.
+        """
+        offset = camera_offset if camera_offset is not None else Vector2.zero()
+
+        for entity in self._entity_manager.get_entities_with(Transform, Collider):
+            transform = entity.get_component(Transform)
+            collider = entity.get_component(Collider)
+            position = transform.position - offset
+            colour = self._colour(entity, collider)
+
+            if collider.shape_type == ShapeType.CIRCLE:
+                renderer.draw_circle(
+                    position + collider.offset, collider.dimensions[0], colour, width=1
+                )
+            else:
+                width, height = collider.dimensions[0], collider.dimensions[1]
+                centre = position + collider.offset
+                renderer.draw_rect(
+                    Rect(
+                        int(centre.x - width / 2),
+                        int(centre.y - height / 2),
+                        int(width),
+                        int(height),
+                    ),
+                    colour,
+                    width=1,
+                )
+
+        for entity in self._entity_manager.get_entities_with(
+            Transform, Collider, PlatformerController
+        ):
+            self._draw_probe_rays(renderer, entity, offset)
+
+    def _draw_probe_rays(
+        self, renderer: IRenderer, entity: object, offset: Vector2
+    ) -> None:
+        """Draw the ground and wall rays exactly where the system casts them.
+
+        The ray is where a grounding bug shows itself: too long and the
+        character is grounded while it floats, too short and it never lands.
+        """
+        transform = entity.get_component(Transform)  # type: ignore[attr-defined]
+        collider = entity.get_component(Collider)  # type: ignore[attr-defined]
+        controller = entity.get_component(PlatformerController)  # type: ignore[attr-defined]
+
+        half_height = collider.dimensions[1] / 2
+        half_width = collider.dimensions[0] / 2
+        position = transform.position - offset
+
+        colour = GROUNDED if controller.is_grounded else AIRBORNE
+        start = position + Vector2(0, half_height + 1)
+        renderer.draw_line(
+            start, start + Vector2(0, controller.ground_check_distance), colour, width=2
+        )
+
+        for direction in (-1.0, 1.0):
+            side_start = position + Vector2(direction * (half_width + 2), -10)
+            renderer.draw_line(
+                side_start,
+                side_start + Vector2(direction * controller.wall_check_distance, 0),
+                KINEMATIC,
+                width=1,
+            )
+
+    @staticmethod
+    def _colour(entity: object, collider: Collider) -> Color:
+        """Pick a colour conveying what kind of collider this is."""
+        if collider.is_sensor:
+            return SENSOR
+        if collider.one_way:
+            return ONE_WAY
+        if entity.has_component(RigidBody):  # type: ignore[attr-defined]
+            body_type = entity.get_component(RigidBody).body_type  # type: ignore[attr-defined]
+            if body_type == BodyType.DYNAMIC:
+                return DYNAMIC
+            if body_type == BodyType.KINEMATIC:
+                return KINEMATIC
+        return STATIC

--- a/pyguara/physics/events.py
+++ b/pyguara/physics/events.py
@@ -168,6 +168,29 @@ class OnTriggerExit(TriggerEvent):
 
 
 @dataclass
+class OnActorSquished(Event):
+    """A character was carried or pushed into something with no room to go.
+
+    Fired by `SolidMover` every tick a carry or push leaves an actor still
+    overlapping something other than the solid that moved it. Nothing in
+    the physics layer decides what a squish means -- that's the game's
+    call (damage, death, or nothing at all) -- and nothing here clears the
+    matching `CharacterBody.squished` flag automatically either.
+
+    Attributes:
+        entity_id: The squished character.
+        solid_entity_id: The `MovingSolid` that carried or pushed it.
+        timestamp: Time when the event occurred (seconds since epoch).
+        source: Entity that triggered the event (SolidMover).
+    """
+
+    entity_id: str
+    solid_entity_id: str
+    timestamp: float = 0.0
+    source: Any | None = None
+
+
+@dataclass
 class OnTriggerStay(TriggerEvent):
     """Entity remains inside a trigger volume.
 

--- a/pyguara/physics/physics_system.py
+++ b/pyguara/physics/physics_system.py
@@ -159,6 +159,8 @@ class PhysicsSystem:
                 col.material,
                 col.layer,
                 col.is_sensor,
+                one_way=col.one_way,
+                one_way_normal=col.one_way_normal,
             )
 
     def cleanup(self) -> None:

--- a/pyguara/physics/physics_system.py
+++ b/pyguara/physics/physics_system.py
@@ -125,6 +125,14 @@ class PhysicsSystem:
         Internal helper that handles the specific sequence of body creation
         and shape attachment.
         """
+        # This transform is now stepped at the fixed physics rate, so the
+        # renderer must draw it between ticks or motion stutters on any
+        # display not locked to that rate. Opt in here rather than asking
+        # every game to remember: the system that makes a transform
+        # fixed-stepped is the one that knows it needs interpolating.
+        transform.interpolate = True
+        transform.previous_position = transform.position
+
         # 1. Create Body in the backend
         body_handle = self._engine.create_body(
             entity.id, rb.body_type, transform.position, rb.mass

--- a/pyguara/physics/physics_system.py
+++ b/pyguara/physics/physics_system.py
@@ -64,6 +64,41 @@ class PhysicsSystem:
             return
         self._pending_teardown.append(rb._body_handle)
 
+    def sync_kinematic_transforms(self) -> None:
+        """
+        Push ECS state into the engine, ahead of anything that queries it.
+
+        Drains pending teardowns, creates bodies for entities new to the
+        engine, and mirrors a kinematic body's position/rotation from its
+        Transform. Split out of `update()` so it can run before systems
+        that query the engine this same tick (`SolidSystem`, a character's
+        ground/wall probes) -- otherwise those queries would see last
+        tick's kinematic positions, since `update()` used to only sync
+        kinematic transforms immediately before stepping the simulation.
+
+        `update()` still calls this itself, so nothing that only calls
+        `update()` needs to change.
+        """
+        # Drain pending teardowns before anything else touches the engine,
+        # so destroyed bodies never participate in this tick.
+        for handle in self._pending_teardown:
+            self._engine.destroy_body(handle)
+        self._pending_teardown.clear()
+
+        for entity in self._entity_manager.get_entities_with(Transform, RigidBody):
+            transform = entity.get_component(Transform)
+            rb = entity.get_component(RigidBody)
+
+            # If the body hasn't been created in the engine yet, create it
+            if rb._body_handle is None:
+                self._create_physics_entity(entity, transform, rb)
+
+            # Sync Transform -> Physics (Kinematic or manual overrides)
+            # If we move a kinematic body in game, we must update physics engine
+            if rb.body_type == BodyType.KINEMATIC and rb._body_handle:
+                rb._body_handle.position = transform.position
+                rb._body_handle.rotation = transform.rotation
+
     def update(self, dt: float) -> None:
         """
         Advance the physics simulation and sync transforms.
@@ -74,44 +109,17 @@ class PhysicsSystem:
         Note:
             P2-013: Refactored to Pull pattern. System queries entities internally.
         """
-        # Drain pending teardowns before stepping, so destroyed bodies never
-        # participate in this step's simulation.
-        for handle in self._pending_teardown:
-            self._engine.destroy_body(handle)
-        self._pending_teardown.clear()
+        self.sync_kinematic_transforms()
 
-        # Query physics entities (Pull pattern)
-        entities = list(self._entity_manager.get_entities_with(Transform, RigidBody))
-
-        # 1. Sync ECS -> Physics Engine
-        for entity in entities:
-            # OPTIMIZATION: Use get_component instead of attribute access
-            transform = entity.get_component(Transform)
-            rb = entity.get_component(RigidBody)
-
-            # If the body hasn't been created in the engine yet, create it
-            # FIX: Check backing field directly
-            if rb._body_handle is None:
-                self._create_physics_entity(entity, transform, rb)
-
-            # Sync Transform -> Physics (Kinematic or manual overrides)
-            # If we move a kinematic body in game, we must update physics engine
-            # FIX: Use backing field
-            if rb.body_type == BodyType.KINEMATIC and rb._body_handle:
-                rb._body_handle.position = transform.position
-                rb._body_handle.rotation = transform.rotation
-
-        # 2. Step the Simulation
-        # FIX: Protocol defines this as 'update', not 'step'
+        # Step the Simulation
         self._engine.update(dt)
 
-        # 3. Sync Physics Engine -> ECS
-        for entity in entities:
+        # Sync Physics Engine -> ECS
+        for entity in self._entity_manager.get_entities_with(Transform, RigidBody):
             transform = entity.get_component(Transform)
             rb = entity.get_component(RigidBody)
 
             # If physics moved the object, update the game transform
-            # FIX: Use backing field
             if rb._body_handle and rb.body_type == BodyType.DYNAMIC:
                 transform.position = rb._body_handle.position
                 transform.rotation = rb._body_handle.rotation

--- a/pyguara/physics/physics_system.py
+++ b/pyguara/physics/physics_system.py
@@ -135,7 +135,12 @@ class PhysicsSystem:
 
         # 1. Create Body in the backend
         body_handle = self._engine.create_body(
-            entity.id, rb.body_type, transform.position, rb.mass
+            entity.id,
+            rb.body_type,
+            transform.position,
+            rb.mass,
+            fixed_rotation=rb.fixed_rotation,
+            gravity_scale=rb.gravity_scale,
         )
         body_handle.rotation = transform.rotation
 

--- a/pyguara/physics/platformer_controller.py
+++ b/pyguara/physics/platformer_controller.py
@@ -83,8 +83,10 @@ class PlatformerController(BaseComponent):
         wall_jump_force_x: Horizontal force for wall jump.
         wall_jump_force_y: Vertical force for wall jump.
 
-        ground_check_distance: Raycast distance for ground detection.
-        wall_check_distance: Raycast distance for wall detection.
+        wall_check_distance: Clearance beyond each side probed for a wall.
+            Ground has no equivalent: `CharacterMover.probe()` checks
+            exactly one pixel below, Celeste's model, not a configurable
+            distance.
 
         current_state: Current movement state (internal).
         is_grounded: Whether character is on ground (internal).
@@ -117,8 +119,7 @@ class PlatformerController(BaseComponent):
     wall_jump_force_y: float = 350.0
 
     # Detection parameters
-    ground_check_distance: float = 5.0  # Raycast length for ground
-    wall_check_distance: float = 5.0  # Raycast length for walls
+    wall_check_distance: float = 5.0  # Clearance beyond each side
 
     # Internal state (managed by PlatformerSystem)
     current_state: PlatformerState = field(default=PlatformerState.AIRBORNE, init=False)

--- a/pyguara/physics/platformer_system.py
+++ b/pyguara/physics/platformer_system.py
@@ -2,12 +2,21 @@
 
 The PlatformerSystem updates PlatformerController components each frame,
 handling ground detection, movement, jumping, and wall mechanics.
+
+Movement is driven by `CharacterMover`, not the Chipmunk solver: a character
+has no `RigidBody`/shape registered with the physics engine at all, only a
+`CharacterBody` (velocity, ground state, knockback) and a `Collider` used
+purely as a source of dimensions. Gravity is integrated here manually, since
+nothing else does it for an entity with no physics body.
 """
+
+from __future__ import annotations
 
 from pyguara.common.components import Transform
 from pyguara.common.types import Vector2
 from pyguara.ecs.manager import EntityManager
-from pyguara.physics.components import Collider, RigidBody
+from pyguara.physics.character_mover import CharacterMover
+from pyguara.physics.components import CharacterBody, Collider
 from pyguara.physics.platformer_controller import (
     PlatformerController,
     PlatformerInput,
@@ -15,28 +24,70 @@ from pyguara.physics.platformer_controller import (
 )
 from pyguara.physics.protocols import IPhysicsEngine
 
+# Default half-extents for a character with no Collider -- matches the
+# fallback the old raycast-based system used.
+_DEFAULT_HALF_EXTENTS = Vector2(12.0, 20.0)
+
+# Per-tick multiplier applied to a knockback's residual velocity while
+# `CharacterBody.external_velocity_timer` is running. ~0.9 at 60Hz decays to
+# under 0.2% of the original push within a second, which is fast enough to
+# read as a hit rather than a launch, without a visible snap to zero.
+EXTERNAL_VELOCITY_DECAY = 0.9
+
+
+def apply_knockback(body: CharacterBody, velocity: Vector2, duration: float) -> None:
+    """Override a character's velocity with a knockback for `duration` seconds.
+
+    Consumed the way the doc that reasoned about this promised: as velocity,
+    not an impulse. While the timer is running, `PlatformerSystem` ignores
+    input-driven horizontal control and lets `velocity` decay back toward
+    zero instead, with gravity still integrating into it underneath.
+
+    Args:
+        body: The character's CharacterBody.
+        velocity: The knockback's initial velocity.
+        duration: How long input control stays suppressed, in seconds.
+    """
+    body.velocity = velocity
+    body.external_velocity = velocity
+    body.external_velocity_timer = duration
+
 
 class PlatformerSystem:
     """System that updates platformer controller movement and state.
 
-    The PlatformerSystem performs raycasts for ground/wall detection,
-    updates movement velocities, handles jump logic with coyote time
-    and jump buffering, and manages wall slide/jump mechanics.
+    Ground/wall detection is by overlap probe, not raycast: a character has
+    no shape of its own in the engine, so it can never detect itself, which
+    is what let ground detection self-detect before this switch. Movement is
+    swept by `CharacterMover`, so penetration cannot occur -- overlap is
+    resolved before a step is committed, not after the fact.
 
     Attributes:
         _entity_manager: EntityManager for querying entities.
-        _physics_engine: Physics engine for raycasting.
+        _physics_engine: Physics engine for wall-probe overlap queries.
+        _mover: CharacterMover doing the actual swept movement.
+        _gravity: Manually integrated into each character's velocity, since
+            an entity with no RigidBody gets none from the engine.
     """
 
-    def __init__(self, entity_manager: EntityManager, physics_engine: IPhysicsEngine):
+    def __init__(
+        self,
+        entity_manager: EntityManager,
+        physics_engine: IPhysicsEngine,
+        gravity: Vector2 | None = None,
+    ):
         """Initialize the platformer system.
 
         Args:
             entity_manager: EntityManager to access entities and components.
-            physics_engine: Physics engine for raycasting.
+            physics_engine: Physics engine for wall-probe overlap queries.
+            gravity: Downward acceleration integrated into each character's
+                velocity every tick. Defaults to `(0, 900)`.
         """
         self._entity_manager = entity_manager
         self._physics_engine = physics_engine
+        self._mover = CharacterMover(physics_engine)
+        self._gravity = gravity if gravity is not None else Vector2(0, 900)
 
     def update(self, delta_time: float) -> None:
         """Update all platformer controllers.
@@ -44,17 +95,21 @@ class PlatformerSystem:
         Args:
             delta_time: Time elapsed since last update (seconds).
         """
-        # Query all entities with platformer controller
         for entity in self._entity_manager.get_entities_with(
-            PlatformerController, RigidBody, Transform
+            PlatformerController, CharacterBody, Transform
         ):
             controller = entity.get_component(PlatformerController)
-            rigidbody = entity.get_component(RigidBody)
+            body = entity.get_component(CharacterBody)
             transform = entity.get_component(Transform)
             collider = (
                 entity.get_component(Collider)
                 if entity.has_component(Collider)
                 else None
+            )
+            half_extents = (
+                Vector2(collider.dimensions[0] / 2, collider.dimensions[1] / 2)
+                if collider
+                else _DEFAULT_HALF_EXTENTS
             )
 
             # Consume this tick's movement/jump intent
@@ -67,25 +122,22 @@ class PlatformerSystem:
                 controller._jump_requested = True
                 controller.jump_buffer_timer = controller.jump_buffer
 
-            # Get collider half-dimensions for raycast offsets
-            half_height = collider.dimensions[1] / 2 if collider else 20.0
-            half_width = collider.dimensions[0] / 2 if collider else 12.0
+            # Ground/wall detection, from where the character ended up last
+            # tick -- movement itself happens at the end of this one.
+            self._update_ground_detection(
+                controller, body, transform, half_extents, entity.id
+            )
+            self._update_wall_detection(controller, transform, half_extents, entity.id)
 
-            # Perform ground and wall detection
-            self._update_ground_detection(controller, transform, half_height, entity.id)
-            self._update_wall_detection(controller, transform, half_width, entity.id)
-
-            # Update timers
             self._update_timers(controller, delta_time)
-
-            # Update state machine
             self._update_state(controller)
 
-            # Apply movement
-            self._apply_movement(controller, rigidbody)
+            self._integrate_gravity(body, delta_time)
+            self._tick_knockback(body, delta_time)
+            self._apply_movement(controller, body)
+            self._handle_jump(controller, body)
 
-            # Handle jumping
-            self._handle_jump(controller, rigidbody)
+            self._move(body, transform, half_extents, delta_time, entity.id)
 
             # Reset intent for next frame
             controller.pending_input = PlatformerInput()
@@ -107,32 +159,29 @@ class PlatformerSystem:
     def _update_ground_detection(
         self,
         controller: PlatformerController,
+        body: CharacterBody,
         transform: Transform,
-        half_height: float,
+        half_extents: Vector2,
         entity_id: int | str,
     ) -> None:
-        """Detect if character is on ground using raycast.
+        """Detect ground with a one-pixel overlap probe, not a raycast.
 
         Args:
             controller: PlatformerController component.
+            body: CharacterBody, whose `grounded` mirrors the result.
             transform: Transform component.
-            half_height: Half the collider height (to start ray from feet).
-            entity_id: The character, excluded from the query. Offsetting the
-                ray start below the collider is not enough on its own: the
-                query is a swept circle, so its radius reaches back into the
-                collider and the character detects itself. That reads as
-                permanently grounded, which silently disables coyote time,
-                jump buffering and the landing reset that clears the
-                one-jump-per-landing flag.
+            half_extents: The character's half width and half height.
+            entity_id: The character, excluded from the probe. Harmless to
+                pass even though the character has no shape to exclude --
+                it just never matches.
         """
-        # Cast ray downward from just below character's feet
-        start = transform.position + Vector2(0, half_height + 1)
-        end = start + Vector2(0, controller.ground_check_distance)
-
-        hit = self._physics_engine.raycast(start, end, ignore_entity_id=entity_id)
+        hit = self._mover.probe(
+            transform.position, half_extents, Vector2(0, 1), entity_id
+        )
 
         was_grounded = controller.is_grounded
-        controller.is_grounded = hit is not None
+        body.grounded = hit is not None
+        controller.is_grounded = body.grounded
 
         # Reset coyote time when landing
         if controller.is_grounded and not was_grounded:
@@ -147,41 +196,38 @@ class PlatformerSystem:
         self,
         controller: PlatformerController,
         transform: Transform,
-        half_width: float,
+        half_extents: Vector2,
         entity_id: int | str,
     ) -> None:
-        """Detect if character is touching walls using raycasts.
+        """Detect walls with a small overlap query at upper-body height.
 
         Args:
             controller: PlatformerController component.
             transform: Transform component.
-            half_width: Half the collider width (to start ray from sides).
-            entity_id: The character, excluded so the side rays cannot detect
-                its own collider as a wall.
+            half_extents: The character's half width and half height.
+            entity_id: The character, excluded so it cannot detect itself.
         """
-        # Always detect walls (needed to prevent pushing into them)
-        # Wall sliding/jumping is a separate feature that uses this data
+        # A thin box at upper-body height, not the character's full height,
+        # so a floor tile stepping up beside the character doesn't itself
+        # read as a wall.
+        ray_y_offset = -10  # Cast from upper body, not centre
+        probe_half = Vector2(controller.wall_check_distance / 2, 10.0)
 
-        # Cast rays from just outside character's sides at upper body height
-        # to avoid detecting ground tiles. Use a point above the feet.
-        ray_y_offset = -10  # Cast from upper body, not center
-
-        # Start further outside the collider to avoid self-intersection
-        left_start = transform.position + Vector2(-half_width - 2, ray_y_offset)
-        right_start = transform.position + Vector2(half_width + 2, ray_y_offset)
-
-        left_end = left_start + Vector2(-controller.wall_check_distance, 0)
-        right_end = right_start + Vector2(controller.wall_check_distance, 0)
-
-        left_hit = self._physics_engine.raycast(
-            left_start, left_end, ignore_entity_id=entity_id
+        left_centre = transform.position + Vector2(
+            -(half_extents.x + probe_half.x), ray_y_offset
         )
-        right_hit = self._physics_engine.raycast(
-            right_start, right_end, ignore_entity_id=entity_id
+        right_centre = transform.position + Vector2(
+            half_extents.x + probe_half.x, ray_y_offset
         )
 
-        controller.on_wall_left = left_hit is not None
-        controller.on_wall_right = right_hit is not None
+        controller.on_wall_left = (
+            self._physics_engine.overlap_box(left_centre, probe_half, entity_id)
+            is not None
+        )
+        controller.on_wall_right = (
+            self._physics_engine.overlap_box(right_centre, probe_half, entity_id)
+            is not None
+        )
 
     def _update_timers(
         self, controller: PlatformerController, delta_time: float
@@ -221,20 +267,56 @@ class PlatformerSystem:
         else:
             controller.current_state = PlatformerState.AIRBORNE
 
+    def _integrate_gravity(self, body: CharacterBody, delta_time: float) -> None:
+        """Add gravity to vertical velocity.
+
+        Nothing else does this for a character: it has no RigidBody for the
+        physics engine to simulate, so unlike a dynamic body, its own
+        velocity is the only place gravity can accumulate.
+
+        Args:
+            body: CharacterBody being integrated.
+            delta_time: Time elapsed since last update.
+        """
+        body.velocity = Vector2(
+            body.velocity.x, body.velocity.y + self._gravity.y * delta_time
+        )
+
+    def _tick_knockback(self, body: CharacterBody, delta_time: float) -> None:
+        """Count down and decay an active knockback.
+
+        Args:
+            body: CharacterBody possibly mid-knockback.
+            delta_time: Time elapsed since last update.
+        """
+        if body.external_velocity_timer <= 0.0:
+            return
+
+        body.external_velocity_timer = max(
+            0.0, body.external_velocity_timer - delta_time
+        )
+        body.external_velocity = Vector2(
+            body.external_velocity.x * EXTERNAL_VELOCITY_DECAY,
+            body.external_velocity.y * EXTERNAL_VELOCITY_DECAY,
+        )
+
     def _apply_movement(
-        self, controller: PlatformerController, rigidbody: RigidBody
+        self, controller: PlatformerController, body: CharacterBody
     ) -> None:
-        """Apply horizontal movement to rigidbody.
+        """Apply horizontal movement to the character's velocity.
 
         Args:
             controller: PlatformerController component.
-            rigidbody: RigidBody component.
+            body: CharacterBody component.
         """
-        if not rigidbody.handle:
-            return
+        current_velocity = body.velocity
 
-        # Get current velocity
-        current_velocity = rigidbody.handle.velocity
+        if body.external_velocity_timer > 0.0:
+            # Knockback in progress: input control is suppressed. Gravity,
+            # already integrated into current_velocity.y above, keeps
+            # acting underneath it.
+            body.velocity = Vector2(body.external_velocity.x, current_velocity.y)
+            return
 
         # Calculate target horizontal velocity
         target_velocity_x = controller.move_input * controller.move_speed
@@ -247,8 +329,8 @@ class PlatformerSystem:
         if controller.move_input == 0:
             new_velocity_x = 0.0
         else:
-            # Don't push into walls when airborne - this prevents fighting the physics engine
-            # On ground, physics collision handles this naturally
+            # Don't push into walls when airborne -- on the ground, the
+            # mover stops horizontal motion at the wall by construction.
             if not controller.is_grounded:
                 if (
                     controller.on_wall_left
@@ -279,58 +361,49 @@ class PlatformerSystem:
             # Clamp falling speed to max (don't exceed terminal velocity)
             new_velocity_y = min(current_velocity.y, controller.max_fall_speed)
 
-        rigidbody.handle.velocity = Vector2(new_velocity_x, new_velocity_y)
+        body.velocity = Vector2(new_velocity_x, new_velocity_y)
 
     def _handle_jump(
-        self, controller: PlatformerController, rigidbody: RigidBody
+        self, controller: PlatformerController, body: CharacterBody
     ) -> None:
         """Handle jump logic with coyote time and jump buffering.
 
         Args:
             controller: PlatformerController component.
-            rigidbody: RigidBody component.
+            body: CharacterBody component.
         """
-        if not rigidbody.handle:
-            return
-
         # Check if jump was requested (either this frame or buffered)
         if not controller._jump_requested and controller.jump_buffer_timer <= 0:
             return
 
         # Wall jump takes priority
         if controller.can_wall_jump():
-            self._perform_wall_jump(controller, rigidbody)
+            self._perform_wall_jump(controller, body)
             return
 
         # Regular jump
         if controller.can_jump():
-            self._perform_jump(controller, rigidbody)
+            self._perform_jump(controller, body)
             return
 
         # Clear jump request if couldn't jump
         controller._jump_requested = False
 
     def _perform_jump(
-        self, controller: PlatformerController, rigidbody: RigidBody
+        self, controller: PlatformerController, body: CharacterBody
     ) -> None:
         """Execute a regular jump.
 
         Args:
             controller: PlatformerController component.
-            rigidbody: RigidBody component.
+            body: CharacterBody component.
         """
-        if not rigidbody.handle:
-            return
-
         # Set upward velocity
         # If no horizontal input, don't preserve horizontal velocity (prevents diagonal jumps)
         if controller.move_input == 0:
-            rigidbody.handle.velocity = Vector2(0, -controller.jump_force)
+            body.velocity = Vector2(0, -controller.jump_force)
         else:
-            current_velocity = rigidbody.handle.velocity
-            rigidbody.handle.velocity = Vector2(
-                current_velocity.x, -controller.jump_force
-            )
+            body.velocity = Vector2(body.velocity.x, -controller.jump_force)
 
         # Consume jump - mark as used to prevent air jumps
         controller._jump_requested = False
@@ -339,17 +412,14 @@ class PlatformerSystem:
         controller.coyote_timer = 0.0
 
     def _perform_wall_jump(
-        self, controller: PlatformerController, rigidbody: RigidBody
+        self, controller: PlatformerController, body: CharacterBody
     ) -> None:
         """Execute a wall jump.
 
         Args:
             controller: PlatformerController component.
-            rigidbody: RigidBody component.
+            body: CharacterBody component.
         """
-        if not rigidbody.handle:
-            return
-
         # Determine jump direction (away from wall)
         if controller.on_wall_left:
             jump_x = controller.wall_jump_force_x  # Jump right
@@ -357,9 +427,37 @@ class PlatformerSystem:
             jump_x = -controller.wall_jump_force_x  # Jump left
 
         # Apply wall jump velocity
-        rigidbody.handle.velocity = Vector2(jump_x, -controller.wall_jump_force_y)
+        body.velocity = Vector2(jump_x, -controller.wall_jump_force_y)
 
         # Consume jump
         controller._jump_requested = False
         controller.jump_buffer_timer = 0.0
         controller.coyote_timer = 0.0
+
+    def _move(
+        self,
+        body: CharacterBody,
+        transform: Transform,
+        half_extents: Vector2,
+        delta_time: float,
+        entity_id: int | str,
+    ) -> None:
+        """Sweep the character by this tick's velocity and write back the result.
+
+        Args:
+            body: CharacterBody providing velocity and the remainder
+                accumulator, and receiving the updated remainder.
+            transform: Transform providing and receiving position.
+            half_extents: The character's half width and half height.
+            delta_time: Time elapsed since last update.
+            entity_id: The character, excluded from overlap tests.
+        """
+        result = self._mover.move(
+            transform.position,
+            half_extents,
+            body.velocity * delta_time,
+            body._remainder,
+            entity_id,
+        )
+        transform.position = result.position
+        body._remainder = result.remainder

--- a/pyguara/physics/platformer_system.py
+++ b/pyguara/physics/platformer_system.py
@@ -16,13 +16,14 @@ from pyguara.common.components import Transform
 from pyguara.common.types import Vector2
 from pyguara.ecs.manager import EntityManager
 from pyguara.physics.character_mover import CharacterMover
-from pyguara.physics.components import CharacterBody, Collider
+from pyguara.physics.components import CharacterBody, Collider, Pushable
 from pyguara.physics.platformer_controller import (
     PlatformerController,
     PlatformerInput,
     PlatformerState,
 )
 from pyguara.physics.protocols import IPhysicsEngine
+from pyguara.physics.solid_mover import SolidMover
 
 # Default half-extents for a character with no Collider -- matches the
 # fallback the old raycast-based system used.
@@ -75,6 +76,7 @@ class PlatformerSystem:
         entity_manager: EntityManager,
         physics_engine: IPhysicsEngine,
         gravity: Vector2 | None = None,
+        solid_mover: SolidMover | None = None,
     ):
         """Initialize the platformer system.
 
@@ -83,11 +85,15 @@ class PlatformerSystem:
             physics_engine: Physics engine for wall-probe overlap queries.
             gravity: Downward acceleration integrated into each character's
                 velocity every tick. Defaults to `(0, 900)`.
+            solid_mover: Shoves a `Pushable` entity a character walks into.
+                Without one, a pushable simply blocks like any other solid
+                -- crates aren't a feature every game needs.
         """
         self._entity_manager = entity_manager
         self._physics_engine = physics_engine
         self._mover = CharacterMover(physics_engine)
         self._gravity = gravity if gravity is not None else Vector2(0, 900)
+        self._solid_mover = solid_mover
 
     def update(self, delta_time: float) -> None:
         """Update all platformer controllers.
@@ -452,12 +458,63 @@ class PlatformerSystem:
             delta_time: Time elapsed since last update.
             entity_id: The character, excluded from overlap tests.
         """
+        origin = transform.position
+        delta = body.velocity * delta_time
         result = self._mover.move(
-            transform.position,
-            half_extents,
-            body.velocity * delta_time,
-            body._remainder,
-            entity_id,
+            origin, half_extents, delta, body._remainder, entity_id
         )
+
+        if self._solid_mover is not None:
+            pushed = False
+            if result.hit_x and self._push_if_pushable(
+                result.blocking_x,
+                Vector2(delta.x - (result.position.x - origin.x), 0),
+                entity_id,
+            ):
+                pushed = True
+            if result.hit_y and self._push_if_pushable(
+                result.blocking_y,
+                Vector2(0, delta.y - (result.position.y - origin.y)),
+                entity_id,
+            ):
+                pushed = True
+            if pushed:
+                # The crate moved out of the way: retry the full move from
+                # scratch rather than patching up the partial result -- one
+                # retry is enough, since a crate itself only moves once per
+                # push and cannot cascade further within this same tick.
+                result = self._mover.move(
+                    origin, half_extents, delta, body._remainder, entity_id
+                )
+
         transform.position = result.position
         body._remainder = result.remainder
+
+    def _push_if_pushable(
+        self,
+        blocking_entity_id: int | str | None,
+        remaining: Vector2,
+        pusher_id: int | str,
+    ) -> bool:
+        """Ask SolidMover to shove whatever blocked a step, if it can be shoved.
+
+        Args:
+            blocking_entity_id: What `CharacterMover` found in the way, or
+                None if nothing did.
+            remaining: How much of this tick's requested motion the block
+                left untravelled on that axis -- how far a push needs to
+                clear it.
+            pusher_id: The character doing the pushing, so `SolidMover`
+                doesn't also react to its own push by shoving that same
+                character back.
+
+        Returns:
+            True if the block was a `Pushable` entity and it moved.
+        """
+        if blocking_entity_id is None or (remaining.x == 0.0 and remaining.y == 0.0):
+            return False
+        entity = self._entity_manager.get_entity(str(blocking_entity_id))
+        if entity is None or not entity.has_component(Pushable):
+            return False
+        assert self._solid_mover is not None  # guarded by the caller
+        return self._solid_mover.try_move(entity, remaining, pusher_id=pusher_id)

--- a/pyguara/physics/platformer_system.py
+++ b/pyguara/physics/platformer_system.py
@@ -72,8 +72,8 @@ class PlatformerSystem:
             half_width = collider.dimensions[0] / 2 if collider else 12.0
 
             # Perform ground and wall detection
-            self._update_ground_detection(controller, transform, half_height)
-            self._update_wall_detection(controller, transform, half_width)
+            self._update_ground_detection(controller, transform, half_height, entity.id)
+            self._update_wall_detection(controller, transform, half_width, entity.id)
 
             # Update timers
             self._update_timers(controller, delta_time)
@@ -105,7 +105,11 @@ class PlatformerSystem:
         controller._jump_used = False
 
     def _update_ground_detection(
-        self, controller: PlatformerController, transform: Transform, half_height: float
+        self,
+        controller: PlatformerController,
+        transform: Transform,
+        half_height: float,
+        entity_id: int | str,
     ) -> None:
         """Detect if character is on ground using raycast.
 
@@ -113,13 +117,19 @@ class PlatformerSystem:
             controller: PlatformerController component.
             transform: Transform component.
             half_height: Half the collider height (to start ray from feet).
+            entity_id: The character, excluded from the query. Offsetting the
+                ray start below the collider is not enough on its own: the
+                query is a swept circle, so its radius reaches back into the
+                collider and the character detects itself. That reads as
+                permanently grounded, which silently disables coyote time,
+                jump buffering and the landing reset that clears the
+                one-jump-per-landing flag.
         """
         # Cast ray downward from just below character's feet
-        # Start slightly below the collider to avoid self-intersection
         start = transform.position + Vector2(0, half_height + 1)
         end = start + Vector2(0, controller.ground_check_distance)
 
-        hit = self._physics_engine.raycast(start, end)
+        hit = self._physics_engine.raycast(start, end, ignore_entity_id=entity_id)
 
         was_grounded = controller.is_grounded
         controller.is_grounded = hit is not None
@@ -134,7 +144,11 @@ class PlatformerSystem:
             controller.coyote_timer = controller.coyote_time
 
     def _update_wall_detection(
-        self, controller: PlatformerController, transform: Transform, half_width: float
+        self,
+        controller: PlatformerController,
+        transform: Transform,
+        half_width: float,
+        entity_id: int | str,
     ) -> None:
         """Detect if character is touching walls using raycasts.
 
@@ -142,6 +156,8 @@ class PlatformerSystem:
             controller: PlatformerController component.
             transform: Transform component.
             half_width: Half the collider width (to start ray from sides).
+            entity_id: The character, excluded so the side rays cannot detect
+                its own collider as a wall.
         """
         # Always detect walls (needed to prevent pushing into them)
         # Wall sliding/jumping is a separate feature that uses this data
@@ -157,8 +173,12 @@ class PlatformerSystem:
         left_end = left_start + Vector2(-controller.wall_check_distance, 0)
         right_end = right_start + Vector2(controller.wall_check_distance, 0)
 
-        left_hit = self._physics_engine.raycast(left_start, left_end)
-        right_hit = self._physics_engine.raycast(right_start, right_end)
+        left_hit = self._physics_engine.raycast(
+            left_start, left_end, ignore_entity_id=entity_id
+        )
+        right_hit = self._physics_engine.raycast(
+            right_start, right_end, ignore_entity_id=entity_id
+        )
 
         controller.on_wall_left = left_hit is not None
         controller.on_wall_right = right_hit is not None

--- a/pyguara/physics/protocols.py
+++ b/pyguara/physics/protocols.py
@@ -141,6 +141,28 @@ class IPhysicsEngine(Protocol):
         """
         ...
 
+    def overlap_box(
+        self,
+        centre: Vector2,
+        half_extents: Vector2,
+        ignore_entity_id: int | str | None = None,
+    ) -> bool:
+        """Report whether an axis-aligned box overlaps any solid shape.
+
+        The question a character mover asks before committing a step: "if I
+        were here, would I be inside something?" Sensors do not count -- they
+        are meant to be passed through.
+
+        Args:
+            centre: Box centre in world space.
+            half_extents: Half width and half height.
+            ignore_entity_id: Body to disregard, normally the mover itself.
+
+        Returns:
+            True if the box would overlap a solid shape.
+        """
+        ...
+
     def create_joint(
         self,
         body_a: IPhysicsBody,

--- a/pyguara/physics/protocols.py
+++ b/pyguara/physics/protocols.py
@@ -146,12 +146,14 @@ class IPhysicsEngine(Protocol):
         centre: Vector2,
         half_extents: Vector2,
         ignore_entity_id: int | str | None = None,
-    ) -> bool:
-        """Report whether an axis-aligned box overlaps any solid shape.
+    ) -> int | str | None:
+        """Report which entity's solid shape an axis-aligned box overlaps.
 
         The question a character mover asks before committing a step: "if I
-        were here, would I be inside something?" Sensors do not count -- they
-        are meant to be passed through.
+        were here, would I be inside something, and if so, what?" Knowing
+        *what* -- not just whether -- is what lets a mover recognise a
+        pushable crate rather than merely stopping at it. Sensors do not
+        count -- they are meant to be passed through.
 
         Args:
             centre: Box centre in world space.
@@ -159,7 +161,8 @@ class IPhysicsEngine(Protocol):
             ignore_entity_id: Body to disregard, normally the mover itself.
 
         Returns:
-            True if the box would overlap a solid shape.
+            The entity id of the first solid, non-sensor shape found
+            overlapping, or None if the box is clear.
         """
         ...
 

--- a/pyguara/physics/protocols.py
+++ b/pyguara/physics/protocols.py
@@ -78,6 +78,8 @@ class IPhysicsEngine(Protocol):
         body_type: BodyType,
         position: Vector2,
         mass: float = 1.0,
+        fixed_rotation: bool = False,
+        gravity_scale: float = 1.0,
     ) -> IPhysicsBody:
         """Create and register a new physics body."""
         ...

--- a/pyguara/physics/protocols.py
+++ b/pyguara/physics/protocols.py
@@ -100,9 +100,25 @@ class IPhysicsEngine(Protocol):
         ...
 
     def raycast(
-        self, start: Vector2, end: Vector2, mask: int = 0xFFFFFFFF
+        self,
+        start: Vector2,
+        end: Vector2,
+        mask: int = 0xFFFFFFFF,
+        ignore_entity_id: int | str | None = None,
     ) -> RaycastHit | None:
-        """Cast a ray in the physics world."""
+        """Cast a ray in the physics world.
+
+        Args:
+            start: Ray origin in world space.
+            end: Ray end in world space.
+            mask: Collision mask; shapes outside it are ignored.
+            ignore_entity_id: Skip hits on this entity's own body. A character
+                casting to find the ground beneath its feet starts the ray at
+                its own edge and would otherwise detect itself.
+
+        Returns:
+            The nearest hit, or None.
+        """
         ...
 
     def create_joint(

--- a/pyguara/physics/protocols.py
+++ b/pyguara/physics/protocols.py
@@ -97,8 +97,26 @@ class IPhysicsEngine(Protocol):
         material: PhysicsMaterial,
         collision_layer: CollisionLayer,
         is_sensor: bool,
+        one_way: bool = False,
+        one_way_normal: Vector2 | None = None,
     ) -> Any:
-        """Attach a collision shape to a body."""
+        """Attach a collision shape to a body.
+
+        Args:
+            body: The body to attach to.
+            shape_type: Circle, box, segment or polygon.
+            dimensions: Radius, or width and height.
+            offset: Local offset from the body's centre.
+            material: Friction, restitution and density.
+            collision_layer: Category, mask and group filtering.
+            is_sensor: Detect overlaps without blocking.
+            one_way: Solid from one side only.
+            one_way_normal: Which side is solid, in world space. Defaults to
+                `(0, -1)` -- up the screen -- when `one_way` is set.
+
+        Returns:
+            The backend's shape object.
+        """
         ...
 
     def raycast(

--- a/pyguara/physics/solid_mover.py
+++ b/pyguara/physics/solid_mover.py
@@ -1,0 +1,235 @@
+"""Move a solid, carrying and pushing whatever it touches.
+
+`CharacterMover` is how a character moves under its own control. This is
+the other half of Celeste's model: how the *world* moves a character that
+isn't driving -- riding a platform, or being shoved by one closing in from
+the side or above.
+
+A rider or a pushed actor is placed directly at the position the solid's
+own motion dictates, not swept there: the solid has already decided exactly
+where the actor is going, so there is nothing to search for. What has to be
+checked afterwards is whether that position is actually clear of everything
+*except* the solid that moved it -- if not, the actor has been squished
+between it and something else, which is reported rather than silently
+resolved, since what a squish should do (damage, death, nothing) is a game
+decision, not a physics one.
+
+This mirrors Celeste's `Solid.MoveHExact`/`MoveVExact`: riders are found by
+their position *before* the solid moves (an actor resting flush on top),
+carried by the exact same delta, then checked; anything not riding that the
+solid's *new* footprint now overlaps is pushed clear along whichever axis
+the solid is actually moving, then checked the same way.
+"""
+
+from __future__ import annotations
+
+import time
+
+from pyguara.common.components import Transform
+from pyguara.common.types import Vector2
+from pyguara.ecs.entity import Entity
+from pyguara.ecs.manager import EntityManager
+from pyguara.events.dispatcher import EventDispatcher
+from pyguara.physics.character_mover import SKIN
+from pyguara.physics.components import CharacterBody, Collider
+from pyguara.physics.events import OnActorSquished
+from pyguara.physics.protocols import IPhysicsEngine
+
+# How close a resting gap can be and still count as riding. Matches the
+# mover's own SKIN allowance: a swept actor settles within this of a
+# surface, not necessarily at an exact zero gap.
+RIDE_TOLERANCE = 1.0
+
+_DEFAULT_HALF_EXTENTS = Vector2(12.0, 20.0)
+
+
+def _half_extents(collider: Collider | None) -> Vector2:
+    """Half width/height from a Collider, or a sane default without one."""
+    if collider is None:
+        return _DEFAULT_HALF_EXTENTS
+    return Vector2(collider.dimensions[0] / 2, collider.dimensions[1] / 2)
+
+
+def _shrink(half: Vector2) -> Vector2:
+    """Apply the same skin allowance CharacterMover queries with."""
+    return Vector2(max(half.x - SKIN, 0.01), max(half.y - SKIN, 0.01))
+
+
+def _is_riding(
+    actor_pos: Vector2, actor_half: Vector2, solid_pos: Vector2, solid_half: Vector2
+) -> bool:
+    """Report whether an actor rests on top of a solid, before it moves."""
+    within_x = abs(actor_pos.x - solid_pos.x) < actor_half.x + solid_half.x
+    actor_bottom = actor_pos.y + actor_half.y
+    solid_top = solid_pos.y - solid_half.y
+    return within_x and abs(actor_bottom - solid_top) <= RIDE_TOLERANCE
+
+
+def _push_delta(
+    actor_pos: Vector2,
+    actor_half: Vector2,
+    solid_pos: Vector2,
+    solid_half: Vector2,
+    solid_delta: Vector2,
+) -> Vector2:
+    """How far to shove an actor clear of a solid's new footprint.
+
+    Along whichever axis the solid is actually moving -- the one it would
+    feel like being pushed by -- resolving the smaller of the two overlaps
+    first when it moves on both.
+    """
+    overlap_x = (actor_half.x + solid_half.x) - abs(actor_pos.x - solid_pos.x)
+    overlap_y = (actor_half.y + solid_half.y) - abs(actor_pos.y - solid_pos.y)
+    if overlap_x <= 0 or overlap_y <= 0:
+        return Vector2(0, 0)
+
+    if solid_delta.x != 0 and (solid_delta.y == 0 or overlap_x <= overlap_y):
+        return Vector2(overlap_x if solid_delta.x > 0 else -overlap_x, 0)
+    if solid_delta.y != 0:
+        return Vector2(0, overlap_y if solid_delta.y > 0 else -overlap_y)
+    return Vector2(0, 0)
+
+
+class SolidMover:
+    """Carries and pushes `CharacterBody` actors as a solid moves.
+
+    Attributes:
+        _entity_manager: Source of actor entities to check each move.
+        _engine: Used only for the post-move squish check.
+        _dispatcher: Notified of a squish, if given.
+    """
+
+    def __init__(
+        self,
+        entity_manager: EntityManager,
+        engine: IPhysicsEngine,
+        dispatcher: EventDispatcher | None = None,
+    ) -> None:
+        """Store collaborators.
+
+        Args:
+            entity_manager: Source of actor entities.
+            engine: Physics engine, for the squish overlap check.
+            dispatcher: Receives `OnActorSquished`, if given.
+        """
+        self._entity_manager = entity_manager
+        self._engine = engine
+        self._dispatcher = dispatcher
+
+    def move_solid(
+        self,
+        solid_entity: Entity,
+        delta: Vector2,
+        exclude_entity_id: int | str | None = None,
+    ) -> None:
+        """Carry/push every actor touched by `solid_entity`'s move.
+
+        Args:
+            solid_entity: The solid, already at its destination Transform
+                this tick -- this reacts to that displacement, it doesn't
+                apply it.
+            delta: How far `solid_entity` moved this tick.
+            exclude_entity_id: Skip this actor entirely. Set when the solid's
+                own motion was itself a character pushing it (`try_move`):
+                that character's position is that sweep's to decide, not
+                this reactive pass's -- without excluding it, a pushed
+                crate would also shove back at whoever just pushed it.
+        """
+        if delta.x == 0.0 and delta.y == 0.0:
+            return
+
+        solid_transform = solid_entity.get_component(Transform)
+        solid_half = _half_extents(
+            solid_entity.get_component(Collider)
+            if solid_entity.has_component(Collider)
+            else None
+        )
+        solid_pos_before = solid_transform.position - delta
+        solid_pos_after = solid_transform.position
+
+        for actor in self._entity_manager.get_entities_with(
+            CharacterBody, Transform, Collider
+        ):
+            if actor.id == solid_entity.id or actor.id == exclude_entity_id:
+                continue
+            body = actor.get_component(CharacterBody)
+            transform = actor.get_component(Transform)
+            half = _half_extents(actor.get_component(Collider))
+
+            if _is_riding(transform.position, half, solid_pos_before, solid_half):
+                self._displace(actor, body, transform, delta, solid_entity.id)
+                body.riding = solid_entity.id
+                continue
+
+            push = _push_delta(
+                transform.position, half, solid_pos_after, solid_half, delta
+            )
+            if push.x != 0.0 or push.y != 0.0:
+                self._displace(actor, body, transform, push, solid_entity.id)
+
+    def try_move(
+        self, entity: Entity, delta: Vector2, pusher_id: int | str | None = None
+    ) -> bool:
+        """Attempt to move a `Pushable` solid by `delta`.
+
+        Used when a character's own movement is blocked by a pushable
+        entity: `PlatformerSystem` asks this before deciding whether the
+        character itself gets to continue.
+
+        Args:
+            entity: The pushable solid.
+            delta: The distance a character tried to push it.
+            pusher_id: The character doing the pushing, excluded from the
+                reactive carry/push pass below -- its own position is that
+                character's own sweep to decide, not this one's.
+
+        Returns:
+            True if the push succeeded -- its Transform moved, and
+            whatever else was riding or in the way of *it* was
+            carried/pushed in turn. False if something else blocks it, in
+            which case its Transform is left exactly where it started.
+        """
+        transform = entity.get_component(Transform)
+        half = _half_extents(
+            entity.get_component(Collider) if entity.has_component(Collider) else None
+        )
+        origin = transform.position
+        transform.position = origin + delta
+
+        blocker = self._engine.overlap_box(
+            transform.position, _shrink(half), ignore_entity_id=entity.id
+        )
+        if blocker is not None:
+            transform.position = origin
+            return False
+
+        self.move_solid(entity, delta, exclude_entity_id=pusher_id)
+        return True
+
+    def _displace(
+        self,
+        actor: Entity,
+        body: CharacterBody,
+        transform: Transform,
+        delta: Vector2,
+        solid_id: int | str,
+    ) -> None:
+        """Move an actor directly and check what that left it overlapping."""
+        transform.position = transform.position + delta
+        half = _half_extents(
+            actor.get_component(Collider) if actor.has_component(Collider) else None
+        )
+        blocker = self._engine.overlap_box(
+            transform.position, _shrink(half), ignore_entity_id=solid_id
+        )
+        if blocker is not None:
+            body.squished = True
+            if self._dispatcher is not None:
+                self._dispatcher.dispatch(
+                    OnActorSquished(
+                        entity_id=str(actor.id),
+                        solid_entity_id=str(solid_id),
+                        timestamp=time.time(),
+                        source=self,
+                    )
+                )

--- a/pyguara/physics/solid_system.py
+++ b/pyguara/physics/solid_system.py
@@ -1,0 +1,50 @@
+"""System that carries/pushes actors for every MovingSolid, once a tick.
+
+Belongs between whatever authors a solid's motion (a patrol script, a
+tween -- anything that moves its Transform) and `PlatformerSystem`: a
+character's own movement should be swept against solids at *this* tick's
+positions, not last tick's, so this has to run after the solids move and
+before the character does.
+"""
+
+from __future__ import annotations
+
+from pyguara.common.components import Transform
+from pyguara.ecs.manager import EntityManager
+from pyguara.physics.components import CharacterBody, MovingSolid
+from pyguara.physics.solid_mover import SolidMover
+
+
+class SolidSystem:
+    """Drives `SolidMover` over every `MovingSolid` entity, once a tick."""
+
+    def __init__(self, entity_manager: EntityManager, solid_mover: SolidMover) -> None:
+        """Store collaborators.
+
+        Args:
+            entity_manager: Source of solid and actor entities.
+            solid_mover: Does the actual carrying/pushing.
+        """
+        self._entity_manager = entity_manager
+        self._solid_mover = solid_mover
+
+    def update(self, delta_time: float) -> None:
+        """Move whatever each `MovingSolid` touched this tick.
+
+        Args:
+            delta_time: Unused; a solid's delta is read from how far its
+                Transform already moved this tick, not derived from a
+                velocity here.
+        """
+        # Riding is re-decided fresh from this tick's geometry, every tick,
+        # for every solid -- never carried over as stale state from one a
+        # character has since left.
+        for actor in self._entity_manager.get_entities_with(CharacterBody):
+            actor.get_component(CharacterBody).riding = None
+
+        for solid in self._entity_manager.get_entities_with(MovingSolid, Transform):
+            transform = solid.get_component(Transform)
+            delta = transform.position - transform.previous_position
+            if delta.x == 0.0 and delta.y == 0.0:
+                continue
+            self._solid_mover.move_solid(solid, delta)

--- a/pyguara/physics/tilemap.py
+++ b/pyguara/physics/tilemap.py
@@ -1,0 +1,88 @@
+"""Build collision geometry from a tile grid.
+
+A tile grid drawn as individual squares is naturally built as one collider
+per tile, and that produces a floor made of dozens of separate boxes. The
+interior faces where they meet are real collision surfaces to the solver,
+even though nothing about the level is there: a character resting on the
+floor sits `collision_slop` deep inside it, so its leading bottom corner is
+below the tops of the tiles ahead and strikes their vertical faces as it
+moves. Measured in guara_falcao, that deflected a walking character upward
+at 47 px/s at a tile boundary; it then fell back and landed 8px inside the
+floor. The same interior corners are what a character jumping against a wall
+snags on.
+
+Merging contiguous tiles into as few rectangles as possible removes those
+faces altogether -- there is nothing left to catch on. Sprites stay
+per-tile; only the collision shape changes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from pyguara.common.types import Rect
+
+
+def merge_tile_rects(solid: Sequence[Sequence[bool]], tile_size: int) -> list[Rect]:
+    """Cover the solid tiles with as few rectangles as the greedy pass finds.
+
+    Runs of solid tiles are joined along a row, then rows whose runs line up
+    exactly are stacked. For a rectangular floor this collapses to a single
+    box; for the general case it leaves far fewer interior faces than one
+    collider per tile.
+
+    Args:
+        solid: Row-major grid, `solid[y][x]` true where a tile blocks.
+        tile_size: Edge length of one tile in pixels.
+
+    Returns:
+        World-space rectangles covering exactly the solid tiles, in
+        row order. Empty when nothing is solid.
+    """
+    if not solid or not solid[0]:
+        return []
+
+    height = len(solid)
+    width = len(solid[0])
+    claimed = [[False] * width for _ in range(height)]
+    rects: list[Rect] = []
+
+    for y in range(height):
+        x = 0
+        while x < width:
+            if not solid[y][x] or claimed[y][x]:
+                x += 1
+                continue
+
+            # Extend right while the row stays solid and unclaimed.
+            run_end = x
+            while (
+                run_end + 1 < width
+                and solid[y][run_end + 1]
+                and not claimed[y][run_end + 1]
+            ):
+                run_end += 1
+
+            # Extend down while the whole run repeats exactly.
+            bottom = y
+            while bottom + 1 < height and all(
+                solid[bottom + 1][cx] and not claimed[bottom + 1][cx]
+                for cx in range(x, run_end + 1)
+            ):
+                bottom += 1
+
+            for cy in range(y, bottom + 1):
+                for cx in range(x, run_end + 1):
+                    claimed[cy][cx] = True
+
+            rects.append(
+                Rect(
+                    x * tile_size,
+                    y * tile_size,
+                    (run_end - x + 1) * tile_size,
+                    (bottom - y + 1) * tile_size,
+                )
+            )
+            x = run_end + 1
+
+    return rects

--- a/tests/integration/test_character_mover.py
+++ b/tests/integration/test_character_mover.py
@@ -1,0 +1,163 @@
+"""Collide-and-slide movement: the character is never inside the world.
+
+The dynamic-body controller lets the solver resolve penetration after the
+fact, so a character pressed into geometry is briefly inside it -- measured
+at 8px in guara_falcao, recovering at 0.04px a tick. A swept mover cannot
+produce that state: it stops flush at the surface instead of passing through
+it and being pushed back.
+
+Every test here asserts the same underlying property in a different
+situation: after the move, the character does not overlap anything.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyguara.common.components import Transform
+from pyguara.common.types import Vector2
+from pyguara.ecs.manager import EntityManager
+from pyguara.events.dispatcher import EventDispatcher
+from pyguara.physics.backends.pymunk_impl import PymunkEngine
+from pyguara.physics.character_mover import CharacterMover
+from pyguara.physics.collision_system import CollisionSystem
+from pyguara.physics.components import Collider, RigidBody
+from pyguara.physics.physics_system import PhysicsSystem
+from pyguara.physics.types import BodyType, ShapeType
+
+pytestmark = pytest.mark.integration
+
+DT = 1.0 / 60.0
+HALF = Vector2(12.0, 20.0)
+FLOOR_TOP = 480.0
+TILE = 32
+
+
+class World:
+    """Static geometry plus a mover, with no character body of its own."""
+
+    def __init__(self) -> None:
+        """Create an empty world."""
+        self.entities = EntityManager()
+        self.dispatcher = EventDispatcher()
+        self.engine = PymunkEngine()
+        self.engine.set_collision_system(CollisionSystem(self.dispatcher))
+        self.physics = PhysicsSystem(
+            self.engine, self.entities, self.dispatcher, gravity=Vector2(0, 0)
+        )
+        self.mover = CharacterMover(self.engine)
+
+    def solid(self, centre: Vector2, dimensions: list[float]) -> None:
+        """Add one static box."""
+        entity = self.entities.create_entity()
+        entity.add_component(Transform(position=centre))
+        entity.add_component(RigidBody(body_type=BodyType.STATIC))
+        entity.add_component(Collider(shape_type=ShapeType.BOX, dimensions=dimensions))
+
+    def tiled_floor(self, tiles: int) -> None:
+        """A floor built as separate tiles, seams and all."""
+        for i in range(tiles):
+            self.solid(
+                Vector2(i * TILE + TILE / 2, FLOOR_TOP + TILE / 2),
+                [float(TILE), float(TILE)],
+            )
+
+    def build(self) -> None:
+        """Create the bodies in the backend."""
+        self.physics.update(DT)
+
+    def sunk_below(self, position: Vector2, surface_top: float) -> float:
+        """How far the character's feet are below a surface. Negative is clear.
+
+        Asserted geometrically rather than by asking the engine whether the
+        box overlaps: a box resting exactly flush counts as overlapping, so a
+        boolean answer cannot distinguish "resting on" from "inside".
+        """
+        return (position.y + HALF.y) - surface_top
+
+
+def test_falling_stops_flush_on_the_floor() -> None:
+    """Landing leaves the character touching the surface, not inside it."""
+    world = World()
+    world.solid(Vector2(400, FLOOR_TOP + TILE / 2), [800.0, float(TILE)])
+    world.build()
+
+    result = world.mover.move(Vector2(400, 300), HALF, Vector2(0, 400))
+
+    assert result.grounded
+    assert world.sunk_below(result.position, FLOOR_TOP) <= 0.1
+    assert result.position.y == pytest.approx(FLOOR_TOP - HALF.y, abs=0.1)
+
+
+def test_walking_into_a_wall_stops_flush() -> None:
+    """Horizontal motion is stopped without entering the wall."""
+    world = World()
+    world.solid(Vector2(500, 400), [float(TILE), 200.0])
+    world.build()
+
+    result = world.mover.move(Vector2(400, 400), HALF, Vector2(200, 0))
+
+    assert result.hit_x
+    wall_face = 500 - TILE / 2
+    assert (result.position.x + HALF.x) <= wall_face + 0.1
+    assert result.position.x == pytest.approx(wall_face - HALF.x, abs=0.1)
+
+
+def test_landing_keeps_horizontal_motion() -> None:
+    """Axes resolve separately, which is what makes it slide rather than stick."""
+    world = World()
+    world.solid(Vector2(400, FLOOR_TOP + TILE / 2), [800.0, float(TILE)])
+    world.build()
+
+    start = Vector2(300, FLOOR_TOP - HALF.y - 5)
+    result = world.mover.move(start, HALF, Vector2(60, 40))
+
+    assert result.grounded
+    assert result.position.x == pytest.approx(360, abs=0.1), "slid along the floor"
+    assert world.sunk_below(result.position, FLOOR_TOP) <= 0.1
+
+
+def test_walking_across_tile_seams_never_penetrates() -> None:
+    """The reported bug, in the form it took: seams flung the character up.
+
+    A swept mover has nothing to catch on -- it either fits at the next
+    position or stops before it -- so the interior faces of a tiled floor
+    stop mattering.
+    """
+    world = World()
+    world.tiled_floor(tiles=20)
+    world.build()
+
+    position = Vector2(48, FLOOR_TOP - HALF.y)
+    worst = -HALF.y
+    for _ in range(200):
+        result = world.mover.move(position, HALF, Vector2(3.0, 1.0))
+        position = result.position
+        worst = max(worst, world.sunk_below(position, FLOOR_TOP))
+
+    assert worst <= 0.1, f"sank {worst:.3f}px into a tiled floor while walking"
+    assert position.x > 400, "should have travelled along the floor"
+
+
+def test_a_fast_move_does_not_step_over_a_thin_wall() -> None:
+    """Sweeping in bounded steps is also what prevents tunnelling."""
+    world = World()
+    world.solid(Vector2(500, 400), [4.0, 200.0])
+    world.build()
+
+    result = world.mover.move(Vector2(400, 400), HALF, Vector2(3000, 0))
+
+    assert result.hit_x
+    assert (result.position.x + HALF.x) <= 500 - 2.0 + 0.1
+
+
+def test_moving_through_open_space_is_unobstructed() -> None:
+    """The control: nothing in the way means the full delta is travelled."""
+    world = World()
+    world.solid(Vector2(400, FLOOR_TOP + TILE / 2), [800.0, float(TILE)])
+    world.build()
+
+    result = world.mover.move(Vector2(400, 100), HALF, Vector2(50, 60))
+
+    assert not result.hit_x and not result.hit_y
+    assert result.position == Vector2(450, 160)

--- a/tests/integration/test_character_mover.py
+++ b/tests/integration/test_character_mover.py
@@ -6,6 +6,12 @@ at 8px in guara_falcao, recovering at 0.04px a tick. A swept mover cannot
 produce that state: it stops flush at the surface instead of passing through
 it and being pushed back.
 
+Movement is Celeste's model: whole pixels only, with a float remainder
+carrying whatever didn't add up to one yet. That means a resting position is
+never approximate -- most of these assertions are exact pixel equalities,
+not `pytest.approx(..., abs=0.1)`, because there is no bisection settling
+near the answer; the last free whole pixel *is* the answer.
+
 Every test here asserts the same underlying property in a different
 situation: after the move, the character does not overlap anything.
 """
@@ -47,12 +53,13 @@ class World:
         )
         self.mover = CharacterMover(self.engine)
 
-    def solid(self, centre: Vector2, dimensions: list[float]) -> None:
-        """Add one static box."""
+    def solid(self, centre: Vector2, dimensions: list[float]) -> str:
+        """Add one static box and return its entity id."""
         entity = self.entities.create_entity()
         entity.add_component(Transform(position=centre))
         entity.add_component(RigidBody(body_type=BodyType.STATIC))
         entity.add_component(Collider(shape_type=ShapeType.BOX, dimensions=dimensions))
+        return entity.id
 
     def tiled_floor(self, tiles: int) -> None:
         """A floor built as separate tiles, seams and all."""
@@ -85,22 +92,22 @@ def test_falling_stops_flush_on_the_floor() -> None:
     result = world.mover.move(Vector2(400, 300), HALF, Vector2(0, 400))
 
     assert result.grounded
-    assert world.sunk_below(result.position, FLOOR_TOP) <= 0.1
-    assert result.position.y == pytest.approx(FLOOR_TOP - HALF.y, abs=0.1)
+    assert world.sunk_below(result.position, FLOOR_TOP) == 0.0
+    assert result.position.y == FLOOR_TOP - HALF.y
 
 
 def test_walking_into_a_wall_stops_flush() -> None:
     """Horizontal motion is stopped without entering the wall."""
     world = World()
-    world.solid(Vector2(500, 400), [float(TILE), 200.0])
+    wall_id = world.solid(Vector2(500, 400), [float(TILE), 200.0])
     world.build()
 
     result = world.mover.move(Vector2(400, 400), HALF, Vector2(200, 0))
 
     assert result.hit_x
     wall_face = 500 - TILE / 2
-    assert (result.position.x + HALF.x) <= wall_face + 0.1
-    assert result.position.x == pytest.approx(wall_face - HALF.x, abs=0.1)
+    assert result.position.x == wall_face - HALF.x
+    assert result.blocking_x == wall_id
 
 
 def test_landing_keeps_horizontal_motion() -> None:
@@ -113,8 +120,8 @@ def test_landing_keeps_horizontal_motion() -> None:
     result = world.mover.move(start, HALF, Vector2(60, 40))
 
     assert result.grounded
-    assert result.position.x == pytest.approx(360, abs=0.1), "slid along the floor"
-    assert world.sunk_below(result.position, FLOOR_TOP) <= 0.1
+    assert result.position.x == 360, "slid along the floor"
+    assert world.sunk_below(result.position, FLOOR_TOP) == 0.0
 
 
 def test_walking_across_tile_seams_never_penetrates() -> None:
@@ -129,18 +136,20 @@ def test_walking_across_tile_seams_never_penetrates() -> None:
     world.build()
 
     position = Vector2(48, FLOOR_TOP - HALF.y)
+    remainder = Vector2(0.0, 0.0)
     worst = -HALF.y
     for _ in range(200):
-        result = world.mover.move(position, HALF, Vector2(3.0, 1.0))
+        result = world.mover.move(position, HALF, Vector2(3.0, 1.0), remainder)
         position = result.position
+        remainder = result.remainder
         worst = max(worst, world.sunk_below(position, FLOOR_TOP))
 
-    assert worst <= 0.1, f"sank {worst:.3f}px into a tiled floor while walking"
+    assert worst == 0.0, f"sank {worst:.3f}px into a tiled floor while walking"
     assert position.x > 400, "should have travelled along the floor"
 
 
 def test_a_fast_move_does_not_step_over_a_thin_wall() -> None:
-    """Sweeping in bounded steps is also what prevents tunnelling."""
+    """Sweeping one pixel at a time is also what prevents tunnelling."""
     world = World()
     world.solid(Vector2(500, 400), [4.0, 200.0])
     world.build()
@@ -148,7 +157,7 @@ def test_a_fast_move_does_not_step_over_a_thin_wall() -> None:
     result = world.mover.move(Vector2(400, 400), HALF, Vector2(3000, 0))
 
     assert result.hit_x
-    assert (result.position.x + HALF.x) <= 500 - 2.0 + 0.1
+    assert result.position.x == 500 - 2.0 - HALF.x
 
 
 def test_moving_through_open_space_is_unobstructed() -> None:
@@ -161,3 +170,66 @@ def test_moving_through_open_space_is_unobstructed() -> None:
 
     assert not result.hit_x and not result.hit_y
     assert result.position == Vector2(450, 160)
+    assert result.blocking_x is None and result.blocking_y is None
+
+
+def test_a_blocked_axis_discards_its_banked_remainder() -> None:
+    """Being stuck against a wall must not store up a lurch for later.
+
+    Without discarding it, a character held against a wall by continuous
+    input would bank the full distance requested every tick, and the
+    instant the wall was gone, jump forward by everything that had piled up.
+    """
+    world = World()
+    world.solid(Vector2(500, 400), [float(TILE), 200.0])
+    world.build()
+
+    # Slam flush against the wall first, then keep pushing into it in small
+    # increments -- the case that would bank a remainder if blocking didn't
+    # discard it.
+    result = world.mover.move(Vector2(400, 400), HALF, Vector2(200, 0))
+    assert result.hit_x
+    for _ in range(5):
+        result = world.mover.move(
+            result.position, HALF, Vector2(1.0, 0), result.remainder
+        )
+        assert result.hit_x
+        assert result.remainder.x == 0.0
+
+
+def test_sub_pixel_motion_accumulates_without_drift() -> None:
+    """Ten ticks of 0.3px add up to exactly 3px, not zero and not four.
+
+    Each individual tick rounds to zero whole pixels -- if the remainder
+    weren't carried forward, the character would never move at all under
+    a force applied in small enough increments, which gravity often is.
+    """
+    world = World()
+    remainder = Vector2(0.0, 0.0)
+    position = Vector2(400, 100)
+    for _ in range(10):
+        result = world.mover.move(position, HALF, Vector2(0.3, 0), remainder)
+        position = result.position
+        remainder = result.remainder
+
+    assert position.x == 403
+
+
+def test_probe_detects_a_surface_without_moving() -> None:
+    """The ground-check primitive: one pixel below, no movement involved."""
+    world = World()
+    floor_id = world.solid(Vector2(400, FLOOR_TOP + TILE / 2), [800.0, float(TILE)])
+    world.build()
+
+    resting = Vector2(400, FLOOR_TOP - HALF.y)
+    assert world.mover.probe(resting, HALF, Vector2(0, 1)) == floor_id
+
+
+def test_probe_finds_nothing_over_open_space() -> None:
+    """The control: nothing below means the probe reports clear."""
+    world = World()
+    world.solid(Vector2(400, FLOOR_TOP + TILE / 2), [800.0, float(TILE)])
+    world.build()
+
+    airborne = Vector2(400, 100)
+    assert world.mover.probe(airborne, HALF, Vector2(0, 1)) is None

--- a/tests/integration/test_collision_robustness.py
+++ b/tests/integration/test_collision_robustness.py
@@ -158,16 +158,63 @@ class TestRenderInterpolation:
         assert transform.render_position(0.5) == Vector2(5, 0)
         assert transform.render_position(1.0) == Vector2(10, 0)
 
-    def test_a_transform_that_did_not_opt_in_is_drawn_where_it_is(self) -> None:
-        """Interpolation costs a tick of latency, so it stays opt-in.
+    def test_a_transform_that_opted_out_is_drawn_where_it_is(self) -> None:
+        """Opting out must keep working now that interpolation is the default.
 
-        `previous_position` is not maintained for these, so interpolating
-        anyway would drag the sprite toward a stale position.
+        `previous_position` is not maintained for an opted-out transform, so
+        interpolating anyway would drag the sprite toward a stale position.
         """
-        transform = Transform(position=Vector2(10, 0))
+        transform = Transform(position=Vector2(10, 0), interpolate=False)
         transform.previous_position = Vector2(0, 0)
 
         assert transform.render_position(0.5) == Vector2(10, 0)
+
+    def test_physics_turns_interpolation_on_for_the_bodies_it_creates(self) -> None:
+        """A game should not have to know to ask for this.
+
+        Interpolation is right for a transform stepped at the fixed rate and
+        wrong for one moved every frame in variable-rate update(), so it
+        cannot simply default on. The system that makes a transform
+        fixed-stepped is the one that knows, so it opts the transform in.
+        """
+        world = World(gravity=Vector2(0, 900))
+        box = world.add(Vector2(400, 100), BodyType.DYNAMIC, [20.0, 20.0])
+
+        assert box.get_component(Transform).interpolate is False, (
+            "not yet -- the body is created on the first update"
+        )
+
+        world.run(1)
+
+        assert box.get_component(Transform).interpolate is True
+
+    def test_a_plain_transform_is_left_alone(self) -> None:
+        """Nothing opts in a transform a variable-rate system drives.
+
+        Interpolating those adds judder rather than removing it: previous
+        position is snapshotted on the fixed clock while position advances on
+        the frame clock, so the lerp mixes the two.
+        """
+        assert Transform(position=Vector2(0, 0)).interpolate is False
+
+    def test_teleport_does_not_draw_the_journey(self) -> None:
+        """A respawn or screen-wrap must not streak across the screen.
+
+        Setting position alone leaves previous_position behind, so the frame
+        after a teleport is drawn somewhere between the two -- for a wrap from
+        one screen edge to the other, that is the whole screen away.
+        """
+        transform = Transform(position=Vector2(10, 0), interpolate=True)
+        transform.previous_position = Vector2(10, 0)
+
+        transform.position = Vector2(790, 0)
+        assert transform.render_position(0.5) == Vector2(400, 0), (
+            "a plain assignment interpolates, which is the hazard teleport exists for"
+        )
+
+        transform.teleport(Vector2(10, 0))
+        assert transform.render_position(0.5) == Vector2(10, 0)
+        assert transform.render_position(0.0) == Vector2(10, 0)
 
     def test_interpolation_evens_out_the_steps_a_viewer_sees(self) -> None:
         """The point of the helper, stated as the property that matters.

--- a/tests/integration/test_collision_robustness.py
+++ b/tests/integration/test_collision_robustness.py
@@ -1,4 +1,4 @@
-"""Collision behaviour a 2D engine must get right, through the real ECS path.
+"""Collision and motion behaviour a 2D engine must get right.
 
 These go through EntityManager -> PhysicsSystem -> PymunkEngine, wired the
 way `application/bootstrap.py` wires it, because that is where the behaviour
@@ -144,3 +144,62 @@ def test_a_collision_raises_an_event() -> None:
     world.run(240)
 
     assert seen, "a box landing on the ground raised no collision event"
+
+
+class TestRenderInterpolation:
+    """Drawing between fixed ticks, which is what makes motion look smooth."""
+
+    def test_an_opted_in_transform_interpolates_between_ticks(self) -> None:
+        """The drawn position walks from the previous tick to the current one."""
+        transform = Transform(position=Vector2(10, 0), interpolate=True)
+        transform.previous_position = Vector2(0, 0)
+
+        assert transform.render_position(0.0) == Vector2(0, 0)
+        assert transform.render_position(0.5) == Vector2(5, 0)
+        assert transform.render_position(1.0) == Vector2(10, 0)
+
+    def test_a_transform_that_did_not_opt_in_is_drawn_where_it_is(self) -> None:
+        """Interpolation costs a tick of latency, so it stays opt-in.
+
+        `previous_position` is not maintained for these, so interpolating
+        anyway would drag the sprite toward a stale position.
+        """
+        transform = Transform(position=Vector2(10, 0))
+        transform.previous_position = Vector2(0, 0)
+
+        assert transform.render_position(0.5) == Vector2(10, 0)
+
+    def test_interpolation_evens_out_the_steps_a_viewer_sees(self) -> None:
+        """The point of the helper, stated as the property that matters.
+
+        Physics ticks at 60Hz; this frame budget is a 75Hz display, so ticks
+        and frames do not line up. Drawn raw, the body advances 0px on some
+        frames and 5px on others -- visible stutter. Interpolated, every
+        frame advances by close to the true average.
+        """
+        fixed_dt = 1.0 / 60.0
+        speed = 300.0
+        transform = Transform(position=Vector2(0, 0), interpolate=True)
+
+        accumulator = 0.0
+        raw: list[float] = []
+        smooth: list[float] = []
+        for _ in range(200):
+            accumulator += 1.0 / 75.0
+            while accumulator >= fixed_dt:
+                transform.previous_position = transform.position
+                transform.position = transform.position + Vector2(speed * fixed_dt, 0)
+                accumulator -= fixed_dt
+            alpha = accumulator / fixed_dt
+            raw.append(transform.position.x)
+            smooth.append(transform.render_position(alpha).x)
+
+        raw_steps = [b - a for a, b in zip(raw, raw[1:], strict=False)]
+        smooth_steps = [b - a for a, b in zip(smooth, smooth[1:], strict=False)]
+
+        # Raw motion stalls completely on some frames and jumps on others.
+        assert min(raw_steps) == pytest.approx(0.0, abs=0.01)
+        assert max(raw_steps) - min(raw_steps) > 4.0
+
+        # Interpolated motion stays close to the true per-frame distance.
+        assert max(smooth_steps) - min(smooth_steps) < 1.5

--- a/tests/integration/test_knockback.py
+++ b/tests/integration/test_knockback.py
@@ -1,0 +1,128 @@
+"""Knockback: velocity a character consumes, not an impulse.
+
+`Hazard.knockback_force` was declared on the component from the start and
+read by nothing -- there was no velocity a dynamic-body player could
+receive it as that didn't immediately get overwritten by
+PlatformerSystem's own input-driven control the very same tick.
+`apply_knockback()` gives it a real place to land: it overrides
+`CharacterBody.velocity` directly and suppresses input control for a short
+window, during which the velocity decays back toward zero and gravity
+keeps acting underneath it, exactly like an ordinary hit-stun.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyguara.common.components import Transform
+from pyguara.common.types import Vector2
+from pyguara.ecs.manager import EntityManager
+from pyguara.events.dispatcher import EventDispatcher
+from pyguara.physics.backends.pymunk_impl import PymunkEngine
+from pyguara.physics.collision_system import CollisionSystem
+from pyguara.physics.components import CharacterBody, Collider
+from pyguara.physics.physics_system import PhysicsSystem
+from pyguara.physics.platformer_controller import PlatformerController, PlatformerInput
+from pyguara.physics.platformer_system import PlatformerSystem, apply_knockback
+
+pytestmark = pytest.mark.integration
+
+DT = 1.0 / 60.0
+
+
+class World:
+    """A character alone in open space -- knockback needs no geometry."""
+
+    def __init__(self, gravity: Vector2 = Vector2(0, 900)) -> None:
+        """Build the world and drop a character into it."""
+        self.entities = EntityManager()
+        self.dispatcher = EventDispatcher()
+        engine = PymunkEngine()
+        engine.set_collision_system(CollisionSystem(self.dispatcher))
+        self.physics = PhysicsSystem(
+            engine, self.entities, self.dispatcher, gravity=gravity
+        )
+        self.platformer = PlatformerSystem(self.entities, engine, gravity=gravity)
+
+        self.character = self.entities.create_entity()
+        self.character.add_component(Transform(position=Vector2(400, 100)))
+        self.character.add_component(CharacterBody())
+        self.character.add_component(Collider(dimensions=[24.0, 40.0]))
+        self.character.add_component(PlatformerController(move_speed=200.0))
+
+    @property
+    def body(self) -> CharacterBody:
+        """The character's CharacterBody."""
+        return self.character.get_component(CharacterBody)
+
+    @property
+    def controller(self) -> PlatformerController:
+        """The character's controller."""
+        return self.character.get_component(PlatformerController)
+
+    def run(self, ticks: int, move_input: float = 0.0) -> None:
+        """Advance physics then the platformer layer, holding `move_input`."""
+        for _ in range(ticks):
+            self.controller.pending_input = PlatformerInput(move=move_input)
+            self.physics.update(DT)
+            self.platformer.update(DT)
+
+
+def test_knockback_overrides_velocity_immediately() -> None:
+    """The hit itself: velocity becomes the knockback, not whatever it was."""
+    world = World(gravity=Vector2(0, 0))
+    world.body.velocity = Vector2(50, 0)
+
+    apply_knockback(world.body, Vector2(-300, -200), duration=0.2)
+
+    assert world.body.velocity == Vector2(-300, -200)
+    assert world.body.external_velocity_timer == pytest.approx(0.2)
+
+
+def test_knockback_suppresses_input_control_while_active() -> None:
+    """Pressing the opposite direction doesn't cancel the knockback outright."""
+    world = World(gravity=Vector2(0, 0))
+    apply_knockback(world.body, Vector2(-300, 0), duration=0.2)
+
+    # Hold input toward +x -- away from the knockback -- for a few ticks.
+    world.run(5, move_input=1.0)
+
+    assert world.body.velocity.x < 0, "knockback should still be in control"
+
+
+def test_knockback_decays_toward_zero() -> None:
+    """Residual velocity shrinks every tick, not just at the end of the timer."""
+    world = World(gravity=Vector2(0, 0))
+    apply_knockback(world.body, Vector2(-300, 0), duration=1.0)
+
+    speeds = []
+    for _ in range(10):
+        world.run(1)
+        speeds.append(abs(world.body.velocity.x))
+
+    assert all(a >= b for a, b in zip(speeds, speeds[1:], strict=False)), (
+        f"speed should shrink monotonically, was {speeds}"
+    )
+    assert speeds[-1] < speeds[0]
+
+
+def test_control_resumes_once_the_timer_expires() -> None:
+    """After the window closes, input drives velocity again."""
+    world = World(gravity=Vector2(0, 0))
+    apply_knockback(world.body, Vector2(-300, 0), duration=0.05)
+
+    world.run(10, move_input=1.0)  # well past 0.05s
+
+    assert world.body.external_velocity_timer == 0.0
+    assert world.body.velocity.x > 0, "input should be driving velocity again"
+
+
+def test_gravity_still_acts_during_knockback() -> None:
+    """A knockback arcs through the air; it doesn't suspend gravity."""
+    world = World(gravity=Vector2(0, 900))
+    apply_knockback(world.body, Vector2(-300, -200), duration=0.5)
+
+    start_vy = world.body.velocity.y
+    world.run(10)
+
+    assert world.body.velocity.y > start_vy, "gravity should have kept adding downward"

--- a/tests/integration/test_platformer_feel.py
+++ b/tests/integration/test_platformer_feel.py
@@ -25,7 +25,7 @@ from pyguara.ecs.manager import EntityManager
 from pyguara.events.dispatcher import EventDispatcher
 from pyguara.physics.backends.pymunk_impl import PymunkEngine
 from pyguara.physics.collision_system import CollisionSystem
-from pyguara.physics.components import Collider, RigidBody
+from pyguara.physics.components import CharacterBody, Collider, RigidBody
 from pyguara.physics.physics_system import PhysicsSystem
 from pyguara.physics.platformer_controller import PlatformerController, PlatformerInput
 from pyguara.physics.platformer_system import PlatformerSystem
@@ -51,14 +51,12 @@ class Platformer:
         self.physics = PhysicsSystem(
             engine, self.entities, self.dispatcher, gravity=gravity
         )
-        self.platformer = PlatformerSystem(self.entities, engine)
+        self.platformer = PlatformerSystem(self.entities, engine, gravity=gravity)
 
         self.ground = self._body(
             Vector2(400, 500), BodyType.STATIC, [floor_width, 40.0]
         )
-        self.player = self._body(
-            Vector2(400, RESTING_Y), BodyType.DYNAMIC, [24.0, PLAYER_HEIGHT]
-        )
+        self.player = self._character(Vector2(400, RESTING_Y), [24.0, PLAYER_HEIGHT])
         self.player.add_component(PlatformerController(jump_force=350.0))
 
     def _body(
@@ -70,10 +68,23 @@ class Platformer:
         entity.add_component(Collider(shape_type=ShapeType.BOX, dimensions=dimensions))
         return entity
 
+    def _character(self, position: Vector2, dimensions: list[float]) -> Entity:
+        """A mover-driven character: CharacterBody, never a RigidBody."""
+        entity = self.entities.create_entity()
+        entity.add_component(Transform(position=position))
+        entity.add_component(CharacterBody())
+        entity.add_component(Collider(shape_type=ShapeType.BOX, dimensions=dimensions))
+        return entity
+
     @property
     def controller(self) -> PlatformerController:
         """The character's controller."""
         return self.player.get_component(PlatformerController)
+
+    @property
+    def body(self) -> CharacterBody:
+        """The character's CharacterBody."""
+        return self.player.get_component(CharacterBody)
 
     @property
     def y(self) -> float:
@@ -108,7 +119,7 @@ def test_a_character_in_mid_air_is_not_grounded() -> None:
     world.run(60)
     assert world.controller.is_grounded, "should be standing on the floor to start"
 
-    world.player.get_component(RigidBody)._body_handle.velocity = Vector2(0, -400)
+    world.player.get_component(CharacterBody).velocity = Vector2(0, -400)
     world.run(10)
 
     assert world.y < RESTING_Y - 20, "should have left the ground"
@@ -152,32 +163,52 @@ def test_leaving_a_ledge_starts_coyote_time() -> None:
     world.run(60)
     assert world.controller.coyote_timer == 0.0
 
-    world.player.get_component(RigidBody)._body_handle.velocity = Vector2(0, -400)
+    world.player.get_component(CharacterBody).velocity = Vector2(0, -400)
     world.run(10)
 
     assert not world.controller.is_grounded
     assert world.controller.coyote_timer > 0.0
 
 
-def test_a_raycast_can_exclude_the_body_that_cast_it() -> None:
-    """The engine-level capability the fix rests on."""
-    world = Platformer(gravity=Vector2(0, 0))
-    # Float the character far from the floor, so the only thing its own
-    # downward ray can possibly reach is the character itself.
+def test_a_character_has_no_shape_to_self_detect_at_all() -> None:
+    """The fix is structural now, not a query-time exclusion.
+
+    A character used to have its own Chipmunk shape, and a downward ray's
+    swept-circle geometry could reach back into it -- `ignore_entity_id` on
+    `raycast()` was the guard against that. A `CharacterBody` character
+    registers no shape with the engine whatsoever, so there is nothing left
+    to detect: a query centred exactly on the character finds only what is
+    genuinely there.
+    """
+    world = Platformer(gravity=Vector2(0, 0), floor_width=1.0)
     world.player.get_component(Transform).position = Vector2(400, 100)
     world.run(1)
 
-    centre = world.player.get_component(Transform).position
-    feet = centre + Vector2(0, PLAYER_HEIGHT / 2 + 1)
-    just_below = feet + Vector2(0, 3.0)
     engine = world.physics._engine
+    centre = world.player.get_component(Transform).position
 
-    included = engine.raycast(feet, just_below)
-    excluded = engine.raycast(feet, just_below, ignore_entity_id=world.player.id)
+    assert engine.overlap_box(centre, Vector2(12.0, 20.0)) is None
 
-    assert included is not None, "the swept ray does touch the caster"
-    assert included.entity_id == world.player.id
-    assert excluded is None or excluded.entity_id != world.player.id
+
+def test_ignore_entity_id_still_excludes_a_real_body() -> None:
+    """The exclusion mechanism itself still works, for bodies that do exist.
+
+    `overlap_box`/`raycast`'s `ignore_entity_id` is still real
+    infrastructure -- a moving platform or a pushed crate needs it to
+    query the world without detecting itself -- it's just no longer what a
+    character relies on for its own self-detection.
+    """
+    world = Platformer(gravity=Vector2(0, 0), floor_width=1.0)
+    engine = world.physics._engine
+    world.physics.sync_kinematic_transforms()
+
+    included = engine.overlap_box(Vector2(400, 500), Vector2(1.0, 1.0))
+    excluded = engine.overlap_box(
+        Vector2(400, 500), Vector2(1.0, 1.0), ignore_entity_id=world.ground.id
+    )
+
+    assert included == world.ground.id
+    assert excluded is None
 
 
 class TestCharacterBodyOptions:
@@ -409,15 +440,8 @@ class TestWalkingOverTileSeams:
                     [float(self.TILE), float(self.TILE)],
                 )
 
-        walker = world.entities.create_entity()
-        walker.add_component(
-            Transform(position=Vector2(48, self.FLOOR_TOP - PLAYER_HEIGHT / 2))
-        )
-        walker.add_component(
-            RigidBody(mass=1.0, body_type=BodyType.DYNAMIC, fixed_rotation=True)
-        )
-        walker.add_component(
-            Collider(shape_type=ShapeType.BOX, dimensions=[24.0, PLAYER_HEIGHT])
+        walker = world._character(
+            Vector2(48, self.FLOOR_TOP - PLAYER_HEIGHT / 2), [24.0, PLAYER_HEIGHT]
         )
         walker.add_component(PlatformerController(move_speed=180.0))
         controller = walker.get_component(PlatformerController)
@@ -437,11 +461,11 @@ class TestWalkingOverTileSeams:
         return worst
 
     def test_a_merged_floor_keeps_the_character_on_the_surface(self) -> None:
-        """Sinking stays within Chipmunk's slop, which is 0.1px.
+        """A swept mover has nothing to catch on, merged floor or not.
 
         The seam catch itself is only reproducible in a full level -- this
         harness walks cleanly across separate tiles too -- so this pins the
         property that matters rather than the mechanism. The mechanism is
         recorded from the guara_falcao measurement in the class docstring.
         """
-        assert self._walk(merged=True) < 1.0
+        assert self._walk(merged=True) == 0.0

--- a/tests/integration/test_platformer_feel.py
+++ b/tests/integration/test_platformer_feel.py
@@ -254,3 +254,111 @@ class TestCharacterBodyOptions:
             world.physics.update(DT)
 
         assert abs(entity.get_component(Transform).rotation) > 0.1
+
+
+class TestOneWayPlatforms:
+    """Drop-through platforms: solid from above, passable from below.
+
+    Chipmunk has no notion of a one-way surface, so this is entirely
+    PyGuara's. It is the staple of the genre the demos target and was the
+    one platform behaviour missing -- kinematic platforms already carry a
+    rider through friction.
+    """
+
+    PLATFORM_Y = 400.0
+    PLATFORM_HALF_HEIGHT = 10.0
+
+    def _world(self, one_way: bool) -> tuple[Platformer, Entity]:
+        """A lone platform at y=400 with a character 120px below it."""
+        world = Platformer(floor_width=1.0)
+        # The fixture's own character sits at x=400; move it out of the lane
+        # so the jumper below meets the platform and not it.
+        world.player.get_component(Transform).position = Vector2(2000, 0)
+
+        platform = world.entities.create_entity()
+        platform.add_component(Transform(position=Vector2(400, self.PLATFORM_Y)))
+        platform.add_component(RigidBody(body_type=BodyType.STATIC))
+        platform.add_component(
+            Collider(
+                shape_type=ShapeType.BOX,
+                dimensions=[200.0, self.PLATFORM_HALF_HEIGHT * 2],
+                one_way=one_way,
+            )
+        )
+
+        jumper = world.entities.create_entity()
+        jumper.add_component(Transform(position=Vector2(400, 520)))
+        jumper.add_component(
+            RigidBody(mass=1.0, body_type=BodyType.DYNAMIC, fixed_rotation=True)
+        )
+        jumper.add_component(
+            Collider(shape_type=ShapeType.BOX, dimensions=[24.0, PLAYER_HEIGHT])
+        )
+        return world, jumper
+
+    def _launch(self, world: Platformer, jumper: Entity) -> tuple[float, float]:
+        """Fire the character upward; return its peak and settled heights."""
+        world.physics.update(DT)
+        jumper.get_component(RigidBody)._body_handle.velocity = Vector2(0, -700)
+
+        peak = 520.0
+        for _ in range(30):
+            world.physics.update(DT)
+            peak = min(peak, jumper.get_component(Transform).position.y)
+        for _ in range(180):
+            world.physics.update(DT)
+        return peak, jumper.get_component(Transform).position.y
+
+    def test_a_character_jumps_up_through_and_lands_on_top(self) -> None:
+        """The whole behaviour in one test: through from below, solid above."""
+        world, jumper = self._world(one_way=True)
+        peak, settled = self._launch(world, jumper)
+
+        assert peak < self.PLATFORM_Y - 50, "should have passed clear through"
+
+        resting = self.PLATFORM_Y - self.PLATFORM_HALF_HEIGHT - PLAYER_HEIGHT / 2
+        assert settled == pytest.approx(resting, abs=3), (
+            "should have come back down and landed on top of the platform"
+        )
+
+    def test_an_ordinary_platform_still_blocks_from_below(self) -> None:
+        """The control. Without it, a platform that had stopped colliding at
+        all would pass the test above's first assertion."""
+        world, jumper = self._world(one_way=False)
+        peak, _ = self._launch(world, jumper)
+
+        assert peak > self.PLATFORM_Y - 50, "should have been blocked underneath"
+
+    def test_the_solid_side_can_be_pointed_the_other_way(self) -> None:
+        """A ceiling you can drop through but not jump up into.
+
+        Same mechanism, normal reversed -- so the check is on the contact
+        normal rather than hardcoded to gravity's direction.
+        """
+        world = Platformer(floor_width=1.0)
+        world.player.get_component(Transform).position = Vector2(2000, 0)
+        platform = world.entities.create_entity()
+        platform.add_component(Transform(position=Vector2(400, self.PLATFORM_Y)))
+        platform.add_component(RigidBody(body_type=BodyType.STATIC))
+        platform.add_component(
+            Collider(
+                shape_type=ShapeType.BOX,
+                dimensions=[200.0, 20.0],
+                one_way=True,
+                one_way_normal=Vector2(0, 1),  # solid from below
+            )
+        )
+        jumper = world.entities.create_entity()
+        jumper.add_component(Transform(position=Vector2(400, 520)))
+        jumper.add_component(
+            RigidBody(mass=1.0, body_type=BodyType.DYNAMIC, fixed_rotation=True)
+        )
+        jumper.add_component(
+            Collider(shape_type=ShapeType.BOX, dimensions=[24.0, PLAYER_HEIGHT])
+        )
+
+        peak, _ = self._launch(world, jumper)
+
+        assert peak > self.PLATFORM_Y - 50, (
+            "with the solid face pointing down, jumping up into it must be blocked"
+        )

--- a/tests/integration/test_platformer_feel.py
+++ b/tests/integration/test_platformer_feel.py
@@ -362,3 +362,86 @@ class TestOneWayPlatforms:
         assert peak > self.PLATFORM_Y - 50, (
             "with the solid face pointing down, jumping up into it must be blocked"
         )
+
+
+class TestWalkingOverTileSeams:
+    """Walking must not be disturbed by how the floor was built.
+
+    A floor of separate tile colliders has interior faces between the tiles.
+    A character rests `collision_slop` deep in the floor, so its leading
+    bottom corner sits below the tops of the tiles ahead and strikes their
+    vertical faces. Measured in guara_falcao before the fix: at a tile
+    boundary the character was flung upward at 47 px/s, hopped, and landed
+    8.4px inside the floor, where it stayed. It reads as the character
+    sinking into the ground for no reason.
+    """
+
+    FLOOR_TOP = 480.0
+    TILE = 32
+    TILES = 24
+
+    def _walk(self, merged: bool) -> float:
+        """Walk a character across a floor and return the deepest sink."""
+        world = Platformer(floor_width=1.0)
+        world.player.get_component(Transform).position = Vector2(2000, 0)
+
+        def solid(centre: Vector2, dimensions: list[float]) -> None:
+            entity = world.entities.create_entity()
+            entity.add_component(Transform(position=centre))
+            entity.add_component(RigidBody(body_type=BodyType.STATIC))
+            entity.add_component(
+                Collider(shape_type=ShapeType.BOX, dimensions=dimensions)
+            )
+
+        span = self.TILES * self.TILE
+        if merged:
+            solid(
+                Vector2(span / 2, self.FLOOR_TOP + self.TILE / 2),
+                [float(span), float(self.TILE)],
+            )
+        else:
+            for i in range(self.TILES):
+                solid(
+                    Vector2(
+                        i * self.TILE + self.TILE / 2,
+                        self.FLOOR_TOP + self.TILE / 2,
+                    ),
+                    [float(self.TILE), float(self.TILE)],
+                )
+
+        walker = world.entities.create_entity()
+        walker.add_component(
+            Transform(position=Vector2(48, self.FLOOR_TOP - PLAYER_HEIGHT / 2))
+        )
+        walker.add_component(
+            RigidBody(mass=1.0, body_type=BodyType.DYNAMIC, fixed_rotation=True)
+        )
+        walker.add_component(
+            Collider(shape_type=ShapeType.BOX, dimensions=[24.0, PLAYER_HEIGHT])
+        )
+        walker.add_component(PlatformerController(move_speed=180.0))
+        controller = walker.get_component(PlatformerController)
+        transform = walker.get_component(Transform)
+
+        world.run(40)  # settle onto the floor
+
+        worst = 0.0
+        for _ in range(300):
+            controller.pending_input = PlatformerInput(move=1.0)
+            world.physics.update(DT)
+            world.platformer.update(DT)
+            feet = transform.position.y + PLAYER_HEIGHT / 2
+            worst = max(worst, feet - self.FLOOR_TOP)
+            if transform.position.x > span - 3 * self.TILE:
+                break
+        return worst
+
+    def test_a_merged_floor_keeps_the_character_on_the_surface(self) -> None:
+        """Sinking stays within Chipmunk's slop, which is 0.1px.
+
+        The seam catch itself is only reproducible in a full level -- this
+        harness walks cleanly across separate tiles too -- so this pins the
+        property that matters rather than the mechanism. The mechanism is
+        recorded from the guara_falcao measurement in the class docstring.
+        """
+        assert self._walk(merged=True) < 1.0

--- a/tests/integration/test_platformer_feel.py
+++ b/tests/integration/test_platformer_feel.py
@@ -178,3 +178,79 @@ def test_a_raycast_can_exclude_the_body_that_cast_it() -> None:
     assert included is not None, "the swept ray does touch the caster"
     assert included.entity_id == world.player.id
     assert excluded is None or excluded.entity_id != world.player.id
+
+
+class TestCharacterBodyOptions:
+    """RigidBody options a game needs for character feel.
+
+    Both were declared on the component and documented in its docstring, and
+    both were read by nothing: a game could set them, see no effect, and have
+    no way to tell the option was inert rather than its value wrong.
+    """
+
+    def _body(self, gravity: Vector2, **rigidbody: object) -> tuple[Platformer, Entity]:
+        world = Platformer(gravity=gravity)
+        entity = world.entities.create_entity()
+        entity.add_component(Transform(position=Vector2(400, 100)))
+        entity.add_component(
+            RigidBody(mass=1.0, body_type=BodyType.DYNAMIC, **rigidbody)  # type: ignore[arg-type]
+        )
+        entity.add_component(
+            Collider(shape_type=ShapeType.BOX, dimensions=[24.0, 40.0])
+        )
+        return world, entity
+
+    @pytest.mark.parametrize(
+        ("scale", "expected_ratio"),
+        [(0.0, 0.0), (0.5, 0.5), (2.0, 2.0)],
+    )
+    def test_gravity_scale_changes_how_fast_a_body_falls(
+        self, scale: float, expected_ratio: float
+    ) -> None:
+        """0.0 floats, 2.0 falls twice as fast -- floaty jumps and fast falls."""
+        baseline_world, baseline = self._body(Vector2(0, 900))
+        scaled_world, scaled = self._body(Vector2(0, 900), gravity_scale=scale)
+
+        # Half a second only: at 2x gravity a full second would land the body
+        # on the floor and the comparison would measure the floor, not gravity.
+        for _ in range(30):
+            baseline_world.physics.update(DT)
+            scaled_world.physics.update(DT)
+
+        normal_fall = baseline.get_component(Transform).position.y - 100
+        scaled_fall = scaled.get_component(Transform).position.y - 100
+
+        assert scaled_fall == pytest.approx(normal_fall * expected_ratio, rel=0.01)
+
+    def test_fixed_rotation_keeps_a_character_upright(self) -> None:
+        """A character box knocked off-centre must not tumble.
+
+        Setting the moment at creation is not enough: attaching a shape with
+        a density makes Chipmunk re-derive mass and moment from the shapes,
+        discarding it.
+        """
+        world, entity = self._body(Vector2(0, 0), fixed_rotation=True)
+        world.physics.update(DT)
+
+        body = entity.get_component(RigidBody)._body_handle._body
+        body.apply_impulse_at_local_point((200, 0), (0, -20))
+        for _ in range(120):
+            world.physics.update(DT)
+
+        assert entity.get_component(Transform).rotation == pytest.approx(0.0, abs=1e-6)
+
+    def test_a_body_without_fixed_rotation_still_turns(self) -> None:
+        """The control: the same shove must spin an ordinary body.
+
+        Without this, the test above would pass just as well if torque had
+        stopped working altogether.
+        """
+        world, entity = self._body(Vector2(0, 0))
+        world.physics.update(DT)
+
+        body = entity.get_component(RigidBody)._body_handle._body
+        body.apply_impulse_at_local_point((200, 0), (0, -20))
+        for _ in range(120):
+            world.physics.update(DT)
+
+        assert abs(entity.get_component(Transform).rotation) > 0.1

--- a/tests/integration/test_platformer_feel.py
+++ b/tests/integration/test_platformer_feel.py
@@ -1,0 +1,180 @@
+"""The game-feel layer built on top of the simulation.
+
+Chipmunk simulates rigid bodies; it knows nothing about characters, ground or
+jumping. Everything that makes a platformer feel right -- knowing you are
+standing on something, coyote time, jump buffering, one jump per landing --
+is PyGuara's own, and all of it rests on the ground raycast telling the truth.
+
+It did not. The ray starts just below the character's feet, but a Chipmunk
+segment query is a swept circle whose radius reached back into the character's
+own collider, so every character detected itself and read as permanently
+grounded -- in mid-air, and with no ground in the world at all. Coyote time
+never started, jump buffering had nothing to buffer for, and the landing that
+clears the one-jump-per-landing flag never happened, so a character stopped
+being able to jump until it died.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyguara.common.components import Transform
+from pyguara.common.types import Vector2
+from pyguara.ecs.entity import Entity
+from pyguara.ecs.manager import EntityManager
+from pyguara.events.dispatcher import EventDispatcher
+from pyguara.physics.backends.pymunk_impl import PymunkEngine
+from pyguara.physics.collision_system import CollisionSystem
+from pyguara.physics.components import Collider, RigidBody
+from pyguara.physics.physics_system import PhysicsSystem
+from pyguara.physics.platformer_controller import PlatformerController, PlatformerInput
+from pyguara.physics.platformer_system import PlatformerSystem
+from pyguara.physics.types import BodyType, ShapeType
+
+pytestmark = pytest.mark.integration
+
+DT = 1.0 / 60.0
+PLAYER_HEIGHT = 40.0
+GROUND_TOP = 480.0  # ground centre y=500, 40 tall
+RESTING_Y = GROUND_TOP - PLAYER_HEIGHT / 2
+
+
+class Platformer:
+    """A character on a floor, wired as a game would wire it."""
+
+    def __init__(self, gravity: Vector2 = Vector2(0, 900), floor_width: float = 800.0):
+        """Build the world and drop a character into it."""
+        self.entities = EntityManager()
+        self.dispatcher = EventDispatcher()
+        engine = PymunkEngine()
+        engine.set_collision_system(CollisionSystem(self.dispatcher))
+        self.physics = PhysicsSystem(
+            engine, self.entities, self.dispatcher, gravity=gravity
+        )
+        self.platformer = PlatformerSystem(self.entities, engine)
+
+        self.ground = self._body(
+            Vector2(400, 500), BodyType.STATIC, [floor_width, 40.0]
+        )
+        self.player = self._body(
+            Vector2(400, RESTING_Y), BodyType.DYNAMIC, [24.0, PLAYER_HEIGHT]
+        )
+        self.player.add_component(PlatformerController(jump_force=350.0))
+
+    def _body(
+        self, position: Vector2, body_type: BodyType, dimensions: list[float]
+    ) -> Entity:
+        entity = self.entities.create_entity()
+        entity.add_component(Transform(position=position))
+        entity.add_component(RigidBody(mass=1.0, body_type=body_type))
+        entity.add_component(Collider(shape_type=ShapeType.BOX, dimensions=dimensions))
+        return entity
+
+    @property
+    def controller(self) -> PlatformerController:
+        """The character's controller."""
+        return self.player.get_component(PlatformerController)
+
+    @property
+    def y(self) -> float:
+        """The character's current height."""
+        return self.player.get_component(Transform).position.y
+
+    def run(self, ticks: int) -> None:
+        """Advance physics then the platformer layer, as fixed_update does."""
+        for _ in range(ticks):
+            self.physics.update(DT)
+            self.platformer.update(DT)
+
+    def jump(self) -> float:
+        """Request a jump and return how high the character actually got."""
+        resting = self.y
+        self.controller.pending_input = PlatformerInput(jump=True)
+        peak = resting
+        for _ in range(60):
+            self.physics.update(DT)
+            self.platformer.update(DT)
+            peak = min(peak, self.y)
+        return resting - peak
+
+
+def test_a_character_in_mid_air_is_not_grounded() -> None:
+    """The bug in one line: it used to detect its own collider.
+
+    The character is launched upward and checked while it is unambiguously
+    airborne, tens of pixels above the floor.
+    """
+    world = Platformer()
+    world.run(60)
+    assert world.controller.is_grounded, "should be standing on the floor to start"
+
+    world.player.get_component(RigidBody)._body_handle.velocity = Vector2(0, -400)
+    world.run(10)
+
+    assert world.y < RESTING_Y - 20, "should have left the ground"
+    assert not world.controller.is_grounded
+
+
+def test_a_character_with_no_ground_beneath_it_is_not_grounded() -> None:
+    """The sharpest version: nothing to stand on anywhere in the world."""
+    world = Platformer(gravity=Vector2(0, 0), floor_width=1.0)
+    world.player.get_component(Transform).position = Vector2(400, 100)
+    world.run(2)
+
+    assert not world.controller.is_grounded
+
+
+def test_a_character_can_jump_again_after_landing() -> None:
+    """One jump per landing, not one jump per lifetime.
+
+    `_jump_used` is cleared by the airborne-to-grounded transition. While
+    grounding was stuck on, that transition never fired again and the third
+    jump -- the first after the input buffer was exhausted -- did nothing.
+    """
+    world = Platformer()
+    world.run(60)
+
+    heights = []
+    for _ in range(3):
+        heights.append(world.jump())
+        world.run(60)  # land and settle
+
+    assert all(h > 20 for h in heights), f"jump heights were {heights}"
+
+
+def test_leaving_a_ledge_starts_coyote_time() -> None:
+    """Coyote time is the grace period after walking off an edge.
+
+    It can only start on the grounded-to-airborne transition, which never
+    happened while the character believed it was always on the ground.
+    """
+    world = Platformer()
+    world.run(60)
+    assert world.controller.coyote_timer == 0.0
+
+    world.player.get_component(RigidBody)._body_handle.velocity = Vector2(0, -400)
+    world.run(10)
+
+    assert not world.controller.is_grounded
+    assert world.controller.coyote_timer > 0.0
+
+
+def test_a_raycast_can_exclude_the_body_that_cast_it() -> None:
+    """The engine-level capability the fix rests on."""
+    world = Platformer(gravity=Vector2(0, 0))
+    # Float the character far from the floor, so the only thing its own
+    # downward ray can possibly reach is the character itself.
+    world.player.get_component(Transform).position = Vector2(400, 100)
+    world.run(1)
+
+    centre = world.player.get_component(Transform).position
+    feet = centre + Vector2(0, PLAYER_HEIGHT / 2 + 1)
+    just_below = feet + Vector2(0, 3.0)
+    engine = world.physics._engine
+
+    included = engine.raycast(feet, just_below)
+    excluded = engine.raycast(feet, just_below, ignore_entity_id=world.player.id)
+
+    assert included is not None, "the swept ray does touch the caster"
+    assert included.entity_id == world.player.id
+    assert excluded is None or excluded.entity_id != world.player.id

--- a/tests/integration/test_scene_owned_systems.py
+++ b/tests/integration/test_scene_owned_systems.py
@@ -313,8 +313,13 @@ def test_interpolated_transform_lerps_by_render_alpha() -> None:
 
 
 def test_non_interpolated_transform_ignores_render_alpha() -> None:
-    """A Transform with interpolate=False (the default) always submits at its
-    raw current position, regardless of render_alpha."""
+    """A Transform with interpolate=False always submits at its raw current
+    position, regardless of render_alpha.
+
+    Interpolation is the default now, so opting out is explicit -- but the
+    opt-out must keep working for transforms driven directly each frame
+    rather than stepped.
+    """
     app = create_headless_application()
     scene = _boot(app)
 
@@ -324,7 +329,7 @@ def test_non_interpolated_transform_ignores_render_alpha() -> None:
     )
 
     entity = scene.entity_manager.create_entity()
-    transform = Transform(position=Vector2(100, 0))
+    transform = Transform(position=Vector2(100, 0), interpolate=False)
     transform.previous_position = Vector2(0, 0)  # would matter if interpolated
     entity.add_component(transform)
     entity.add_component(Sprite(texture=texture, visible=True))
@@ -378,7 +383,7 @@ def test_fixed_update_does_not_snapshot_non_interpolated_transforms() -> None:
     scene = _boot(app)
 
     entity = scene.entity_manager.create_entity()
-    transform = Transform(position=Vector2(5, 5))
+    transform = Transform(position=Vector2(5, 5), interpolate=False)
     transform.previous_position = Vector2(-1, -1)  # sentinel, must stay put
     entity.add_component(transform)
 

--- a/tests/integration/test_solid_mover.py
+++ b/tests/integration/test_solid_mover.py
@@ -1,0 +1,282 @@
+"""SolidMover: solids carry riders and push what's in their way.
+
+`CharacterMover` covers a character moving under its own control; this is
+the other half of the model -- a platform (or a crate a character shoves)
+moving *the character*. Every test here checks the same thing `move_solid`
+promises: an actor riding or in the way ends up exactly where the solid's
+motion put it, and if that position has no room, it's flagged rather than
+silently allowed to overlap.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyguara.common.components import Transform
+from pyguara.common.types import Vector2
+from pyguara.ecs.entity import Entity
+from pyguara.ecs.manager import EntityManager
+from pyguara.events.dispatcher import EventDispatcher
+from pyguara.physics.backends.pymunk_impl import PymunkEngine
+from pyguara.physics.collision_system import CollisionSystem
+from pyguara.physics.components import (
+    CharacterBody,
+    Collider,
+    MovingSolid,
+    Pushable,
+    RigidBody,
+)
+from pyguara.physics.events import OnActorSquished
+from pyguara.physics.physics_system import PhysicsSystem
+from pyguara.physics.platformer_controller import PlatformerController, PlatformerInput
+from pyguara.physics.platformer_system import PlatformerSystem
+from pyguara.physics.solid_mover import SolidMover
+from pyguara.physics.solid_system import SolidSystem
+from pyguara.physics.types import BodyType, ShapeType
+
+pytestmark = pytest.mark.integration
+
+DT = 1.0 / 60.0
+HALF = Vector2(12.0, 20.0)
+
+
+class World:
+    """Static geometry, solids and actors, wired the way a game would."""
+
+    def __init__(self) -> None:
+        """Create an empty world."""
+        self.entities = EntityManager()
+        self.dispatcher = EventDispatcher()
+        self.engine = PymunkEngine()
+        self.engine.set_collision_system(CollisionSystem(self.dispatcher))
+        self.physics = PhysicsSystem(
+            self.engine, self.entities, self.dispatcher, gravity=Vector2(0, 0)
+        )
+        self.mover = SolidMover(self.entities, self.engine, self.dispatcher)
+
+    def wall(self, centre: Vector2, dimensions: list[float]) -> Entity:
+        """A static, immovable box."""
+        entity = self.entities.create_entity()
+        entity.add_component(Transform(position=centre))
+        entity.add_component(RigidBody(body_type=BodyType.STATIC))
+        entity.add_component(Collider(shape_type=ShapeType.BOX, dimensions=dimensions))
+        return entity
+
+    def solid(
+        self, centre: Vector2, dimensions: list[float], pushable: bool = False
+    ) -> Entity:
+        """A MovingSolid: still a real KINEMATIC body, as far as Chipmunk cares."""
+        entity = self.entities.create_entity()
+        entity.add_component(Transform(position=centre))
+        entity.add_component(RigidBody(body_type=BodyType.KINEMATIC))
+        entity.add_component(Collider(shape_type=ShapeType.BOX, dimensions=dimensions))
+        entity.add_component(MovingSolid())
+        if pushable:
+            entity.add_component(Pushable())
+        return entity
+
+    def actor(self, centre: Vector2, dimensions: list[float]) -> Entity:
+        """A mover-driven character: no shape in the engine at all."""
+        entity = self.entities.create_entity()
+        entity.add_component(Transform(position=centre))
+        entity.add_component(CharacterBody())
+        entity.add_component(Collider(shape_type=ShapeType.BOX, dimensions=dimensions))
+        return entity
+
+    def build(self) -> None:
+        """Create every body in the backend."""
+        self.physics.update(DT)
+
+    def move_solid_by(self, entity: Entity, delta: Vector2) -> None:
+        """Apply a solid's authored displacement, then react to it.
+
+        Mirrors what SolidSystem does every tick: something else (a patrol
+        script, a tween) moves the Transform first; SolidMover only reacts
+        to a displacement that's already happened, it never applies one.
+        """
+        transform = entity.get_component(Transform)
+        transform.position = transform.position + delta
+        self.mover.move_solid(entity, delta)
+
+
+def test_riding_a_platform_moves_with_it() -> None:
+    """An actor resting on top of a solid is carried the exact same delta."""
+    world = World()
+    platform = world.solid(Vector2(400, 480), [200.0, 20.0])
+    rider = world.actor(Vector2(400, 480 - 10 - HALF.y), [HALF.x * 2, HALF.y * 2])
+    world.build()
+
+    world.move_solid_by(platform, Vector2(50, 0))
+
+    assert rider.get_component(Transform).position == Vector2(450, 480 - 10 - HALF.y)
+    assert rider.get_component(CharacterBody).riding == platform.id
+
+
+def test_an_actor_not_touching_the_solid_is_left_alone() -> None:
+    """The control: an actor nowhere near the solid isn't touched."""
+    world = World()
+    platform = world.solid(Vector2(400, 480), [200.0, 20.0])
+    bystander = world.actor(Vector2(400, 100), [HALF.x * 2, HALF.y * 2])
+    world.build()
+
+    world.move_solid_by(platform, Vector2(50, 0))
+
+    assert bystander.get_component(Transform).position == Vector2(400, 100)
+    assert not bystander.get_component(CharacterBody).riding
+
+
+def test_a_solid_pushes_an_actor_clear_of_its_new_footprint() -> None:
+    """A solid closing in from the side shoves a standing actor clear.
+
+    The actor isn't riding -- it's beside the solid at the same height --
+    so this is the push branch, not the carry one.
+    """
+    world = World()
+    platform = world.solid(Vector2(300, 400), [40.0, 40.0])
+    actor = world.actor(Vector2(335, 400), [HALF.x * 2, HALF.y * 2])
+    world.build()
+
+    world.move_solid_by(platform, Vector2(30, 0))
+
+    # Platform's right face moved from 320 to 350; the actor should be shoved
+    # to sit exactly flush against it, not left overlapping.
+    pushed = actor.get_component(Transform).position
+    assert pushed.x == pytest.approx(362.0)
+    assert not actor.get_component(CharacterBody).squished
+
+
+def test_a_pinned_actor_is_flagged_and_reported() -> None:
+    """Pushed into a wall behind it, with nowhere left to go.
+
+    The push formula only resolves the overlap against the solid doing the
+    pushing; it has no notion of a wall on the other side. That's what the
+    post-push overlap check catches.
+    """
+    world = World()
+    world.wall(Vector2(375, 400), [40.0, 200.0])  # left face at 355
+    platform = world.solid(Vector2(300, 400), [40.0, 40.0])
+    actor = world.actor(Vector2(335, 400), [HALF.x * 2, HALF.y * 2])
+    world.build()
+
+    events: list[OnActorSquished] = []
+    world.dispatcher.subscribe(OnActorSquished, events.append)
+
+    world.move_solid_by(platform, Vector2(30, 0))
+
+    assert actor.get_component(CharacterBody).squished
+    assert len(events) == 1
+    assert events[0].entity_id == actor.id
+    assert events[0].solid_entity_id == platform.id
+
+
+def test_solid_system_reads_delta_from_the_transform_that_already_moved() -> None:
+    """SolidSystem never applies a solid's motion -- only reacts to it.
+
+    Whatever authors a platform's patrol (not built here) already moved its
+    Transform by the time SolidSystem runs; `previous_position` is how it
+    recovers *how far*, the same mechanism the render-interpolation
+    snapshot already maintains every fixed tick.
+    """
+    world = World()
+    platform = world.solid(Vector2(400, 480), [200.0, 20.0])
+    rider = world.actor(Vector2(400, 480 - 10 - HALF.y), [HALF.x * 2, HALF.y * 2])
+    world.build()
+    system = SolidSystem(world.entities, world.mover)
+
+    transform = platform.get_component(Transform)
+    transform.previous_position = transform.position  # this tick's "before"
+    transform.position = transform.position + Vector2(40, 0)  # already moved
+
+    system.update(DT)
+
+    assert rider.get_component(Transform).position == Vector2(440, 480 - 10 - HALF.y)
+    assert rider.get_component(CharacterBody).riding == platform.id
+
+
+def test_solid_system_clears_riding_for_a_platform_left_behind() -> None:
+    """Riding is re-decided every tick, not remembered from a stale one."""
+    world = World()
+    platform = world.solid(Vector2(400, 480), [200.0, 20.0])
+    actor = world.actor(Vector2(400, 480 - 10 - HALF.y), [HALF.x * 2, HALF.y * 2])
+    world.build()
+    system = SolidSystem(world.entities, world.mover)
+    actor.get_component(CharacterBody).riding = platform.id  # stale, from before
+
+    transform = platform.get_component(Transform)
+    transform.previous_position = transform.position  # didn't move this tick
+
+    system.update(DT)
+
+    assert actor.get_component(CharacterBody).riding is None
+
+
+FLOOR_TOP = 480.0
+
+
+class TestPushableCrate:
+    """A character shoving a Pushable solid, through PlatformerSystem.
+
+    Grounded, not airborne: `_apply_movement` deliberately refuses to push
+    into whatever `on_wall_left`/`on_wall_right` sees while airborne (so a
+    jumping character doesn't fight the mover), and that check doesn't
+    distinguish a `Pushable` from an ordinary wall. A crate is a ground-level
+    mechanic (`guara_falcao`'s GDD calls it "Bash"), so these characters
+    stand on a floor like a real one would.
+    """
+
+    def _world(self) -> tuple[World, PlatformerSystem, Entity]:
+        world = World()
+        world.wall(Vector2(400, FLOOR_TOP + 20), [2000.0, 40.0])
+        solid_mover = SolidMover(world.entities, world.engine, world.dispatcher)
+        platformer = PlatformerSystem(
+            world.entities,
+            world.engine,
+            gravity=Vector2(0, 900),
+            solid_mover=solid_mover,
+        )
+        # A gap, not contact: the character has to walk 48px before it even
+        # reaches the crate, so this exercises the approach, not just an
+        # already-touching edge case.
+        character = world.actor(Vector2(350, FLOOR_TOP - 20), [24.0, 40.0])
+        character.add_component(PlatformerController(move_speed=180.0))
+        world.build()
+        for _ in range(30):  # settle onto the floor before either test starts
+            world.physics.update(DT)
+            platformer.update(DT)
+        return world, platformer, character
+
+    def test_walking_into_a_free_crate_pushes_it_along(self) -> None:
+        world, platformer, character = self._world()
+        crate = world.solid(Vector2(430, FLOOR_TOP - 20), [40.0, 40.0], pushable=True)
+        world.build()
+
+        controller = character.get_component(PlatformerController)
+        for _ in range(120):
+            controller.pending_input = PlatformerInput(move=1.0)
+            world.physics.update(DT)
+            platformer.update(DT)
+
+        crate_x = crate.get_component(Transform).position.x
+        character_x = character.get_component(Transform).position.x
+        assert crate_x > 430, "crate should have been pushed along"
+        assert character_x > 350, "character should have kept moving behind it"
+
+    def test_a_crate_blocked_by_a_wall_stops_the_character_too(self) -> None:
+        world, platformer, character = self._world()
+        crate = world.solid(Vector2(430, FLOOR_TOP - 20), [40.0, 40.0], pushable=True)
+        world.wall(Vector2(470, FLOOR_TOP - 20), [20.0, 200.0])  # left face at 460
+        world.build()
+
+        controller = character.get_component(PlatformerController)
+        for _ in range(150):
+            controller.pending_input = PlatformerInput(move=1.0)
+            world.physics.update(DT)
+            platformer.update(DT)
+
+        crate_x = crate.get_component(Transform).position.x
+        # The crate can travel at most 10px before its own right face (450)
+        # meets the wall's left face (460).
+        assert crate_x <= 440 + 0.5
+        character_right = character.get_component(Transform).position.x + 12.0
+        crate_left = crate_x - 20.0
+        assert character_right <= crate_left + 0.5

--- a/tests/test_platformer_controller.py
+++ b/tests/test_platformer_controller.py
@@ -4,14 +4,14 @@ from pyguara.common.components import Transform
 from pyguara.common.types import Vector2
 from pyguara.ecs.manager import EntityManager
 from pyguara.physics.backends.pymunk_impl import PymunkEngine
-from pyguara.physics.components import Collider, RigidBody
+from pyguara.physics.components import CharacterBody, Collider
 from pyguara.physics.platformer_controller import (
     PlatformerController,
     PlatformerInput,
     PlatformerState,
 )
 from pyguara.physics.platformer_system import PlatformerSystem
-from pyguara.physics.types import BodyType, ShapeType
+from pyguara.physics.types import ShapeType
 
 
 class TestPlatformerControllerComponent:
@@ -122,7 +122,9 @@ class TestPlatformerSystem:
         self.manager = EntityManager()
         self.physics_engine = PymunkEngine()
         self.physics_engine.initialize(Vector2(0, 980))  # Gravity
-        self.platformer_system = PlatformerSystem(self.manager, self.physics_engine)
+        self.platformer_system = PlatformerSystem(
+            self.manager, self.physics_engine, gravity=Vector2(0, 980)
+        )
 
     def test_system_creation(self):
         """PlatformerSystem should be created successfully."""
@@ -137,10 +139,10 @@ class TestPlatformerSystem:
         # Should not raise
         self.platformer_system.update(1 / 60)
 
-        # Entity with controller and rigidbody but no transform
+        # Entity with controller and body but no transform
         entity2 = self.manager.create_entity()
         entity2.add_component(PlatformerController())
-        entity2.add_component(RigidBody(body_type=BodyType.DYNAMIC))
+        entity2.add_component(CharacterBody())
 
         # Should not raise
         self.platformer_system.update(1 / 60)
@@ -149,17 +151,11 @@ class TestPlatformerSystem:
         """System should update coyote and jump buffer timers."""
         entity = self.manager.create_entity()
         entity.add_component(Transform(position=Vector2(100, 100)))
-        entity.add_component(RigidBody(body_type=BodyType.DYNAMIC))
+        entity.add_component(CharacterBody())
         controller = PlatformerController()
         controller.coyote_timer = 0.15
         controller.jump_buffer_timer = 0.1
         entity.add_component(controller)
-
-        # Create physics body
-        body = self.physics_engine.create_body(
-            entity.id, BodyType.DYNAMIC, Vector2(100, 100)
-        )
-        entity.get_component(RigidBody)._body_handle = body
 
         # Update system
         dt = 1 / 60  # 60 FPS
@@ -174,16 +170,10 @@ class TestPlatformerSystem:
         """System should reset pending_input after consuming it each update."""
         entity = self.manager.create_entity()
         entity.add_component(Transform(position=Vector2(100, 100)))
-        entity.add_component(RigidBody(body_type=BodyType.DYNAMIC))
+        entity.add_component(CharacterBody())
         controller = PlatformerController()
         controller.pending_input = PlatformerInput(move=1.0)
         entity.add_component(controller)
-
-        # Create physics body
-        body = self.physics_engine.create_body(
-            entity.id, BodyType.DYNAMIC, Vector2(100, 100)
-        )
-        entity.get_component(RigidBody)._body_handle = body
 
         # Update system
         self.platformer_system.update(1 / 60)
@@ -212,14 +202,9 @@ class TestPlatformerSystem:
         """pending_input.jump should translate into a buffered jump request."""
         entity = self.manager.create_entity()
         entity.add_component(Transform(position=Vector2(100, 100)))
-        entity.add_component(RigidBody(body_type=BodyType.DYNAMIC))
+        entity.add_component(CharacterBody())
         controller = PlatformerController(jump_buffer=0.1)
         entity.add_component(controller)
-
-        body = self.physics_engine.create_body(
-            entity.id, BodyType.DYNAMIC, Vector2(100, 100)
-        )
-        entity.get_component(RigidBody)._body_handle = body
 
         controller.pending_input = PlatformerInput(jump=True)
         self.platformer_system.update(1 / 60)
@@ -345,9 +330,7 @@ class TestPlatformerUsagePatterns:
         # Create player
         player = manager.create_entity()
         player.add_component(Transform(position=Vector2(400, 300)))
-        player.add_component(
-            RigidBody(mass=1.0, body_type=BodyType.DYNAMIC, fixed_rotation=True)
-        )
+        player.add_component(CharacterBody())
         player.add_component(Collider(shape_type=ShapeType.BOX, dimensions=[32, 64]))
         player.add_component(
             PlatformerController(
@@ -357,7 +340,7 @@ class TestPlatformerUsagePatterns:
 
         # Verify all components present
         assert player.has_component(PlatformerController)
-        assert player.has_component(RigidBody)
+        assert player.has_component(CharacterBody)
         assert player.has_component(Transform)
 
     def test_input_handling_pattern(self):

--- a/tests/test_tilemap_collision.py
+++ b/tests/test_tilemap_collision.py
@@ -1,0 +1,100 @@
+"""Merging a tile grid into as few colliders as possible.
+
+A floor built as one collider per tile has interior faces between the tiles.
+They are invisible in the level and real to the solver, and a character
+resting `collision_slop` deep in the floor catches its leading bottom corner
+on them. Merging removes the faces; these tests pin the merge itself, and
+`tests/integration/test_platformer_feel.py` pins the behaviour it buys.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyguara.physics.tilemap import merge_tile_rects
+
+pytestmark = pytest.mark.unit
+
+TILE = 32
+
+
+def grid(rows: list[str]) -> list[list[bool]]:
+    """Build a solidity grid from `#` and `.` rows."""
+    return [[char == "#" for char in row] for row in rows]
+
+
+def test_a_solid_rectangle_becomes_one_collider() -> None:
+    """The case that matters: a flat floor is one box, not forty."""
+    rects = merge_tile_rects(grid(["#" * 40] * 5), TILE)
+
+    assert len(rects) == 1
+    assert (rects[0].x, rects[0].y) == (0, 0)
+    assert (rects[0].width, rects[0].height) == (40 * TILE, 5 * TILE)
+
+
+def test_a_gap_splits_the_run() -> None:
+    """A pit in the floor must remain a pit."""
+    rects = merge_tile_rects(grid(["##..###"]), TILE)
+
+    assert [(r.x, r.width) for r in rects] == [(0, 2 * TILE), (4 * TILE, 3 * TILE)]
+
+
+def test_rows_that_do_not_line_up_are_not_stacked() -> None:
+    """A row is only stacked onto the one above when their runs match.
+
+    Runs extend rightwards first, so the wider row stays whole and the
+    narrower one becomes its own rectangle rather than the pair being
+    squared off into a shape the level does not have.
+    """
+    rects = merge_tile_rects(grid(["###", "##."]), TILE)
+
+    assert sorted((r.x, r.y, r.width, r.height) for r in rects) == [
+        (0, 0, 3 * TILE, TILE),
+        (0, TILE, 2 * TILE, TILE),
+    ]
+
+
+def test_every_solid_tile_is_covered_exactly_once() -> None:
+    """The property that makes merging safe: same area, no overlap.
+
+    A merge that dropped a tile would open a hole to fall through; one that
+    double-covered a tile would leave overlapping colliders fighting.
+    """
+    rows = [
+        "#####...####",
+        "#..##...#..#",
+        "#..#######.#",
+        "############",
+    ]
+    solid = grid(rows)
+    rects = merge_tile_rects(solid, TILE)
+
+    covered: dict[tuple[int, int], int] = {}
+    for rect in rects:
+        for gy in range(rect.y // TILE, (rect.y + rect.height) // TILE):
+            for gx in range(rect.x // TILE, (rect.x + rect.width) // TILE):
+                covered[(gx, gy)] = covered.get((gx, gy), 0) + 1
+
+    expected = {
+        (x, y)
+        for y, row in enumerate(solid)
+        for x, is_solid in enumerate(row)
+        if is_solid
+    }
+    assert set(covered) == expected
+    assert all(count == 1 for count in covered.values())
+
+
+def test_merging_actually_reduces_the_collider_count() -> None:
+    """Otherwise the whole exercise buys nothing."""
+    rows = ["#" * 40] * 5 + ["#" + "." * 38 + "#"] * 10
+    solid = grid(rows)
+    per_tile = sum(row.count(True) for row in solid)
+
+    assert len(merge_tile_rects(solid, TILE)) < per_tile / 10
+
+
+def test_an_empty_grid_yields_nothing() -> None:
+    """No tiles, no colliders -- and no crash on the empty case."""
+    assert merge_tile_rects([], TILE) == []
+    assert merge_tile_rects(grid(["...", "..."]), TILE) == []


### PR DESCRIPTION
## Summary

Platformer characters no longer move as dynamic rigid bodies with assigned
velocity. That was the root of a whole family of bugs — sinking, seam
catching, wall creep, tunnelling — because a character pressed into geometry
is *inside* it until Chipmunk's solver pushes it back out. Characters are
now swept by `CharacterMover`, a Celeste-style (integer position + float
remainder) collide-and-slide mover, and carry no physics body at all.

This branch also carries the physics-audit defect fixes and features that
led up to the switch (substepping, ground self-detection, tile-collider
merging, one-way platforms, a collider debug overlay) — see the commit log
for each one's own rationale. Only the branch's first commit
(`cdc7402`/substep fix) has been merged before now, as PR #24; the rest,
including everything below, is new.

## The switch, in order

1. **`CharacterMover`** rewritten to whole-pixel stepping with a remainder
   accumulator (no more `MAX_STEP`/bisection — the last free whole pixel is
   the answer directly). `overlap_box` now reports *which* entity it hit.
2. **`PhysicsSystem.sync_kinematic_transforms()`** split out of `update()`,
   so later systems can query a solid's current-tick position.
3. **`CharacterBody`** replaces `RigidBody` for a character: no shape
   registered with the engine at all, so the old ground-ray self-detection
   bug class is now structurally impossible rather than guarded against.
   `PlatformerSystem` integrates gravity itself and sweeps via the mover;
   ground/wall detection moved off raycasts onto overlap probes.
4. **`SolidMover`/`SolidSystem`** — full physical parity, decided against
   the actual code rather than assumed: knockback, platform riding, and
   crate pushing were all unbuilt (`Hazard.knockback_force` was dead code,
   crates didn't exist, no system drove a moving platform). Built on
   Celeste's `Solid.MoveHExact`/`MoveVExact` model — a rider or pushed actor
   is placed directly where the solid's motion dictates, then checked for
   whether that's still clear of everything else (a squish, reported via
   `OnActorSquished`, if not).
5. **`Pushable`** crates, via `SolidMover.try_move()`.
6. **`apply_knockback()`** — velocity, not an impulse, wired into
   `guara_falcao`'s `HazardSystem`.
7. **Demo content** — a patrolling platform and a pushable crate in
   `guara_falcao`'s level, and the `fixed_update` reordering the whole
   switch needed.
8. Docs (`docs/physics/character-movement.md`) and the audit tracker
   updated to record the decision and the shape it took.

## Verification

- `pytest && ruff check . && mypy pyguara` clean on the branch tip.
- Also verified from a **clean `git worktree`** (fresh `uv sync`, full
  suite, lint, type-check) — not just the working tree.
- A headless run of the actual `LevelBuilder`-constructed level: settles
  onto the floor, walks the full distance requested, jumps and lands
  grounded again, no sinking; the moving platform patrols and the player
  walks normally alongside it.
- New test files: `tests/integration/test_solid_mover.py` (riding,
  pushing, squish, pushable crates through `PlatformerSystem` end to end),
  `tests/integration/test_knockback.py`. `test_character_mover.py` and the
  platformer test suites rebuilt around `CharacterBody`, with resting-
  position assertions tightened from `pytest.approx(..., abs=0.1)` to exact
  pixel equality now that there's no bisection settling near the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)