### PR TITLE
physics audit: trigger volumes and joints, both inert end to end

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -53,15 +53,19 @@ how the subject is *constructed*, not just what is asserted.
 
 ## Active Subsystem
 
-`pyguara/physics` — **in progress, branch merged, subsystem not closed.**
+`pyguara/physics` — **in progress, subsystem not closed.**
 `fix/physics-collision-tunnelling` merged to `main` as **PR #25** (its first
 commit went out earlier, alone, as PR #24). Symptom-driven so far: six
 defects found and fixed from reported bad collision behaviour, plus one-way
-platforms, a collider debug overlay, and the character-mover switch. The
-systematic pass over `collision_system`, `trigger_volume`/`trigger_system`
-and `joints` is still outstanding, as are Phase B and C — **cut a fresh
-branch from `main` for that** (the old one is gone; PR #25 deleted it on
-merge).
+platforms, a collider debug overlay, and the character-mover switch.
+
+The systematic pass over `collision_system`, `trigger_volume`/`trigger_system`
+and `joints` is now done on branch `refactor/physics-triggers-joints-audit`:
+trigger volumes and the entire `Joint` layer were both inert end to end and
+are now built and tested (see the iteration log entry below). Phase B for
+those files is done with it; **Phase C for the subsystem as a whole, and a
+last read of `materials.py`/`tilemap.py`/`debug_draw.py`, still remain**
+before the subsystem closes.
 
 **The big decision — move characters off dynamic rigid bodies onto
 `CharacterMover` — is resolved, built, and merged.** Full physical parity
