### PR TITLE
test(input): Phase B — assess and strengthen the input test suite

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -22,8 +22,18 @@ rather than fixed in place.
      throwaway probe *before* fixing it. Reading is not enough: every
      significant defect this audit has found looked correct on a read-through
      and was obvious under a probe.
-   - **Phase B** — audit the tests. Look for uniform setup rather than missing
-     coverage; that is what has hidden most bugs here (see the note below).
+   - **Phase B** — audit the tests, and write the verdict into the iteration
+     log. Not "added N tests" — a judgement on what the existing suite is
+     *worth*: which tests are load-bearing, which are theatre. The recurring
+     smells here: **uniform setup** (every test builds the subject the same
+     way — see the note below; this has hidden most bugs), **assertions on
+     private state** (`obj._internal[...]` instead of the public getter, so a
+     refactor breaks the test not the code), **tautological asserts**
+     (`assert x is not None` on something that cannot be None; `assert not
+     raises` as the only check), and **fixtures that mock away the unit under
+     test** (`test_config.py` mocked the filesystem, so no round-trip bug
+     could surface). Then add or rewrite tests to close the gap the verdict
+     names.
    - **Phase C** — audit the docs, and verify the documented API actually
      exists. Three pages have described functions that never existed.
 4. Branch from `main` — see "Branching and Pull Requests" in `CLAUDE.md`.