@@ -103,8 +107,11 @@ Ordered roughly by dependency depth: foundations first, leaves last.
     - [x] 5. Assets & effects — spritesheet, ninepatch, materials, vfx, lighting *(active)*
 - [ ] `pyguara/physics` — protocols, pymunk backend, joints, materials
     - [x] Character movement switched to `CharacterMover` (PRs #24, #25)
-    - [ ] `collision_system.py`, `trigger_volume.py`, `trigger_system.py`,
-      `joints.py`; Phase B and C
+    - [x] `collision_system.py`, `trigger_volume.py`, `trigger_system.py`,
+      `joints.py` — triggers + joints rebuilt end to end
+      (branch `refactor/physics-triggers-joints-audit`)
+    - [ ] Phase C (docs) for the subsystem as a whole; final read of
+      `materials.py`, `tilemap.py`, `debug_draw.py`
 - [ ] `pyguara/input` — input manager, rebinding
 - [ ] `pyguara/audio` — audio manager, spatial audio
 - [ ] `pyguara/animation` — tween, easing, FSM
@@ -322,6 +329,105 @@ convert to explicit `is None` checks as each subsystem is audited.
 ---
 
 ## Iteration Log
+
+### `pyguara/physics` triggers & joints — awaiting approval (branch `refactor/physics-triggers-joints-audit`)
+
+The systematic pass the earlier physics work deferred: `collision_system.py`,
+`trigger_volume.py`, `trigger_system.py`, `joints.py`. Both remaining feature
+areas turned out to be inert end to end -- full API, docstrings and unit
+tests, connected to nothing. Every defect was reproduced with a probe against
+the real pymunk backend before being touched.
+
+**Verification:** 1608 tests pass (up from 1591); `ruff check .` clean;
+`mypy pyguara` clean across 224 files. Each finding below was confirmed by a
+probe, and each fix by watching a new test fail when reverted.
+
+**F1 -- the entire `Joint` ECS layer did nothing.** `Joint` plus all five
+`create_*_joint()` factories plus `create_rope_chain()` produced components
+that no system consumed: there was no `JointSystem`, and `PhysicsSystem` only
+ever looks at `Transform`+`RigidBody`. `engine.create_joint()` was called
+only by tests. Probe: a pin-jointed body free-fell 1846px in 2s;
+`len(space.constraints) == 0`. `joints.py`'s module and class docstrings both
+stated "The joint is created by the PhysicsSystem when both entities have
+RigidBody components" -- untrue since the sentence was written.
+
+New `pyguara/physics/joint_system.py`. `JointSystem` reads `Joint`
+components, calls `engine.create_joint()` once both entities have a body in
+the engine (retrying on later ticks until then, so it is order-independent
+w.r.t. `PhysicsSystem`), stores the handle on `Joint._joint_handle` and
+mirrors it in an owner-keyed table. It tears the constraint down on
+`EntityDestroyed` for either endpoint, and on `Joint` component removal
+(reconciled each `update()`). Opt-in and ticked by the game after
+`PhysicsSystem.update()`, exactly like `PhysicsSystem` itself -- no
+bootstrap/scene auto-registration, matching the existing convention.
+`PymunkEngine.destroy_body()` now also removes a body's attached constraints
+first, so tearing down a jointed body is self-consistent regardless of which
+system gets there first.
+
+**F2 -- trigger volumes fired with the roles swapped, so `TriggerSystem`
+dropped every event.** `CollisionSystem.on_collision_begin/persist/end` took
+`is_sensor: bool` and unconditionally treated `entity_a` as the trigger and
+`entity_b` as the other body. Chipmunk's `arbiter.shapes` order is arbitrary;
+the probe showed the dynamic body landing as `entity_a` in *both* entity
+creation orders, so `OnTriggerEnter` came out `trigger_entity=<the ball>,
+other_entity=<the zone>`. `TriggerSystem._on_trigger_enter` then looked up the
+ball, found no `TriggerVolume`, and returned -- `entities_inside` never
+populated, `contains_entity()` / `one_shot` / tag filtering all dead. The
+callback contract is now `sensor_entity_id: str | None`: the backend resolves
+which shape is the sensor (it is the only thing that can) and
+`CollisionSystem._order_trigger_pair()` puts it first.
+
+**F3 -- a trigger built the documented way never entered the simulation.**
+`trigger_volume.py`'s own usage example adds `Transform` + `TriggerVolume`
+and nothing else. `TriggerSystem.update()` added a sensor `Collider`, but
+`PhysicsSystem` only registers shapes for entities that also have a
+`RigidBody`, so the sensor shape never reached the space and no event ever
+fired. `TriggerSystem` now also adds a static `RigidBody` when the entity has
+none (a game that needs a moving trigger still supplies its own KINEMATIC
+body). This is why `guara_falcao` never used `TriggerVolume` at all -- its
+`CheckpointSystem` is a hand-rolled `distance < 40px` check over a bespoke
+`ZoneTrigger` component, the workaround you write when the engine's triggers
+don't work.
+
+**Pattern, extended.** "Declared and wired to nothing" -- already flagged in
+the last physics entry for `fixed_rotation`, `gravity_scale` and the
+`return False` collision contract -- now has its two largest instances:
+`Joint` (whole ECS layer) and `TriggerVolume` (end-to-end). Both had unit
+tests that passed because each built its subject in isolation: joints tested
+only via `engine.create_joint()` directly, trigger callbacks tested only with
+the sensor hand-passed as `entity_a`. Uniform setup, fifth and sixth
+instances.
+
+**Tests (+17 net; ~50 changed).** `test_collision_events.py` rewritten for
+the `sensor_entity_id` contract, with a new `TestTriggerRoleOrdering` class
+that passes the sensor as `entity_b` and asserts the event still comes out
+sensor-first. New `tests/integration/test_trigger_volumes_backend.py` drives
+`PymunkEngine`+`CollisionSystem`+`PhysicsSystem`+`TriggerSystem` together --
+parametrised on entity creation order (the thing that used to decide whether
+triggers worked), plus the no-RigidBody case, tag filtering and one-shot. New
+`tests/test_joint_system.py`: pin joint holds, deferred creation, teardown on
+either entity's destruction and on component removal, self-target and missing
+target tolerated, rope chain holds together, `cleanup()`.
+
+**Docs (Phase C, partial).** `docs/physics/simulation.md` gains a Joints
+section and a Trigger-volumes section (the three-system requirement, the
+auto-added bodies); the collision section now states the sensor-ordering
+guarantee. `test_docs_api.py` passes. Full-subsystem Phase C -- a dedicated
+page, and reconciling the scattered `RigidBody` examples -- is still open.
+
+**Deliberately not done:** no demo added (triggers/joints are covered by the
+new integration tests and `guara_falcao` has no natural place for a
+pendulum); `guara_falcao`'s checkpoints left on their hand-rolled path;
+`create_joint`'s GEAR/MOTOR still structural-only (`ratio=1`, `rate=0` -- a
+MOTOR joint would need new `Joint` fields to be useful); `set_collision_system`
+still absent from the `IPhysicsEngine` protocol (works because bootstrap holds
+the concrete `PymunkEngine`).
+
+**Still open for subsystem close:** `physics.substeps` default (4 vs 2, from
+the last entry); `point_query`/`bb_query`/`shape_query`/multi-hit segment
+queries still unexposed; `surface_velocity`, slope handling, variable jump
+height, corner correction, body sleeping still absent (all from the last
+entry's reference comparison).
 
 ### `pyguara/physics` — IN PROGRESS (PRs #24 and #25, branch `fix/physics-collision-tunnelling`, merged)
 

--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -94,6 +94,11 @@ Framework-level work above physics — combat spine, seeded RNG service,
 stat/modifier system, projectile layer, procgen, tilemap, run/meta save
 split, flow-field pathfinding, hit-stop, combat juice, local co-op input —
 is **issue #28 (roguelike core)**, out of scope for the physics audit.
+Prior art: `github.com/Wedeueis/reclaimer_legacy`, an earlier iteration of
+this engine (fused with one game, hence the restart) that already built and
+tested combat, stats, equipment/modules, procgen, GOAP/utility AI and
+projectiles — read its `reclaimer/game/<subsystem>` module before starting
+the matching #28 piece.
 
 **The big decision — move characters off dynamic rigid bodies onto
 `CharacterMover` — is resolved, built, and merged.** Full physical parity

--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -63,9 +63,37 @@ The systematic pass over `collision_system`, `trigger_volume`/`trigger_system`
 and `joints` is now done on branch `refactor/physics-triggers-joints-audit`:
 trigger volumes and the entire `Joint` layer were both inert end to end and
 are now built and tested (see the iteration log entry below). Phase B for
-those files is done with it; **Phase C for the subsystem as a whole, and a
-last read of `materials.py`/`tilemap.py`/`debug_draw.py`, still remain**
-before the subsystem closes.
+those files is done with it.
+
+**To close the subsystem** (one more slice, cut fresh from `main`):
+
+- **Expose the remaining pymunk spatial queries** — `point_query`,
+  `shape_query`/`bb_query`, multi-hit `segment_query`. Only `raycast` and
+  `overlap_box` are exposed; the rest rule out click-picking, explosion
+  radii, melee arcs, piercing shots and "can I fit here". Small backend +
+  `IPhysicsEngine` additions. Dependency for the projectile layer in
+  issue #28.
+- **Body sleeping** — honour `space.sleep_time_threshold`. Every idle body
+  is simulated forever; a room-based game carries a lot of settled props
+  and debris. Small, pymunk-native.
+- **Resolve the `physics.substeps` default** (4 vs 2 — 4 costs ~half a
+  60Hz frame at 200 dynamic bodies).
+- **Phase C** (subsystem docs) and a last read of `materials.py`,
+  `tilemap.py`, `debug_draw.py`.
+
+**Next physics slice, its own build/PR (`CharacterMover`-sized):** a
+**top-down kinematic character controller** — 8-directional collide-and-slide
+with actor-vs-actor soft separation and push-out-of-overlap. The physics
+layer currently serves only platformers; every game the engine targets is
+top-down, and dynamic bodies there hit the same sink/creep/jitter family the
+platformer did, plus crowd stacking. Platformer polish (slope handling,
+variable jump height, corner correction) and `surface_velocity` (conveyors)
+are **parked as low priority** given the genre.
+
+Framework-level work above physics — combat spine, seeded RNG service,
+stat/modifier system, projectile layer, procgen, tilemap, run/meta save
+split, flow-field pathfinding, hit-stop, combat juice, local co-op input —
+is **issue #28 (roguelike core)**, out of scope for the physics audit.
 
 **The big decision — move characters off dynamic rigid bodies onto
 `CharacterMover` — is resolved, built, and merged.** Full physical parity
@@ -158,6 +186,7 @@ Concerns that outgrew this file, or that need a decision rather than a fix:
 | [#16](https://github.com/Wedeueis/pyguara/issues/16) | `IFramebuffer`/`IRenderPass` not `runtime_checkable`; `IRenderPass` vs `BaseRenderPass(ABC)` overlap |
 | [#19](https://github.com/Wedeueis/pyguara/issues/19) | ~2,700 lines of GPU-dependent graphics code are read-audited only, with no headless GL coverage |
 | [#23](https://github.com/Wedeueis/pyguara/issues/23) | `camera.rotation` is applied by `Camera2D.world_to_screen` but ignored by the render path; three definitions of world-to-screen disagree |
+| [#28](https://github.com/Wedeueis/pyguara/issues/28) | Roguelike core — framework-level subsystems the target genre needs (combat spine, seeded RNG service, stat/modifier system, projectile layer, procgen, tilemap, run/meta save split, flow-field pathfinding, hit-stop, combat juice, local co-op input) |
 
 ---
 

--- a/docs/physics/simulation.md
+++ b/docs/physics/simulation.md
@@ -25,16 +25,67 @@ The `PhysicsSystem` synchronizes the ECS `Transform` component with the Pymunk b
 
 ## Collision Handling
 
-Collisions generate events via the `CollisionSystem`.
+Collisions generate events via the `CollisionSystem`, which `bootstrap.py`
+wires to the physics engine. Subscribe on the `EventDispatcher`:
 
-*   **`OnCollisionBegin`**: Physical contact started.
-*   **`OnCollisionEnd`**: Physical contact ended.
-*   **`OnTriggerEnter`**: Entered a trigger volume.
+*   **`OnCollisionBegin` / `OnCollisionPersist` / `OnCollisionEnd`**: two
+    solid (non-sensor) colliders touching.
+*   **`OnTriggerEnter` / `OnTriggerStay` / `OnTriggerExit`**: something
+    overlapping a sensor collider.
 
 ```python
 def on_collision(self, event: OnCollisionBegin):
     print(f"Entities {event.entity_a} and {event.entity_b} collided!")
 ```
+
+The engine reports a contact pair in Chipmunk's own order and tells
+`CollisionSystem` which side owns the sensor; the trigger events always come
+out with `trigger_entity` set to the sensor's entity and `other_entity` the
+body that entered it, regardless of that order.
+
+## Trigger volumes
+
+A `TriggerVolume` component is the high-level way to use a sensor: it keeps a
+live `entities_inside` set and supports tag filtering and one-shot
+deactivation. It needs **three** systems running -- `PhysicsSystem`,
+`CollisionSystem`, and `TriggerSystem` (the last is opt-in; create one and
+tick it each frame). `TriggerSystem` gives the entity the pieces it needs to
+enter the simulation:
+
+*   a sensor `Collider` matching the volume's shape, and
+*   a static `RigidBody`, if the entity has none -- `PhysicsSystem` only
+    registers shapes for entities that have a body. Add your own KINEMATIC
+    `RigidBody` instead if the trigger has to move with a platform.
+
+```python
+zone = entity_manager.create_entity()
+zone.add_component(Transform(position=Vector2(400, 300)))
+zone.add_component(TriggerVolume(
+    shape_type=ShapeType.BOX, dimensions=[100, 100], tags={"player"},
+))
+# ...later, any frame:
+if zone.get_component(TriggerVolume).contains_entity(player.id):
+    ...
+```
+
+## Joints
+
+`Joint` connects two entities' `RigidBody` bodies -- pin, distance, spring,
+slider. The component is pure data; `pyguara.physics.joint_system.JointSystem`
+is what turns it into a real constraint. Like `PhysicsSystem` it is opt-in:
+create one and tick it each fixed step, **after** `PhysicsSystem.update()`.
+
+```python
+from pyguara.physics.joints import create_pin_joint
+
+bob.add_component(create_pin_joint(target_entity_id=anchor.id))
+```
+
+`JointSystem` builds the constraint once both entities have a body in the
+engine (retrying on later ticks until then), and destroys it when either
+entity is removed or the `Joint` component is taken off its entity. Factory
+helpers: `create_pin_joint`, `create_distance_joint`, `create_spring_joint`,
+`create_slider_joint`, plus `create_rope_chain` for a segmented rope.
 
 ## Platformer characters: CharacterMover, not RigidBody
 

--- a/pyguara/physics/__init__.py
+++ b/pyguara/physics/__init__.py
@@ -1,8 +1,11 @@
 """Physics subsystem."""
 
 from pyguara.physics.backends.pymunk_impl import PymunkEngine
+from pyguara.physics.collision_system import CollisionSystem
 from pyguara.physics.components import Collider, RigidBody
 from pyguara.physics.physics_system import PhysicsSystem
+from pyguara.physics.trigger_system import TriggerSystem
+from pyguara.physics.trigger_volume import EntityTags, TriggerVolume
 from pyguara.physics.types import BodyType, CollisionLayer, PhysicsMaterial, ShapeType
 
 __all__ = [
@@ -14,4 +17,8 @@ __all__ = [
     "Collider",
     "PhysicsSystem",
     "PymunkEngine",
+    "CollisionSystem",
+    "TriggerVolume",
+    "EntityTags",
+    "TriggerSystem",
 ]

--- a/pyguara/physics/__init__.py
+++ b/pyguara/physics/__init__.py
@@ -3,6 +3,14 @@
 from pyguara.physics.backends.pymunk_impl import PymunkEngine
 from pyguara.physics.collision_system import CollisionSystem
 from pyguara.physics.components import Collider, RigidBody
+from pyguara.physics.joint_system import JointSystem
+from pyguara.physics.joints import (
+    Joint,
+    create_distance_joint,
+    create_pin_joint,
+    create_slider_joint,
+    create_spring_joint,
+)
 from pyguara.physics.physics_system import PhysicsSystem
 from pyguara.physics.trigger_system import TriggerSystem
 from pyguara.physics.trigger_volume import EntityTags, TriggerVolume
@@ -18,6 +26,12 @@ __all__ = [
     "PhysicsSystem",
     "PymunkEngine",
     "CollisionSystem",
+    "Joint",
+    "JointSystem",
+    "create_pin_joint",
+    "create_distance_joint",
+    "create_spring_joint",
+    "create_slider_joint",
     "TriggerVolume",
     "EntityTags",
     "TriggerSystem",

--- a/pyguara/physics/backends/pymunk_impl.py
+++ b/pyguara/physics/backends/pymunk_impl.py
@@ -78,6 +78,27 @@ def _one_way_allows_contact(
     return True
 
 
+def _sensor_entity_id(
+    shape_a: pymunk.Shape,
+    shape_b: pymunk.Shape,
+    entity_a: Any,
+    entity_b: Any,
+) -> str | None:
+    """Return the entity id owning the sensor shape in this pair, or None.
+
+    The collision system needs the sensor identified, not merely a flag that
+    one exists: the pair arrives in Chipmunk's own order, so "which side is
+    the trigger" is otherwise a coin flip. When both shapes are sensors the
+    first is reported -- two overlapping sensors is a degenerate case the
+    event model does not distinguish anyway.
+    """
+    if shape_a.sensor:
+        return str(entity_a)
+    if shape_b.sensor:
+        return str(entity_b)
+    return None
+
+
 def _scaled_gravity(scale: float) -> Any:
     """Build a velocity callback applying scaled gravity to one body.
 
@@ -303,10 +324,10 @@ class PymunkEngine:
             normal = Vector2(0, 1)
 
         impulse = arbiter.total_impulse.length
-        is_sensor = shape_a.sensor or shape_b.sensor
+        sensor_id = _sensor_entity_id(shape_a, shape_b, entity_a, entity_b)
 
         process = self._collision_system.on_collision_begin(
-            str(entity_a), str(entity_b), point, normal, impulse, is_sensor
+            str(entity_a), str(entity_b), point, normal, impulse, sensor_id
         )
 
         # The collision system returns False to mean "report this but do not
@@ -352,10 +373,10 @@ class PymunkEngine:
             normal = Vector2(0, 1)
 
         impulse = arbiter.total_impulse.length
-        is_sensor = shape_a.sensor or shape_b.sensor
+        sensor_id = _sensor_entity_id(shape_a, shape_b, entity_a, entity_b)
 
         process = self._collision_system.on_collision_persist(
-            str(entity_a), str(entity_b), point, normal, impulse, is_sensor
+            str(entity_a), str(entity_b), point, normal, impulse, sensor_id
         )
 
         # The collision system returns False to mean "report this but do not
@@ -387,9 +408,9 @@ class PymunkEngine:
         if entity_a is None or entity_b is None:
             return
 
-        is_sensor = shape_a.sensor or shape_b.sensor
+        sensor_id = _sensor_entity_id(shape_a, shape_b, entity_a, entity_b)
 
-        self._collision_system.on_collision_end(str(entity_a), str(entity_b), is_sensor)
+        self._collision_system.on_collision_end(str(entity_a), str(entity_b), sensor_id)
 
     def update(self, delta_time: float) -> None:
         """Step the physics simulation forward.
@@ -491,6 +512,13 @@ class PymunkEngine:
             )
 
         body = body_handle._body
+        # Constraints must leave the space before the body they anchor, or
+        # pymunk raises. A JointSystem normally tears its own joints down on
+        # EntityDestroyed, but a body destroyed for any other reason (or in a
+        # different order) would otherwise strand them.
+        for constraint in list(body.constraints):
+            with contextlib.suppress(Exception):
+                self.space.remove(constraint)
         for shape in list(body.shapes):
             self.space.remove(shape)
         self.space.remove(body)

--- a/pyguara/physics/collision_system.py
+++ b/pyguara/physics/collision_system.py
@@ -65,6 +65,31 @@ class CollisionSystem:
         # Key: (trigger_entity_id, other_entity_id), Value: True if active
         self._active_triggers: dict[tuple[str, str], bool] = {}
 
+    @staticmethod
+    def _order_trigger_pair(
+        entity_a: str, entity_b: str, sensor_entity_id: str
+    ) -> tuple[str, str]:
+        """Return ``(trigger_entity, other_entity)`` with the sensor first.
+
+        The backend reports a contact pair in an arbitrary order -- Chipmunk
+        decides which shape is A -- and only it knows which of the two shapes
+        is the sensor. Without reordering here, the trigger volume and the
+        body that entered it are swapped for roughly half of all pairs, and
+        ``TriggerSystem`` then silently drops every event whose nominal
+        trigger entity has no ``TriggerVolume`` component.
+
+        Args:
+            entity_a: First entity in the pair, as the backend reported it.
+            entity_b: Second entity in the pair.
+            sensor_entity_id: Which of the two owns the sensor shape.
+
+        Returns:
+            The pair reordered so the sensor entity comes first.
+        """
+        if sensor_entity_id == entity_b:
+            return entity_b, entity_a
+        return entity_a, entity_b
+
     def on_collision_begin(
         self,
         entity_a: str,
@@ -72,7 +97,7 @@ class CollisionSystem:
         point: Vector2,
         normal: Vector2,
         impulse: float,
-        is_sensor: bool,
+        sensor_entity_id: str | None,
     ) -> bool:
         """Handle collision begin event from physics engine.
 
@@ -82,14 +107,19 @@ class CollisionSystem:
             point: Contact point in world coordinates.
             normal: Surface normal (from A to B).
             impulse: Collision impulse magnitude.
-            is_sensor: True if either collider is a sensor.
+            sensor_entity_id: The entity owning the sensor shape when this
+                contact is a trigger overlap, or None for a solid collision.
+                The backend resolves this; the pair itself arrives unordered.
 
         Returns:
             True to process collision physically, False to ignore.
         """
-        if is_sensor:
+        if sensor_entity_id is not None:
             # Handle as trigger, not physical collision
-            self._handle_trigger_begin(entity_a, entity_b)
+            trigger, other = self._order_trigger_pair(
+                entity_a, entity_b, sensor_entity_id
+            )
+            self._handle_trigger_begin(trigger, other)
             return False  # Don't process physically
         else:
             # Handle as physical collision
@@ -114,7 +144,7 @@ class CollisionSystem:
         point: Vector2,
         normal: Vector2,
         impulse: float,
-        is_sensor: bool,
+        sensor_entity_id: str | None,
     ) -> bool:
         """Handle collision persist event from physics engine.
 
@@ -124,14 +154,18 @@ class CollisionSystem:
             point: Contact point in world coordinates.
             normal: Surface normal (from A to B).
             impulse: Current collision impulse magnitude.
-            is_sensor: True if either collider is a sensor.
+            sensor_entity_id: The entity owning the sensor shape when this
+                contact is a trigger overlap, or None for a solid collision.
 
         Returns:
             True to continue processing collision, False to ignore.
         """
-        if is_sensor:
+        if sensor_entity_id is not None:
             # Handle as trigger
-            self._handle_trigger_stay(entity_a, entity_b)
+            trigger, other = self._order_trigger_pair(
+                entity_a, entity_b, sensor_entity_id
+            )
+            self._handle_trigger_stay(trigger, other)
             return False
         else:
             # Dispatch persist event
@@ -150,18 +184,22 @@ class CollisionSystem:
         self,
         entity_a: str,
         entity_b: str,
-        is_sensor: bool,
+        sensor_entity_id: str | None,
     ) -> None:
         """Handle collision end event from physics engine.
 
         Args:
             entity_a: ID of first entity.
             entity_b: ID of second entity.
-            is_sensor: True if either collider is a sensor.
+            sensor_entity_id: The entity owning the sensor shape when this
+                contact was a trigger overlap, or None for a solid collision.
         """
-        if is_sensor:
+        if sensor_entity_id is not None:
             # Handle as trigger
-            self._handle_trigger_end(entity_a, entity_b)
+            trigger, other = self._order_trigger_pair(
+                entity_a, entity_b, sensor_entity_id
+            )
+            self._handle_trigger_end(trigger, other)
         else:
             # Remove from active collisions
             collision_key = frozenset({entity_a, entity_b})

--- a/pyguara/physics/joint_system.py
+++ b/pyguara/physics/joint_system.py
@@ -1,0 +1,217 @@
+"""System that turns ``Joint`` components into live physics constraints.
+
+``Joint`` is a plain data component; on its own it does nothing. ``JointSystem``
+is what reads it, asks the physics engine to create the matching constraint
+once both connected bodies exist, and tears the constraint down again when
+either entity -- or the ``Joint`` component itself -- goes away.
+
+Like ``PhysicsSystem``, this is an opt-in system: a game that uses joints
+creates one and ticks it each fixed step, after ``PhysicsSystem.update()`` so
+that both bodies have been registered with the backend.
+
+Usage:
+    joint_system = JointSystem(engine, entity_manager, event_dispatcher)
+
+    def fixed_update(self, fixed_dt: float) -> None:
+        self.physics_system.update(fixed_dt)
+        self.joint_system.update(fixed_dt)
+"""
+
+from typing import Any
+
+from pyguara.ecs.events import EntityDestroyed
+from pyguara.ecs.manager import EntityManager
+from pyguara.events.dispatcher import EventDispatcher
+from pyguara.log import get_logger
+from pyguara.physics.components import RigidBody
+from pyguara.physics.joints import Joint
+from pyguara.physics.protocols import IPhysicsEngine
+
+logger = get_logger(__name__)
+
+
+class JointSystem:
+    """Creates and destroys physics constraints for ``Joint`` components.
+
+    A ``Joint`` lives on one entity (call it the owner) and names a second
+    entity by id. The constraint is created only once both entities have a
+    ``RigidBody`` whose backend body exists; until then the joint is left
+    pending and retried on the next ``update()``. This makes the system
+    order-independent with respect to body creation -- a joint added the
+    same tick as its bodies simply links up one tick later.
+
+    The backend handle is stored on ``Joint._joint_handle`` (so the same
+    component is never built twice) and mirrored in an internal table keyed
+    by owner id, which is what teardown and reconciliation walk.
+
+    Attributes:
+        _engine: The physics engine backend.
+        _entity_manager: EntityManager for resolving the target entity.
+        _dispatcher: EventDispatcher, subscribed for ``EntityDestroyed``.
+        _handles: Owner entity id -> backend joint handle, for live joints.
+    """
+
+    def __init__(
+        self,
+        engine: IPhysicsEngine,
+        entity_manager: EntityManager,
+        event_dispatcher: EventDispatcher,
+    ) -> None:
+        """Initialise the joint system and subscribe to entity destruction.
+
+        Args:
+            engine: The physics engine backend.
+            entity_manager: EntityManager to resolve target entities.
+            event_dispatcher: EventDispatcher to observe ``EntityDestroyed``.
+        """
+        self._engine = engine
+        self._entity_manager = entity_manager
+        self._dispatcher = event_dispatcher
+        self._handles: dict[str, Any] = {}
+
+        self._dispatcher.subscribe(EntityDestroyed, self._on_entity_destroyed)
+
+    def update(self, delta_time: float) -> None:
+        """Create pending constraints and drop ones whose component is gone.
+
+        Args:
+            delta_time: Fixed timestep in seconds (unused; the constraint,
+                once created, is stepped by the engine).
+        """
+        live_owners: set[str] = set()
+
+        for entity in self._entity_manager.get_entities_with(Joint):
+            joint = entity.get_component(Joint)
+            live_owners.add(entity.id)
+
+            if joint._joint_handle is not None:
+                # Already built. Keep the mirror table in sync in case this
+                # system was constructed after the joint was created.
+                self._handles.setdefault(entity.id, joint._joint_handle)
+                continue
+
+            self._try_create(entity.id, joint)
+
+        # Reconcile: a handle we still track whose owner no longer carries a
+        # matching live Joint (component removed, or entity gone without an
+        # EntityDestroyed we saw) must be released.
+        for owner_id in list(self._handles):
+            if owner_id in live_owners:
+                owner = self._entity_manager.get_entity(owner_id)
+                if (
+                    owner is not None
+                    and owner.has_component(Joint)
+                    and owner.get_component(Joint)._joint_handle
+                    is self._handles[owner_id]
+                ):
+                    continue
+            self._destroy(owner_id)
+
+    def _try_create(self, owner_id: str, joint: Joint) -> None:
+        """Build the constraint if both bodies are ready; otherwise defer.
+
+        Args:
+            owner_id: Id of the entity carrying the ``Joint``.
+            joint: The joint component to realise.
+        """
+        if not joint.target_entity_id:
+            return  # Unconfigured joint; nothing to connect to yet.
+
+        if joint.target_entity_id == owner_id:
+            logger.warning("Joint on entity %s targets itself; ignoring.", owner_id)
+            return
+
+        owner = self._entity_manager.get_entity(owner_id)
+        target = self._entity_manager.get_entity(joint.target_entity_id)
+        if owner is None or target is None:
+            return
+
+        body_a = self._body_of(owner)
+        body_b = self._body_of(target)
+        if body_a is None or body_b is None:
+            return  # Bodies not created yet -- retry next tick.
+
+        handle = self._engine.create_joint(
+            body_a,
+            body_b,
+            joint.joint_type,
+            joint.anchor_a,
+            joint.anchor_b,
+            joint.min_distance,
+            joint.max_distance,
+            joint.stiffness,
+            joint.damping,
+            joint.max_force,
+            joint.collide_connected,
+        )
+        if handle is None:
+            return
+
+        joint._joint_handle = handle
+        self._handles[owner_id] = handle
+
+    @staticmethod
+    def _body_of(entity: Any) -> Any | None:
+        """Return the backend body handle for an entity, or None.
+
+        Args:
+            entity: The entity to inspect.
+
+        Returns:
+            The ``RigidBody._body_handle`` if present and created, else None.
+        """
+        if not entity.has_component(RigidBody):
+            return None
+        return entity.get_component(RigidBody)._body_handle
+
+    def _destroy(self, owner_id: str) -> None:
+        """Remove a tracked constraint and forget it.
+
+        Args:
+            owner_id: Owner entity id whose joint handle should be released.
+        """
+        handle = self._handles.pop(owner_id, None)
+        if handle is not None:
+            self._engine.destroy_joint(handle)
+
+        entity = self._entity_manager.get_entity(owner_id)
+        if entity is not None and entity.has_component(Joint):
+            entity.get_component(Joint)._joint_handle = None
+
+    def _on_entity_destroyed(self, event: EntityDestroyed) -> None:
+        """Release any constraint that touched the destroyed entity.
+
+        Covers both directions: the destroyed entity owning a joint, and
+        other entities whose joint named the destroyed one as its target.
+
+        Args:
+            event: The destruction event; components are still readable here.
+        """
+        dead_id = event.entity.id
+
+        if event.entity.has_component(Joint):
+            joint = event.entity.get_component(Joint)
+            handle = self._handles.pop(dead_id, joint._joint_handle)
+            if handle is not None:
+                self._engine.destroy_joint(handle)
+            joint._joint_handle = None
+
+        for owner_id, handle in list(self._handles.items()):
+            owner = self._entity_manager.get_entity(owner_id)
+            if owner is None or not owner.has_component(Joint):
+                continue
+            joint = owner.get_component(Joint)
+            if joint.target_entity_id == dead_id:
+                self._engine.destroy_joint(handle)
+                self._handles.pop(owner_id, None)
+                joint._joint_handle = None
+
+    def cleanup(self) -> None:
+        """Destroy every constraint this system created.
+
+        Mirrors ``PhysicsSystem.cleanup()``; call it when tearing a scene
+        down so no constraint outlives its space.
+        """
+        for handle in self._handles.values():
+            self._engine.destroy_joint(handle)
+        self._handles.clear()

--- a/pyguara/physics/joints.py
+++ b/pyguara/physics/joints.py
@@ -4,6 +4,11 @@ This module provides joint/constraint components that connect RigidBodies and
 constrain their relative motion. Joints are essential for creating complex
 physical systems like ragdolls, vehicles, rope chains, and mechanical contraptions.
 
+A ``Joint`` is pure data. ``JointSystem`` (``pyguara.physics.joint_system``) is
+what turns it into a live constraint in the backend, once both connected
+entities have a ``RigidBody``; a game that uses joints must create and tick a
+``JointSystem`` alongside its ``PhysicsSystem``.
+
 Usage:
     from pyguara.physics.joints import Joint, create_pin_joint, create_spring_joint
 
@@ -38,9 +43,12 @@ class Joint(BaseComponent):
     A Joint connects this entity's RigidBody to another entity's RigidBody,
     constraining their relative motion according to the joint type.
 
-    The joint is created by the PhysicsSystem when both entities have RigidBody
-    components. The joint will be automatically destroyed when either entity is
-    removed or loses its RigidBody component.
+    ``JointSystem`` creates the backend constraint once both entities have a
+    ``RigidBody`` whose body exists in the engine, retrying on later ticks
+    until then. It destroys the constraint when either entity is removed, or
+    when this ``Joint`` component is removed from its entity. Removing an
+    entity's ``RigidBody`` while keeping the ``Joint`` is not tracked -- drop
+    the ``Joint`` too.
 
     Attributes:
         joint_type: Type of constraint (PIN, DISTANCE, SPRING, SLIDER, GEAR, MOTOR).
@@ -277,7 +285,9 @@ def create_rope_chain(
     """Create a rope/chain made of connected segments.
 
     This is a utility function that creates multiple entities connected by
-    distance or spring joints, forming a flexible rope or rigid chain.
+    spring joints, forming a flexible rope or rigid chain. As with any
+    ``Joint``, the links only become physical once a ``JointSystem`` is
+    ticking the world the segments were created in.
 
     Args:
         entity_manager: EntityManager to create entities in.

--- a/pyguara/physics/trigger_system.py
+++ b/pyguara/physics/trigger_system.py
@@ -11,9 +11,10 @@ using TriggerVolumes in your game.
 from pyguara.ecs.entity import Entity
 from pyguara.ecs.manager import EntityManager
 from pyguara.events.dispatcher import EventDispatcher
-from pyguara.physics.components import Collider
+from pyguara.physics.components import Collider, RigidBody
 from pyguara.physics.events import OnTriggerEnter, OnTriggerExit
 from pyguara.physics.trigger_volume import EntityTags, TriggerVolume
+from pyguara.physics.types import BodyType
 
 
 class TriggerSystem:
@@ -50,16 +51,19 @@ class TriggerSystem:
     def update(self, delta_time: float) -> None:
         """Update trigger volumes.
 
-        Creates sensor Colliders for entities that have TriggerVolume but no Collider.
-        This is called each frame by the application loop.
+        Gives every ``TriggerVolume`` entity the physics setup it needs to
+        actually emit events: a sensor ``Collider`` and, if it has no body of
+        its own, a static ``RigidBody``. This is called each frame by the
+        application loop.
 
         Args:
             delta_time: Time elapsed since last update (unused).
         """
-        # Find entities with TriggerVolume but no Collider
         for entity in self._entity_manager.get_entities_with(TriggerVolume):
             if not entity.has_component(Collider):
                 self._create_trigger_collider(entity)
+            if not entity.has_component(RigidBody):
+                self._create_trigger_body(entity)
 
     def _create_trigger_collider(self, entity: Entity) -> None:
         """Create a sensor Collider for a TriggerVolume entity.
@@ -77,6 +81,20 @@ class TriggerSystem:
         )
 
         entity.add_component(collider)
+
+    def _create_trigger_body(self, entity: Entity) -> None:
+        """Give a bodyless TriggerVolume entity a static RigidBody.
+
+        ``PhysicsSystem`` only registers shapes for entities that have a
+        ``RigidBody``; without one the sensor Collider is never added to the
+        simulation and no trigger event ever fires. A trigger that needs to
+        move (mounted on a platform, say) should carry its own KINEMATIC
+        body -- this only fills in the common stationary case.
+
+        Args:
+            entity: Entity with TriggerVolume but no RigidBody.
+        """
+        entity.add_component(RigidBody(body_type=BodyType.STATIC))
 
     def _on_trigger_enter(self, event: OnTriggerEnter) -> None:
         """Handle entity entering a trigger volume.

--- a/pyguara/physics/trigger_volume.py
+++ b/pyguara/physics/trigger_volume.py
@@ -4,10 +4,18 @@ Trigger volumes are sensor colliders that track which entities are inside them.
 They're essential for implementing checkpoints, collectibles, damage zones,
 teleporters, and any gameplay mechanic that activates when entities enter an area.
 
+A ``TriggerVolume`` only emits events when three systems are running:
+``PhysicsSystem`` (steps the simulation), ``CollisionSystem`` (routes sensor
+contacts to trigger events) and ``TriggerSystem`` (updates the component
+state, and gives the entity the sensor ``Collider`` plus a static
+``RigidBody`` it needs to enter the simulation at all).
+
 Usage:
     from pyguara.physics.trigger_volume import TriggerVolume
 
-    # Create a checkpoint trigger
+    # Create a checkpoint trigger. No Collider or RigidBody needed --
+    # TriggerSystem adds both. Add your own KINEMATIC RigidBody instead if
+    # the trigger must move with a platform.
     checkpoint = entity_manager.create_entity()
     checkpoint.add_component(Transform(position=Vector2(400, 300)))
     checkpoint.add_component(TriggerVolume(

--- a/tests/integration/test_trigger_volumes_backend.py
+++ b/tests/integration/test_trigger_volumes_backend.py
@@ -1,0 +1,163 @@
+"""Trigger volumes, end to end through the real pymunk backend.
+
+The component-level tests in ``tests/test_trigger_volumes.py`` dispatch
+``OnTriggerEnter``/``Exit`` by hand and never touch pymunk. That hid two
+breakages for a long time:
+
+* ``CollisionSystem`` assumed the sensor was always the first entity in a
+  contact pair. Chipmunk's pair order is arbitrary, so trigger events came
+  out with ``trigger_entity`` and ``other_entity`` swapped about half the
+  time, and ``TriggerSystem`` silently dropped every swapped one.
+* A ``TriggerVolume`` entity built the documented way -- ``Transform`` plus
+  ``TriggerVolume``, no ``RigidBody`` -- never entered the simulation at
+  all, because ``PhysicsSystem`` only registers shapes for entities that
+  have a ``RigidBody``.
+
+These drive the whole stack the way ``application/bootstrap.py`` wires it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyguara.common.components import Transform
+from pyguara.common.types import Vector2
+from pyguara.ecs.manager import EntityManager
+from pyguara.events.dispatcher import EventDispatcher
+from pyguara.physics.backends.pymunk_impl import PymunkEngine
+from pyguara.physics.collision_system import CollisionSystem
+from pyguara.physics.components import Collider, RigidBody
+from pyguara.physics.physics_system import PhysicsSystem
+from pyguara.physics.trigger_system import TriggerSystem
+from pyguara.physics.trigger_volume import EntityTags, TriggerVolume
+from pyguara.physics.types import BodyType, ShapeType
+
+pytestmark = pytest.mark.integration
+
+DT = 1.0 / 60.0
+
+
+class World:
+    """ECS world with physics + collision + trigger systems wired together."""
+
+    def __init__(self, gravity: Vector2 = Vector2(0, 60)) -> None:
+        self.entities = EntityManager()
+        self.dispatcher = EventDispatcher()
+        self.engine = PymunkEngine()
+        self.engine.set_collision_system(CollisionSystem(self.dispatcher))
+        self.physics = PhysicsSystem(
+            self.engine, self.entities, self.dispatcher, gravity=gravity
+        )
+        self.triggers = TriggerSystem(self.entities, self.dispatcher)
+
+    def step(self, count: int = 1) -> None:
+        for _ in range(count):
+            self.triggers.update(DT)
+            self.physics.update(DT)
+            self.triggers.update(DT)  # drain events the step produced
+
+    def make_zone(self, **kwargs):
+        zone = self.entities.create_entity()
+        zone.add_component(Transform(position=Vector2(100, 100)))
+        zone.add_component(
+            TriggerVolume(shape_type=ShapeType.BOX, dimensions=[80, 80], **kwargs)
+        )
+        return zone
+
+    def make_faller(self, y: float = 40.0, tags: set[str] | None = None):
+        ball = self.entities.create_entity()
+        ball.add_component(Transform(position=Vector2(100, y)))
+        ball.add_component(RigidBody(body_type=BodyType.DYNAMIC, mass=1.0))
+        ball.add_component(Collider(shape_type=ShapeType.CIRCLE, dimensions=[5]))
+        if tags:
+            ball.add_component(EntityTags(tags=tags))
+        return ball
+
+
+@pytest.mark.parametrize("zone_first", [True, False])
+def test_faller_registers_and_clears_regardless_of_creation_order(zone_first):
+    """entities_inside holds the body while it overlaps, empties on exit.
+
+    Parametrised on creation order because that is what decides Chipmunk's
+    pair ordering here, and the pre-fix code worked for exactly one of the
+    two orders.
+    """
+    world = World()
+    if zone_first:
+        zone = world.make_zone()
+        ball = world.make_faller()
+    else:
+        ball = world.make_faller()
+        zone = world.make_zone()
+
+    tv = zone.get_component(TriggerVolume)
+    seen_inside = False
+    for _ in range(240):
+        world.step()
+        if tv.contains_entity(ball.id):
+            seen_inside = True
+        if seen_inside and tv.is_empty():
+            break
+
+    assert seen_inside, "ball never registered as inside the trigger"
+    assert tv.is_empty(), "ball left the trigger but was not removed"
+
+
+def test_documented_trigger_has_no_rigidbody_but_still_fires():
+    """A zone built the way the docstring shows still emits events.
+
+    ``TriggerSystem`` must add both the sensor Collider and a static
+    RigidBody; without the body the sensor shape never reaches the space.
+    """
+    world = World()
+    zone = world.make_zone()
+    assert not zone.has_component(RigidBody)
+    assert not zone.has_component(Collider)
+
+    ball = world.make_faller()
+    world.step(2)
+
+    assert zone.has_component(Collider)
+    assert zone.has_component(RigidBody)
+    assert zone.get_component(RigidBody).body_type == BodyType.STATIC
+
+    tv = zone.get_component(TriggerVolume)
+    entered = any((world.step(), tv.contains_entity(ball.id))[1] for _ in range(180))
+    assert entered
+
+
+def test_tag_filter_end_to_end():
+    """Only entities whose tags match get tracked."""
+    world = World()
+    zone = world.make_zone(tags={"player"})
+    matching = world.make_faller(tags={"player"})
+    world.step(1)
+    other = world.entities.create_entity()
+    other.add_component(Transform(position=Vector2(100, 45)))
+    other.add_component(RigidBody(body_type=BodyType.DYNAMIC, mass=1.0))
+    other.add_component(Collider(shape_type=ShapeType.CIRCLE, dimensions=[5]))
+    other.add_component(EntityTags(tags={"enemy"}))
+
+    tv = zone.get_component(TriggerVolume)
+    saw_matching = False
+    for _ in range(180):
+        world.step()
+        if tv.contains_entity(matching.id):
+            saw_matching = True
+        assert not tv.contains_entity(other.id), "unmatched tag was tracked"
+    assert saw_matching
+
+
+def test_one_shot_deactivates_after_first_entry():
+    """A one-shot zone goes inactive once something enters it."""
+    world = World()
+    zone = world.make_zone(one_shot=True)
+    world.make_faller()
+
+    tv = zone.get_component(TriggerVolume)
+    for _ in range(180):
+        world.step()
+        if not tv.active:
+            break
+
+    assert tv.active is False

--- a/tests/test_collision_events.py
+++ b/tests/test_collision_events.py
@@ -1,4 +1,11 @@
-"""Tests for physics collision event system."""
+"""Tests for physics collision event system.
+
+The backend hands ``CollisionSystem`` a contact pair in Chipmunk's own,
+arbitrary order plus ``sensor_entity_id`` -- which of the two owns the sensor
+shape, or None for a solid collision. These tests drive that contract
+directly; ``test_trigger_volumes.py`` covers the end-to-end path through the
+real pymunk backend.
+"""
 
 from pyguara.common.types import Vector2
 from pyguara.events.dispatcher import EventDispatcher
@@ -31,20 +38,15 @@ class TestCollisionSystemBasics:
         collision_system = CollisionSystem(dispatcher)
 
         received_events = []
+        dispatcher.subscribe(OnCollisionBegin, received_events.append)
 
-        def on_collision(event: OnCollisionBegin) -> None:
-            received_events.append(event)
-
-        dispatcher.subscribe(OnCollisionBegin, on_collision)
-
-        # Simulate collision begin
         result = collision_system.on_collision_begin(
             entity_a="entity1",
             entity_b="entity2",
             point=Vector2(100, 200),
             normal=Vector2(0, 1),
             impulse=50.0,
-            is_sensor=False,
+            sensor_entity_id=None,
         )
 
         assert result is True  # Physical collision should return True
@@ -61,20 +63,15 @@ class TestCollisionSystemBasics:
         collision_system = CollisionSystem(dispatcher)
 
         received_events = []
+        dispatcher.subscribe(OnCollisionPersist, received_events.append)
 
-        def on_collision_persist(event: OnCollisionPersist) -> None:
-            received_events.append(event)
-
-        dispatcher.subscribe(OnCollisionPersist, on_collision_persist)
-
-        # Simulate collision persist
         result = collision_system.on_collision_persist(
             entity_a="entity1",
             entity_b="entity2",
             point=Vector2(100, 200),
             normal=Vector2(0, 1),
             impulse=25.0,
-            is_sensor=False,
+            sensor_entity_id=None,
         )
 
         assert result is True
@@ -87,19 +84,12 @@ class TestCollisionSystemBasics:
         collision_system = CollisionSystem(dispatcher)
 
         received_events = []
+        dispatcher.subscribe(OnCollisionEnd, received_events.append)
 
-        def on_collision_end(event: OnCollisionEnd) -> None:
-            received_events.append(event)
-
-        dispatcher.subscribe(OnCollisionEnd, on_collision_end)
-
-        # Start collision first
         collision_system.on_collision_begin(
-            "entity1", "entity2", Vector2.zero(), Vector2(0, 1), 50.0, False
+            "entity1", "entity2", Vector2.zero(), Vector2(0, 1), 50.0, None
         )
-
-        # End collision
-        collision_system.on_collision_end("entity1", "entity2", is_sensor=False)
+        collision_system.on_collision_end("entity1", "entity2", None)
 
         assert len(received_events) == 1
         assert received_events[0].entity_a == "entity1"
@@ -115,19 +105,15 @@ class TestCollisionTracking:
         dispatcher = EventDispatcher()
         collision_system = CollisionSystem(dispatcher)
 
-        # Start collision
         collision_system.on_collision_begin(
-            "entity1", "entity2", Vector2.zero(), Vector2(0, 1), 50.0, False
+            "entity1", "entity2", Vector2.zero(), Vector2(0, 1), 50.0, None
         )
 
         assert collision_system.get_active_collision_count() == 1
         assert collision_system.is_colliding("entity1", "entity2") is True
-        assert (
-            collision_system.is_colliding("entity2", "entity1") is True
-        )  # Order-independent
+        assert collision_system.is_colliding("entity2", "entity1") is True
 
-        # End collision
-        collision_system.on_collision_end("entity1", "entity2", is_sensor=False)
+        collision_system.on_collision_end("entity1", "entity2", None)
 
         assert collision_system.get_active_collision_count() == 0
         assert collision_system.is_colliding("entity1", "entity2") is False
@@ -137,15 +123,14 @@ class TestCollisionTracking:
         dispatcher = EventDispatcher()
         collision_system = CollisionSystem(dispatcher)
 
-        # Start three separate collisions
         collision_system.on_collision_begin(
-            "e1", "e2", Vector2.zero(), Vector2(0, 1), 50.0, False
+            "e1", "e2", Vector2.zero(), Vector2(0, 1), 50.0, None
         )
         collision_system.on_collision_begin(
-            "e2", "e3", Vector2.zero(), Vector2(0, 1), 30.0, False
+            "e2", "e3", Vector2.zero(), Vector2(0, 1), 30.0, None
         )
         collision_system.on_collision_begin(
-            "e1", "e3", Vector2.zero(), Vector2(0, 1), 40.0, False
+            "e1", "e3", Vector2.zero(), Vector2(0, 1), 40.0, None
         )
 
         assert collision_system.get_active_collision_count() == 3
@@ -153,8 +138,7 @@ class TestCollisionTracking:
         assert collision_system.is_colliding("e2", "e3") is True
         assert collision_system.is_colliding("e1", "e3") is True
 
-        # End one collision
-        collision_system.on_collision_end("e1", "e2", is_sensor=False)
+        collision_system.on_collision_end("e1", "e2", None)
 
         assert collision_system.get_active_collision_count() == 2
         assert collision_system.is_colliding("e1", "e2") is False
@@ -165,23 +149,19 @@ class TestCollisionTracking:
         dispatcher = EventDispatcher()
         collision_system = CollisionSystem(dispatcher)
 
-        # Add collisions
         collision_system.on_collision_begin(
-            "e1", "e2", Vector2.zero(), Vector2(0, 1), 50.0, False
+            "e1", "e2", Vector2.zero(), Vector2(0, 1), 50.0, None
         )
         collision_system.on_collision_begin(
-            "e2", "e3", Vector2.zero(), Vector2(0, 1), 30.0, False
+            "e2", "e3", Vector2.zero(), Vector2(0, 1), 30.0, None
         )
-
-        # Add triggers
         collision_system.on_collision_begin(
-            "trigger1", "player", Vector2.zero(), Vector2(0, 1), 0.0, True
+            "trigger1", "player", Vector2.zero(), Vector2(0, 1), 0.0, "trigger1"
         )
 
         assert collision_system.get_active_collision_count() > 0
         assert collision_system.get_active_trigger_count() > 0
 
-        # Clear state
         collision_system.clear_state()
 
         assert collision_system.get_active_collision_count() == 0
@@ -189,7 +169,7 @@ class TestCollisionTracking:
 
 
 class TestTriggerEvents:
-    """Test trigger/sensor event handling."""
+    """Test trigger/sensor event handling, sensor passed as entity_a."""
 
     def test_trigger_enter_event(self):
         """Sensor collision should dispatch OnTriggerEnter event."""
@@ -197,20 +177,15 @@ class TestTriggerEvents:
         collision_system = CollisionSystem(dispatcher)
 
         received_events = []
+        dispatcher.subscribe(OnTriggerEnter, received_events.append)
 
-        def on_trigger_enter(event: OnTriggerEnter) -> None:
-            received_events.append(event)
-
-        dispatcher.subscribe(OnTriggerEnter, on_trigger_enter)
-
-        # Simulate trigger enter
         result = collision_system.on_collision_begin(
             entity_a="trigger1",
             entity_b="player",
             point=Vector2.zero(),
             normal=Vector2(0, 1),
             impulse=0.0,
-            is_sensor=True,
+            sensor_entity_id="trigger1",
         )
 
         assert result is False  # Sensors should return False
@@ -224,20 +199,13 @@ class TestTriggerEvents:
         collision_system = CollisionSystem(dispatcher)
 
         received_events = []
+        dispatcher.subscribe(OnTriggerStay, received_events.append)
 
-        def on_trigger_stay(event: OnTriggerStay) -> None:
-            received_events.append(event)
-
-        dispatcher.subscribe(OnTriggerStay, on_trigger_stay)
-
-        # Start trigger first
         collision_system.on_collision_begin(
-            "trigger1", "player", Vector2.zero(), Vector2(0, 1), 0.0, True
+            "trigger1", "player", Vector2.zero(), Vector2(0, 1), 0.0, "trigger1"
         )
-
-        # Trigger persist
         collision_system.on_collision_persist(
-            "trigger1", "player", Vector2.zero(), Vector2(0, 1), 0.0, True
+            "trigger1", "player", Vector2.zero(), Vector2(0, 1), 0.0, "trigger1"
         )
 
         assert len(received_events) == 1
@@ -250,19 +218,12 @@ class TestTriggerEvents:
         collision_system = CollisionSystem(dispatcher)
 
         received_events = []
+        dispatcher.subscribe(OnTriggerExit, received_events.append)
 
-        def on_trigger_exit(event: OnTriggerExit) -> None:
-            received_events.append(event)
-
-        dispatcher.subscribe(OnTriggerExit, on_trigger_exit)
-
-        # Start trigger
         collision_system.on_collision_begin(
-            "trigger1", "player", Vector2.zero(), Vector2(0, 1), 0.0, True
+            "trigger1", "player", Vector2.zero(), Vector2(0, 1), 0.0, "trigger1"
         )
-
-        # End trigger
-        collision_system.on_collision_end("trigger1", "player", is_sensor=True)
+        collision_system.on_collision_end("trigger1", "player", "trigger1")
 
         assert len(received_events) == 1
         assert received_events[0].trigger_entity == "trigger1"
@@ -273,16 +234,14 @@ class TestTriggerEvents:
         dispatcher = EventDispatcher()
         collision_system = CollisionSystem(dispatcher)
 
-        # Enter trigger
         collision_system.on_collision_begin(
-            "trigger1", "player", Vector2.zero(), Vector2(0, 1), 0.0, True
+            "trigger1", "player", Vector2.zero(), Vector2(0, 1), 0.0, "trigger1"
         )
 
         assert collision_system.get_active_trigger_count() == 1
         assert collision_system.is_in_trigger("trigger1", "player") is True
 
-        # Exit trigger
-        collision_system.on_collision_end("trigger1", "player", is_sensor=True)
+        collision_system.on_collision_end("trigger1", "player", "trigger1")
 
         assert collision_system.get_active_trigger_count() == 0
         assert collision_system.is_in_trigger("trigger1", "player") is False
@@ -292,24 +251,93 @@ class TestTriggerEvents:
         dispatcher = EventDispatcher()
         collision_system = CollisionSystem(dispatcher)
 
-        # Two entities enter trigger
         collision_system.on_collision_begin(
-            "trigger1", "player1", Vector2.zero(), Vector2(0, 1), 0.0, True
+            "trigger1", "player1", Vector2.zero(), Vector2(0, 1), 0.0, "trigger1"
         )
         collision_system.on_collision_begin(
-            "trigger1", "player2", Vector2.zero(), Vector2(0, 1), 0.0, True
+            "trigger1", "player2", Vector2.zero(), Vector2(0, 1), 0.0, "trigger1"
         )
 
         assert collision_system.get_active_trigger_count() == 2
         assert collision_system.is_in_trigger("trigger1", "player1") is True
         assert collision_system.is_in_trigger("trigger1", "player2") is True
 
-        # One exits
-        collision_system.on_collision_end("trigger1", "player1", is_sensor=True)
+        collision_system.on_collision_end("trigger1", "player1", "trigger1")
 
         assert collision_system.get_active_trigger_count() == 1
         assert collision_system.is_in_trigger("trigger1", "player1") is False
         assert collision_system.is_in_trigger("trigger1", "player2") is True
+
+
+class TestTriggerRoleOrdering:
+    """The sensor must land as ``trigger_entity`` regardless of pair order.
+
+    Chipmunk reports a contact pair in an order the engine does not control,
+    so the sensor arrives as ``entity_a`` on some pairs and ``entity_b`` on
+    others. Before ``sensor_entity_id`` existed, ``CollisionSystem`` assumed
+    ``entity_a`` was always the trigger; the events then came out with
+    ``trigger_entity`` and ``other_entity`` swapped, and ``TriggerSystem``
+    dropped every one whose "trigger" had no ``TriggerVolume``.
+    """
+
+    def test_sensor_as_entity_b_enter(self):
+        """Sensor passed second still becomes the trigger_entity on enter."""
+        dispatcher = EventDispatcher()
+        collision_system = CollisionSystem(dispatcher)
+
+        events = []
+        dispatcher.subscribe(OnTriggerEnter, events.append)
+
+        result = collision_system.on_collision_begin(
+            entity_a="player",
+            entity_b="zone",
+            point=Vector2.zero(),
+            normal=Vector2(0, 1),
+            impulse=0.0,
+            sensor_entity_id="zone",
+        )
+
+        assert result is False
+        assert len(events) == 1
+        assert events[0].trigger_entity == "zone"
+        assert events[0].other_entity == "player"
+
+    def test_sensor_as_entity_b_stay_and_exit(self):
+        """Stay and exit route by the sensor id too, not by pair position."""
+        dispatcher = EventDispatcher()
+        collision_system = CollisionSystem(dispatcher)
+
+        stay, exit_ = [], []
+        dispatcher.subscribe(OnTriggerStay, stay.append)
+        dispatcher.subscribe(OnTriggerExit, exit_.append)
+
+        collision_system.on_collision_begin(
+            "player", "zone", Vector2.zero(), Vector2(0, 1), 0.0, "zone"
+        )
+        collision_system.on_collision_persist(
+            "player", "zone", Vector2.zero(), Vector2(0, 1), 0.0, "zone"
+        )
+        collision_system.on_collision_end("player", "zone", "zone")
+
+        assert [(e.trigger_entity, e.other_entity) for e in stay] == [
+            ("zone", "player")
+        ]
+        assert [(e.trigger_entity, e.other_entity) for e in exit_] == [
+            ("zone", "player")
+        ]
+        assert collision_system.is_in_trigger("zone", "player") is False
+
+    def test_tracking_query_order_matches_event_order(self):
+        """is_in_trigger takes (trigger, other); enter stored it that way."""
+        dispatcher = EventDispatcher()
+        collision_system = CollisionSystem(dispatcher)
+
+        collision_system.on_collision_begin(
+            "player", "zone", Vector2.zero(), Vector2(0, 1), 0.0, "zone"
+        )
+
+        assert collision_system.is_in_trigger("zone", "player") is True
+        assert collision_system.get_active_trigger_count() == 1
 
 
 class TestEventSequences:
@@ -320,27 +348,19 @@ class TestEventSequences:
         dispatcher = EventDispatcher()
         collision_system = CollisionSystem(dispatcher)
 
-        begin_events = []
-        persist_events = []
-        end_events = []
+        begin_events, persist_events, end_events = [], [], []
+        dispatcher.subscribe(OnCollisionBegin, begin_events.append)
+        dispatcher.subscribe(OnCollisionPersist, persist_events.append)
+        dispatcher.subscribe(OnCollisionEnd, end_events.append)
 
-        dispatcher.subscribe(OnCollisionBegin, lambda e: begin_events.append(e))
-        dispatcher.subscribe(OnCollisionPersist, lambda e: persist_events.append(e))
-        dispatcher.subscribe(OnCollisionEnd, lambda e: end_events.append(e))
-
-        # Begin
         collision_system.on_collision_begin(
-            "e1", "e2", Vector2(100, 100), Vector2(0, 1), 50.0, False
+            "e1", "e2", Vector2(100, 100), Vector2(0, 1), 50.0, None
         )
-
-        # Persist (multiple frames)
         for i in range(5):
             collision_system.on_collision_persist(
-                "e1", "e2", Vector2(100, 100), Vector2(0, 1), 30.0 - i, False
+                "e1", "e2", Vector2(100, 100), Vector2(0, 1), 30.0 - i, None
             )
-
-        # End
-        collision_system.on_collision_end("e1", "e2", is_sensor=False)
+        collision_system.on_collision_end("e1", "e2", None)
 
         assert len(begin_events) == 1
         assert len(persist_events) == 5
@@ -351,27 +371,19 @@ class TestEventSequences:
         dispatcher = EventDispatcher()
         collision_system = CollisionSystem(dispatcher)
 
-        enter_events = []
-        stay_events = []
-        exit_events = []
+        enter_events, stay_events, exit_events = [], [], []
+        dispatcher.subscribe(OnTriggerEnter, enter_events.append)
+        dispatcher.subscribe(OnTriggerStay, stay_events.append)
+        dispatcher.subscribe(OnTriggerExit, exit_events.append)
 
-        dispatcher.subscribe(OnTriggerEnter, lambda e: enter_events.append(e))
-        dispatcher.subscribe(OnTriggerStay, lambda e: stay_events.append(e))
-        dispatcher.subscribe(OnTriggerExit, lambda e: exit_events.append(e))
-
-        # Enter
         collision_system.on_collision_begin(
-            "checkpoint", "player", Vector2.zero(), Vector2(0, 1), 0.0, True
+            "checkpoint", "player", Vector2.zero(), Vector2(0, 1), 0.0, "checkpoint"
         )
-
-        # Stay (multiple frames)
         for _i in range(3):
             collision_system.on_collision_persist(
-                "checkpoint", "player", Vector2.zero(), Vector2(0, 1), 0.0, True
+                "checkpoint", "player", Vector2.zero(), Vector2(0, 1), 0.0, "checkpoint"
             )
-
-        # Exit
-        collision_system.on_collision_end("checkpoint", "player", is_sensor=True)
+        collision_system.on_collision_end("checkpoint", "player", "checkpoint")
 
         assert len(enter_events) == 1
         assert len(stay_events) == 3

--- a/tests/test_joint_system.py
+++ b/tests/test_joint_system.py
@@ -1,0 +1,195 @@
+"""Tests for JointSystem -- Joint components becoming live constraints.
+
+``test_physics_joints.py`` covers the ``Joint`` dataclass, the factory
+functions and the backend's ``create_joint``. None of that connects a
+``Joint`` *component* to the simulation: before ``JointSystem`` existed,
+adding one to an entity did nothing at all -- a pin-jointed body just
+free-fell. These tests drive the component through the real backend.
+"""
+
+from __future__ import annotations
+
+from pyguara.common.components import Transform
+from pyguara.common.types import Vector2
+from pyguara.ecs.events import EntityDestroyed
+from pyguara.ecs.manager import EntityManager
+from pyguara.events.dispatcher import EventDispatcher
+from pyguara.physics.backends.pymunk_impl import PymunkEngine
+from pyguara.physics.components import Collider, RigidBody
+from pyguara.physics.joint_system import JointSystem
+from pyguara.physics.joints import Joint, create_pin_joint, create_rope_chain
+from pyguara.physics.physics_system import PhysicsSystem
+from pyguara.physics.types import BodyType, ShapeType
+
+DT = 1.0 / 60.0
+
+
+class World:
+    """ECS world with PhysicsSystem + JointSystem, wired like a scene."""
+
+    def __init__(self, gravity: Vector2 = Vector2(0, 900)) -> None:
+        self.entities = EntityManager()
+        self.dispatcher = EventDispatcher()
+        self.engine = PymunkEngine()
+        self.physics = PhysicsSystem(
+            self.engine, self.entities, self.dispatcher, gravity=gravity
+        )
+        self.joints = JointSystem(self.engine, self.entities, self.dispatcher)
+        # Mirror Scene.resolve_dependencies(): republish removals as events.
+        self.entities.subscribe_entity_removed(
+            lambda e: self.dispatcher.dispatch(EntityDestroyed(entity=e, source=None))
+        )
+
+    def step(self, count: int = 1) -> None:
+        for _ in range(count):
+            self.physics.update(DT)
+            self.joints.update(DT)
+
+    def body(self, pos: Vector2, body_type: BodyType = BodyType.DYNAMIC):
+        e = self.entities.create_entity()
+        e.add_component(Transform(position=pos))
+        e.add_component(RigidBody(body_type=body_type, mass=1.0))
+        e.add_component(Collider(shape_type=ShapeType.BOX, dimensions=[10, 10]))
+        return e
+
+    @property
+    def constraint_count(self) -> int:
+        return len(self.engine.space.constraints)
+
+
+def test_pin_joint_holds_body_at_rest_length():
+    world = World()
+    anchor = world.body(Vector2(100, 100), BodyType.STATIC)
+    bob = world.body(Vector2(100, 150))
+    bob.add_component(create_pin_joint(target_entity_id=anchor.id))
+
+    world.step(180)
+
+    dist = bob.get_component(Transform).position.distance_to(Vector2(100, 100))
+    assert world.constraint_count == 1
+    assert 45 < dist < 55, f"pinned body drifted to {dist:.1f}px (expected ~50)"
+
+
+def test_joint_added_before_bodies_exist_links_up_later():
+    """Joint tolerates being created the same tick as its bodies."""
+    world = World()
+    anchor = world.body(Vector2(100, 100), BodyType.STATIC)
+    bob = world.body(Vector2(100, 150))
+    # Add the joint the same tick, before any update has created bodies.
+    joint = bob.add_component(create_pin_joint(target_entity_id=anchor.id))
+    assert joint._joint_handle is None
+
+    world.step(1)  # PhysicsSystem creates bodies, JointSystem still waiting/creating
+    world.step(1)
+
+    assert joint._joint_handle is not None
+    assert world.constraint_count == 1
+
+
+def test_constraint_released_when_target_entity_destroyed():
+    world = World()
+    anchor = world.body(Vector2(100, 100), BodyType.STATIC)
+    bob = world.body(Vector2(100, 150))
+    bob.add_component(create_pin_joint(target_entity_id=anchor.id))
+    world.step(10)
+    assert world.constraint_count == 1
+
+    world.entities.remove_entity(anchor.id)
+    world.step(1)
+
+    assert world.constraint_count == 0
+    assert bob.get_component(Joint)._joint_handle is None
+
+
+def test_constraint_released_when_owner_entity_destroyed():
+    world = World()
+    anchor = world.body(Vector2(100, 100), BodyType.STATIC)
+    bob = world.body(Vector2(100, 150))
+    bob.add_component(create_pin_joint(target_entity_id=anchor.id))
+    world.step(10)
+    assert world.constraint_count == 1
+
+    world.entities.remove_entity(bob.id)
+    world.step(1)
+
+    assert world.constraint_count == 0
+
+
+def test_constraint_released_when_joint_component_removed():
+    world = World()
+    anchor = world.body(Vector2(100, 100), BodyType.STATIC)
+    bob = world.body(Vector2(100, 150))
+    bob.add_component(create_pin_joint(target_entity_id=anchor.id))
+    world.step(10)
+    assert world.constraint_count == 1
+
+    bob.remove_component(Joint)
+    world.step(1)
+
+    assert world.constraint_count == 0
+
+
+def test_self_targeting_joint_is_ignored():
+    world = World()
+    bob = world.body(Vector2(100, 150))
+    bob.add_component(create_pin_joint(target_entity_id=bob.id))
+
+    world.step(5)  # must not raise
+
+    assert world.constraint_count == 0
+    assert bob.get_component(Joint)._joint_handle is None
+
+
+def test_unconfigured_joint_is_ignored():
+    world = World()
+    bob = world.body(Vector2(100, 150))
+    bob.add_component(Joint())  # target_entity_id == ""
+
+    world.step(5)
+
+    assert world.constraint_count == 0
+
+
+def test_missing_target_defers_without_error():
+    world = World()
+    bob = world.body(Vector2(100, 150))
+    bob.add_component(create_pin_joint(target_entity_id="does-not-exist"))
+
+    world.step(5)
+
+    assert world.constraint_count == 0
+    assert bob.get_component(Joint)._joint_handle is None
+
+
+def test_rope_chain_holds_together():
+    world = World()
+    segments = create_rope_chain(
+        world.entities,
+        start_position=Vector2(200, 50),
+        segment_count=4,
+        segment_length=20.0,
+    )
+    # create_rope_chain already gives each segment a RigidBody and a Collider.
+    segments[0].get_component(RigidBody).body_type = BodyType.STATIC
+
+    world.step(240)
+
+    # 3 spring links for 4 segments.
+    assert world.constraint_count == 3
+    ys = [s.get_component(Transform).position.y for s in segments]
+    # Each segment hangs below the previous, none has run away to infinity.
+    assert ys == sorted(ys)
+    assert ys[-1] - ys[0] < 200, f"rope stretched to {ys[-1] - ys[0]:.0f}px"
+
+
+def test_cleanup_releases_all_constraints():
+    world = World()
+    anchor = world.body(Vector2(100, 100), BodyType.STATIC)
+    bob = world.body(Vector2(100, 150))
+    bob.add_component(create_pin_joint(target_entity_id=anchor.id))
+    world.step(10)
+    assert world.constraint_count == 1
+
+    world.joints.cleanup()
+
+    assert world.constraint_count == 0


### PR DESCRIPTION
The systematic pass the earlier physics work (PRs #24/#25) deferred:
`collision_system.py`, `trigger_volume.py`, `trigger_system.py`,
`joints.py`. Both remaining feature areas had a full API surface,
docstrings and passing unit tests — and did nothing when actually wired
into a running world. Every defect was reproduced with a probe against
the real pymunk backend before being touched.

Cut fresh from `main`; not stacked.

## F1 — the entire `Joint` layer was inert

`Joint` + all five `create_*_joint()` factories + `create_rope_chain()`
produced components no system consumed. There was no `JointSystem`, and
`PhysicsSystem` only ever looks at `Transform`+`RigidBody`.
`engine.create_joint()` was called only by tests. Probe: a pin-jointed
body free-fell 1846 px in 2 s with zero constraints in the space.
`joints.py`'s docstrings claimed "the joint is created by the
PhysicsSystem" — never true.

New `pyguara/physics/joint_system.py`. `JointSystem` builds the
constraint once both bodies exist (retrying until then, so it is
order-independent w.r.t. `PhysicsSystem`), and tears it down on
`EntityDestroyed` for either endpoint or on `Joint` removal. Opt-in and
ticked after `PhysicsSystem.update()`, the convention `PhysicsSystem`
itself follows. `PymunkEngine.destroy_body()` now removes a body's
attached constraints first.

## F2 — trigger events fired with the roles swapped

`CollisionSystem.on_collision_begin/persist/end` took `is_sensor: bool`
and assumed `entity_a` was always the trigger. Chipmunk's pair order is
arbitrary; a probe showed the dynamic body arriving as `entity_a` in
both entity creation orders, so `OnTriggerEnter` came out with
`trigger_entity`/`other_entity` swapped and `TriggerSystem` dropped it.
Contract is now `sensor_entity_id: str | None` — the backend resolves
which shape is the sensor, `CollisionSystem._order_trigger_pair()` puts
it first.

## F3 — a trigger built the documented way never entered the simulation

`trigger_volume.py`'s usage example adds only `Transform` +
`TriggerVolume`. `TriggerSystem` added a sensor `Collider`, but
`PhysicsSystem` only registers shapes for entities with a `RigidBody`.
`TriggerSystem` now adds a static `RigidBody` when the entity has none.
This is why `guara_falcao` never used `TriggerVolume` — its
`CheckpointSystem` is a hand-rolled `distance < 40px` check.

## Tests

- `test_collision_events.py` rewritten for the new contract, with a
  `TestTriggerRoleOrdering` class passing the sensor as `entity_b`.
- New `tests/integration/test_trigger_volumes_backend.py` — full stack,
  parametrised on entity creation order.
- New `tests/test_joint_system.py` — hold, deferred creation, teardown
  on destruction / component removal, self- and missing-target, rope
  chain, `cleanup()`.

1608 pass (up from 1591); `ruff check .` clean; `mypy pyguara` clean.
Verified at the tip in a detached `git worktree`, and commit 1
standalone.

## Commits

1. `fix(physics): make trigger volumes fire end to end` (F2 + F3)
2. `feat(physics): JointSystem turns Joint components into constraints` (F1)
3. `docs(physics): document JointSystem and the trigger-volume systems`
4. `docs: log the physics triggers & joints audit iteration`

Merge as a merge commit, per `CLAUDE.md`.

## Not in scope

No demo (covered by integration tests; `guara_falcao` has no natural
home for a pendulum). `guara_falcao` checkpoints left on their hand-rolled
path. `create_joint`'s GEAR/MOTOR still structural-only. Subsystem-wide
Phase C and a final read of `materials.py`/`tilemap.py`/`debug_draw.py`
remain before the subsystem closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5