@@ -167,7 +177,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
-| `pyguara/input` | 2026-09-08 | One slice. `InputContext` was inert end to end — `InputManager._context` was pinned to `GAMEPLAY` with no setter, so three of four contexts and the `context=` arg on `bind_input()` could never fire; `test_context_switching` only passed by poking the private attr. Gamepad identity was the pygame device index, not the SDL instance id, so unplugging a non-last pad flagged the wrong one and kept a stale handle. `rebind(SWAP)` returned `SWAPPED` when the action had no prior key and it had really just unbound the other; `RebindResult.CONFLICT` was unreachable (ERROR raises). `OnAction`/`OnRawKey`/`OnMouse` events were frozen at `timestamp=0.0` — the idiom the `events` audit already killed. Recurring shapes again: "declared and wired to nothing" (contexts, the whole rebind/serialize surface has no `InputManager` entry point — added `bindings`) and uniform test setup (every gamepad test unplugged only the last pad; every swap test pre-bound both actions). `input/manager.py` stays a CC-11 / issue #9 offender (raw pygame events) — parked. |
+| `pyguara/input` | 2026-09-08 | One slice. `InputContext` was inert end to end — `InputManager._context` was pinned to `GAMEPLAY` with no setter, so three of four contexts and the `context=` arg on `bind_input()` could never fire; `test_context_switching` only passed by poking the private attr. Gamepad identity was the pygame device index, not the SDL instance id, so unplugging a non-last pad flagged the wrong one and kept a stale handle. `rebind(SWAP)` returned `SWAPPED` when the action had no prior key and it had really just unbound the other; `RebindResult.CONFLICT` was unreachable (ERROR raises). `OnAction`/`OnRawKey`/`OnMouse` events were frozen at `timestamp=0.0` — the idiom the `events` audit already killed. Recurring shapes again: "declared and wired to nothing" (contexts, the whole rebind/serialize surface has no `InputManager` entry point — added `bindings`) and uniform test setup (every gamepad test unplugged only the last pad; every swap test pre-bound both actions). Phase B also found the softer test smells — assertions on `_controllers` privates, `assert x is not None` on a list literal, `assert not raises` as the only check — and rewrote them. `input/manager.py` stays a CC-11 / issue #9 offender (raw pygame events) — parked. |
 | `pyguara/physics` | 2026-09-08 | Judged as *game* physics. Four slices: substepping stops ordinary-speed tunnelling (PR #24); characters moved off dynamic bodies onto `CharacterMover`/`CharacterBody` with full parity — knockback, platform riding, crate pushing — on Celeste's integer+remainder model (PR #25); trigger volumes and the entire `Joint` ECS layer were both inert end to end and were rebuilt and tested (PR #27); the close added five spatial queries, body sleeping, kept `substeps` at 4 on benchmark evidence, and froze `PhysicsMaterial`. Recurring shape: "declared and wired to nothing" (`fixed_rotation`, `gravity_scale`, the `return False` collision contract, `Joint`, `TriggerVolume`) and uniform test setup (every test a slow body already at rest). |
 | `pyguara/graphics` | 2026-09-06 | Audited in five slices: window boundary, components, backends, pipeline, assets. Window reported the requested size not the granted one; `Box`/`Circle` were hard-wired to pygame; the pygame stubs had drifted; a zero-height window produced a 450px viewport; nine-patch produced negative source rects. PRs #12, #14, #15, #17, #18. |
 | `pyguara/systems` | 2026-09-06 | Fixed every game system starting up uninitialised (`initialize()` runs before `on_enter()`), an `unregister()` testing truthiness rather than `None`, and silent duplicate registration keys. PR #11. |
@@ -372,11 +382,11 @@ One slice, ~1,500 lines (`manager`, `binding`, `gamepad`, `types`, `events`,
 a probe against the real code before being touched, plus the unreachable
 public surface they hid behind.
 
-**Verification:** 1652 tests pass (up from 1644); `ruff check .` clean;
+**Verification:** 1658 tests pass (up from 1644); `ruff check .` clean;
 `ruff format` clean; `mypy pyguara` clean across 224 files;
-`mkdocs build --strict` clean. Each of the three commits verified in a
+`mkdocs build --strict` clean. The fix commits were each verified in a
 detached worktree (`git worktree add --detach`, `uv sync --extra dev`):
-1649 / 1652 / 1652.
+1649 / 1652.
 
 **F1 — `InputContext` was inert end to end.** `InputManager._context` was
 set to `GAMEPLAY` in `__init__` and there was no public way to change it:
@@ -430,13 +440,47 @@ had no test that could see it; every `rebind` SWAP test pre-bound both
 actions, so the degenerate case returned the wrong result unnoticed.
 Seventh and eighth instances.
 
-**Phase B (+8).** `test_context_switching` migrated to the public API; new:
-a dormant non-active-context binding fires nothing until switched; exactly
-one `InputContextChangedEvent` per real change; SWAP-without-prior-binding
-returns `UNBOUND`; `OnActionEvent`/`GamepadButtonEvent` carry a real
-timestamp; gamepad mid-list unplug parametrised on *which* pad goes, each
-asserting the survivor keeps slot, name and a working button read; reconnect
-reuses the freed slot.
+**Phase B — verdict on the 29 existing tests (+14, 3 rewritten).**
+
+*`test_input_rebinding.py` (18) — the strong file.* All four
+`ConflictResolution` strategies, export/import, roundtrip, reset, all
+through the public `KeyBindingManager` surface. Real gaps, all uniform
+setup: every `rebind` test pre-bound the action being moved (so F3's
+degenerate case was invisible), every SWAP test used one same-device key
+(cross-device / multi-key / cross-context swap untested), the version guard
+was only ever hit with `999` (the `> FORMAT_VERSION` boundary and the
+warn-and-skip branches for a bad device / missing key / unknown context had
+no coverage), and `test_export_import_roundtrip` keeps the dict in memory —
+never through `json`, `test_config.py`'s exact blind spot. Added 5.
+
+*`test_input.py` (11) — mixed.* `test_bound_gamepad_action_fires_from_polled_state`
+is the model: end to end through the real path. But
+`test_input_registration` / `test_keyboard_event_processing` /
+`test_deadzone_filtering` build the manager by assigning
+`manager._registered_actions[...]` and `manager._bindings.bind(...)`
+directly, so the public `register_action()` / `bind_input()` path was
+exercised by exactly one test — and only because a past field-order bug had
+forced it. `test_gamepad_detection` asserted on `manager._controllers`
+rather than the getters. `test_gamepad_manager_initialization` asserted
+`manager is not None` and `get_connected_controllers() is not None` (a list
+literal) — nothing. `test_input_manager_gamepad_integration` asserted only
+"does not raise". Axis tests asserted `abs(value) > 0.0`, pinning none of
+the deadzone rescale. Rewrote the three empty/private ones to assert real
+behaviour (config actually drives the deadzone; getters report the
+controller); added a test pinning the rescale formula
+`(|raw|-dz)/(1-dz)`.
+
+*`tests/integration/test_input_backend.py` (3) — honest but thin.* Headless,
+so `get_joystick_count()` is always 0 and the entire `PygameJoystick`
+wrapper (`get_button`, `get_axis`, `rumble`, `get_instance_id`) is
+**untested** — the issue-#19 shape, a real adapter that is read-audited
+only. Not fixable without hardware in CI; noted here.
+
+*New for the fixes:* `test_context_switching` moved off the private
+`_context`; a dormant non-active-context binding; one
+`InputContextChangedEvent` per real change; `OnActionEvent` /
+`GamepadButtonEvent` timestamps; gamepad mid-list unplug parametrised on
+which pad goes; reconnect reuses the freed slot.
 
 **Phase C.** `docs/systems/input.md` rewritten — it had described contexts
 (no public API), an "SDL2" backend (does not exist), and told game code to

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -289,23 +289,33 @@ def test_register_action_deadzone_is_stored_correctly(event_dispatcher: Any) -> 
 # ========== Gamepad Tests ==========
 
 
-def test_gamepad_manager_initialization(event_dispatcher: Any) -> None:
-    """Test that GamepadManager initializes correctly."""
-    config = GamepadConfig(deadzone=0.2, vibration_enabled=True)
-    manager = GamepadManager(event_dispatcher, _StubInputBackend(), config)
+def test_gamepad_manager_applies_its_config(event_dispatcher: Any) -> None:
+    """Was `assert manager is not None` plus a list that cannot be None. The
+    real contract is that the passed GamepadConfig drives deadzone handling:
+    a raw axis below the configured deadzone produces no event."""
+    joystick = _StubJoystick(instance_id=0, name="Pad")
+    config = GamepadConfig(deadzone=0.30)
+    manager = GamepadManager(event_dispatcher, _StubInputBackend([joystick]), config)
 
-    assert manager is not None
-    assert manager.get_connected_controllers() is not None
+    events: list[GamepadAxisEvent] = []
+    event_dispatcher.subscribe(GamepadAxisEvent, events.append)
+
+    joystick.axis_values[GamepadAxis.LEFT_STICK_X.value] = 0.25  # under 0.30
+    manager.update()
+    assert events == []
+
+    joystick.axis_values[GamepadAxis.LEFT_STICK_X.value] = 0.60  # over 0.30
+    manager.update()
+    assert len(events) == 1
 
 
 def test_gamepad_detection(event_dispatcher: Any) -> None:
-    """Test gamepad detection on initialization."""
+    """A controller present at construction is reported by the public API."""
     joystick = _StubJoystick(instance_id=0, name="Test Controller")
     manager = GamepadManager(event_dispatcher, _StubInputBackend([joystick]))
 
-    # Verify controller was detected
-    assert 0 in manager._controllers
-    assert manager._controllers[0].name == "Test Controller"
+    assert manager.get_connected_controllers() == [0]
+    assert manager.get_controller_name(0) == "Test Controller"
     assert manager.is_connected(0)
 
 
@@ -359,6 +369,29 @@ def test_gamepad_axis_with_deadzone(event_dispatcher: Any) -> None:
     assert events[0].controller_id == 0
     # Value should be scaled after deadzone
     assert abs(events[0].value) > 0.0
+
+
+def test_gamepad_axis_rescales_linearly_from_the_deadzone_edge(
+    event_dispatcher: Any,
+) -> None:
+    """Existing axis tests only assert `abs(value) > 0.0`, so a regression that
+    changed the rescale slope would pass. Pin the formula:
+    sign * (|raw| - deadzone) / (1 - deadzone), then * axis_sensitivity."""
+    joystick = _StubJoystick(instance_id=0, name="Pad")
+    config = GamepadConfig(deadzone=0.15, axis_sensitivity=1.0)
+    manager = GamepadManager(event_dispatcher, _StubInputBackend([joystick]), config)
+
+    events: list[GamepadAxisEvent] = []
+    event_dispatcher.subscribe(GamepadAxisEvent, events.append)
+
+    joystick.axis_values[GamepadAxis.LEFT_STICK_X.value] = 0.5
+    manager.update()
+    assert events[-1].value == pytest.approx(0.35 / 0.85)  # (0.5-0.15)/(1-0.15)
+
+    # Full deflection maps to exactly 1.0, negative keeps its sign.
+    joystick.axis_values[GamepadAxis.LEFT_STICK_X.value] = -1.0
+    manager.update()
+    assert events[-1].value == pytest.approx(-1.0)
 
 
 def test_gamepad_multiple_controllers(event_dispatcher: Any) -> None:
@@ -486,18 +519,23 @@ def test_gamepad_rumble_support(event_dispatcher: Any) -> None:
     assert result is True
 
 
-def test_input_manager_gamepad_integration(event_dispatcher: Any) -> None:
-    """Test that InputManager properly integrates GamepadManager."""
-    config = GamepadConfig(deadzone=0.2)
-    manager = InputManager(event_dispatcher, _StubInputBackend(), gamepad_config=config)
-
-    # Verify GamepadManager is initialized
-    assert manager.gamepad is not None
+def test_input_manager_passes_gamepad_config_through(event_dispatcher: Any) -> None:
+    """`InputManager` must hand its `gamepad_config` to the GamepadManager it
+    owns, and drive it from `update()`. The old test only checked the manager
+    was 'not None' and that update() 'did not raise'."""
+    joystick = _StubJoystick(instance_id=0, name="Pad")
+    config = GamepadConfig(deadzone=0.30)
+    manager = InputManager(
+        event_dispatcher, _StubInputBackend([joystick]), gamepad_config=config
+    )
     assert isinstance(manager.gamepad, GamepadManager)
 
-    # Verify update() calls gamepad update
-    # (This is a basic integration test - actual behavior tested in gamepad tests)
-    manager.update()  # Should not raise
+    events: list[GamepadAxisEvent] = []
+    event_dispatcher.subscribe(GamepadAxisEvent, events.append)
+
+    joystick.axis_values[GamepadAxis.LEFT_STICK_X.value] = 0.25  # under the deadzone
+    manager.update()
+    assert events == []
 
 
 def test_bound_gamepad_action_fires_from_polled_state(event_dispatcher: Any) -> None:

--- a/tests/test_input_rebinding.py
+++ b/tests/test_input_rebinding.py
@@ -232,6 +232,52 @@ class TestRebinding:
         assert "jump" in actions
         assert "attack" in actions
 
+    def test_rebind_unbound_action_onto_free_key(self, binding_manager):
+        """Every other rebind test starts from an already-bound action. An
+        action with no current binding must still bind cleanly to a free key."""
+        result, conflict = binding_manager.rebind(
+            "block", InputDevice.KEYBOARD, 66, InputContext.GAMEPLAY
+        )
+
+        assert result == RebindResult.SUCCESS
+        assert conflict is None
+        assert binding_manager.get_actions(
+            InputDevice.KEYBOARD, 66, InputContext.GAMEPLAY
+        ) == ["block"]
+
+    def test_rebind_swap_across_devices_and_contexts(self, binding_manager):
+        """A SWAP must move every one of the action's existing keys, and only
+        within the given context. Prior coverage only swapped a single
+        same-device key."""
+        binding_manager.bind(InputDevice.KEYBOARD, 32, "jump", InputContext.GAMEPLAY)
+        binding_manager.bind(InputDevice.GAMEPAD, 0, "jump", InputContext.GAMEPLAY)
+        binding_manager.bind(InputDevice.MOUSE, 1, "fire", InputContext.GAMEPLAY)
+        # Same key in another context must be left untouched.
+        binding_manager.bind(InputDevice.MOUSE, 1, "confirm", InputContext.MENU)
+
+        result, _ = binding_manager.rebind(
+            "jump",
+            InputDevice.MOUSE,
+            1,
+            InputContext.GAMEPLAY,
+            resolution=ConflictResolution.SWAP,
+        )
+
+        assert result == RebindResult.SWAPPED
+        assert binding_manager.get_actions(
+            InputDevice.MOUSE, 1, InputContext.GAMEPLAY
+        ) == ["jump"]
+        # "fire" landed on both keys "jump" vacated.
+        fire_keys = binding_manager.get_bindings_for_action(
+            "fire", InputContext.GAMEPLAY
+        )
+        assert (InputDevice.KEYBOARD, 32) in fire_keys
+        assert (InputDevice.GAMEPAD, 0) in fire_keys
+        # The MENU binding on the same physical key is unchanged.
+        assert binding_manager.get_actions(InputDevice.MOUSE, 1, InputContext.MENU) == [
+            "confirm"
+        ]
+
 
 class TestSerialization:
     """Tests for binding import/export."""
@@ -327,6 +373,68 @@ class TestSerialization:
 
         with pytest.raises(ValueError, match="Unsupported"):
             binding_manager.import_bindings(data)
+
+    def test_import_current_version_is_accepted(self, binding_manager):
+        """The boundary the version guard actually tests -- `> FORMAT_VERSION`
+        -- was only ever exercised with 999. The current version must pass."""
+        data = {
+            "version": KeyBindingManager.BINDING_FORMAT_VERSION,
+            "bindings": {"gameplay": {"jump": [{"device": "KEYBOARD", "code": 32}]}},
+        }
+
+        binding_manager.import_bindings(data)
+
+        assert binding_manager.get_actions(
+            InputDevice.KEYBOARD, 32, InputContext.GAMEPLAY
+        ) == ["jump"]
+
+    def test_import_skips_malformed_entries_without_raising(self, binding_manager):
+        """`import_bindings` has warn-and-skip branches for an unknown device,
+        an unknown context and a missing key -- none were covered. A user's
+        hand-edited or version-drifted file must load what it can."""
+        data = {
+            "version": 1,
+            "bindings": {
+                "gameplay": {
+                    "jump": [
+                        {"device": "KEYBOARD", "code": 32},  # good
+                        {"device": "HOLOGRAM", "code": 5},  # unknown device
+                        {"code": 9},  # missing "device"
+                    ]
+                },
+                "nonsense_context": {"x": [{"device": "KEYBOARD", "code": 1}]},
+            },
+        }
+
+        binding_manager.import_bindings(data)  # must not raise
+
+        assert binding_manager.get_actions(
+            InputDevice.KEYBOARD, 32, InputContext.GAMEPLAY
+        ) == ["jump"]
+        assert binding_manager.get_bindings_for_action(
+            "jump", InputContext.GAMEPLAY
+        ) == [(InputDevice.KEYBOARD, 32)]
+
+    def test_export_import_roundtrip_survives_real_json(self, binding_manager):
+        """The existing roundtrip test keeps the dict in memory. Persistence
+        goes through a file, where dict keys become strings and an int `code`
+        must come back an int -- `test_config.py`'s exact blind spot."""
+        import json
+
+        binding_manager.bind(InputDevice.KEYBOARD, 32, "jump", InputContext.GAMEPLAY)
+        binding_manager.bind(InputDevice.GAMEPAD, 0, "confirm", InputContext.UI)
+
+        data = json.loads(json.dumps(binding_manager.export_bindings()))
+
+        restored = KeyBindingManager()
+        restored.import_bindings(data)
+
+        assert restored.get_actions(
+            InputDevice.KEYBOARD, 32, InputContext.GAMEPLAY
+        ) == ["jump"]
+        assert restored.get_actions(InputDevice.GAMEPAD, 0, InputContext.UI) == [
+            "confirm"
+        ]
 
 
 class TestResetToDefaults:


### PR DESCRIPTION
Follow-up to #31 (merged). Two commits that were pushed to that branch **after** it merged, so they never landed on `main`. Rebased fresh onto `main`; no dependency on any open PR.

## What's here

**`test(input): assess and strengthen the existing suite`** — the Phase B work the audit calls for: a verdict on what the 29 pre-existing input tests were worth, plus the tests to close the gaps.

- `test_input_rebinding.py` (18) was the strong file — public surface, all four `ConflictResolution` paths — but every rebind test pre-bound the moved action (so #31's F3 degenerate case was invisible), every SWAP used one same-device key, the version guard was only hit with `999`, and the roundtrip never went through `json`.
- `test_input.py` (11) was mixed: three tests asserted nothing real (`manager is not None`, a list literal `is not None`, "does not raise"), `test_gamepad_detection` poked `_controllers`, axis tests pinned none of the deadzone rescale.
- `tests/integration/test_input_backend.py` (3): honest but headless-thin — the whole `PygameJoystick` wrapper is untested (no controller in CI; issue-#19 shape).

Rewrote the 3 empty/private tests to assert real behaviour; added 6 for the gaps (unbound-action rebind, cross-device SWAP, version boundary, malformed-import skip, real-`json` roundtrip, axis rescale formula). Suite 1644 → 1658.

**`docs: sharpen Phase B in the tracker; record the input suite verdict`** — `REFACTOR_STATE.md`. The "How to resume" Phase B bullet said only "audit the tests, look for uniform setup"; it now also names the softer smells (assertions on private state, tautological asserts, fixtures that mock away the unit) and requires the iteration log to carry an explicit judgement on the existing suite's worth, not just a test count. The `pyguara/input` entry gets that verdict.

## Verification

1658 tests pass; `ruff check .`, `mypy pyguara` (224 files), `test_docs_api`, `mkdocs build --strict` all clean. `test(input)` commit verified in a detached worktree: 1658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5