### PR TITLE
refactor(audio): fix dead SFX playback, spatial volume corruption, and finished-sound detection

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -63,9 +63,25 @@ how the subject is *constructed*, not just what is asserted.
 
 ## Active Subsystem
 
-**None — `pyguara/input` closed 2026-09-08 (branch `refactor/input-audit`).**
-Next in the queue is `pyguara/audio`. Open `REFACTOR_STATE.md` "How to
+**None — `pyguara/audio` closed 2026-09-08 (branch `refactor/audio-audit`).**
+Next in the queue is `pyguara/animation`. Open `REFACTOR_STATE.md` "How to
 resume" and take it.
+
+`pyguara/audio` in one slice: **SFX playback was dead end to end** —
+`PygameAudioSystem._play_sound` called `Channel.get_id()`, which pygame-ce
+has no such attribute (`Channel.id`), so every real `play_sfx` /
+`play_sfx_at_position` raised, was swallowed by a blind
+`except (AttributeError, Exception)`, and returned `None` while the sound
+played on untracked. Every one of the 107 audio tests missed it: they
+`patch("pygame.mixer")` wholesale (the "mock away the unit under test"
+smell). Volume + pan were set on the ResourceManager-shared `Sound`, not the
+channel, so concurrent plays of one clip corrupted each other's loudness;
+recycled channels kept the previous sound's hard pan; `AudioSourceSystem`
+never detected a finished one-shot (so `is_playing` lied forever, a source
+could not be replayed, and stale channel ids leaked spatial mix updates onto
+whatever reused the channel); `SpatialAudioConfig` had no validation (0 →
+`ZeroDivisionError` in `calculate_pan`); `IAudioSystem` had no `shutdown`.
+See the iteration log entry below.
 
 `pyguara/input` in one slice: `InputContext` was inert end to end (no way to
 leave `GAMEPLAY`), gamepad identity was by device index not SDL instance id
@@ -155,7 +171,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
     - [x] Spatial queries, body sleeping, `substeps` decision, Phase C
       (branch `refactor/physics-queries-sleep-close`)
 - [x] `pyguara/input` — input manager, rebinding *(done)*
-- [ ] `pyguara/audio` — audio manager, spatial audio
+- [x] `pyguara/audio` — audio manager, spatial audio *(done)*
 - [ ] `pyguara/animation` — tween, easing, FSM
 - [ ] `pyguara/resources` — loaders, meta, hot reload
 - [ ] `pyguara/persistence` — save/load, migration
@@ -177,6 +193,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/audio` | 2026-09-08 | One slice. **SFX playback was dead end to end**: the pygame backend called `Channel.get_id()` (pygame-ce has `Channel.id`), so every real `play_sfx`/`play_sfx_at_position` raised, was swallowed by `except (AttributeError, Exception)`, and returned `None` while the sound played on untracked — hidden because all 107 audio tests `patch("pygame.mixer")` wholesale. Loudness/pan were set on the ResourceManager-shared `Sound` not the channel, so concurrent plays of one clip corrupted each other and recycled channels kept the last sound's hard pan. `AudioSourceSystem` never detected a finished one-shot — `is_playing` lied forever, a source could not be replayed, and stale channel ids kept receiving spatial mix updates meant for whatever reused the channel; fixed with a new `IAudioSystem.is_channel_active()` reconciled each frame, plus an `_auto_played` latch (auto_play is "on awake", not loop — the fix exposed a retrigger storm). `SpatialAudioConfig` gained `__post_init__` validation (0 → `ZeroDivisionError` in `calculate_pan`; inverted range → attenuation cliff). Added `IAudioSystem.shutdown()` (idempotent `pygame.mixer.quit()`), wired into `Application.shutdown()`. Recurring shapes: "mock away the unit under test" (the whole `test_audio.py`) and "declared and wired to nothing" (`AudioManager._active_channels`, removed). Left open: bus/master volume changes don't re-mix already-playing non-spatial SFX (mixer limitation, documented). |
 | `pyguara/input` | 2026-09-08 | One slice. `InputContext` was inert end to end — `InputManager._context` was pinned to `GAMEPLAY` with no setter, so three of four contexts and the `context=` arg on `bind_input()` could never fire; `test_context_switching` only passed by poking the private attr. Gamepad identity was the pygame device index, not the SDL instance id, so unplugging a non-last pad flagged the wrong one and kept a stale handle. `rebind(SWAP)` returned `SWAPPED` when the action had no prior key and it had really just unbound the other; `RebindResult.CONFLICT` was unreachable (ERROR raises). `OnAction`/`OnRawKey`/`OnMouse` events were frozen at `timestamp=0.0` — the idiom the `events` audit already killed. Recurring shapes again: "declared and wired to nothing" (contexts, the whole rebind/serialize surface has no `InputManager` entry point — added `bindings`) and uniform test setup (every gamepad test unplugged only the last pad; every swap test pre-bound both actions). Phase B also found the softer test smells — assertions on `_controllers` privates, `assert x is not None` on a list literal, `assert not raises` as the only check — and rewrote them. `input/manager.py` stays a CC-11 / issue #9 offender (raw pygame events) — parked. |
 | `pyguara/physics` | 2026-09-08 | Judged as *game* physics. Four slices: substepping stops ordinary-speed tunnelling (PR #24); characters moved off dynamic bodies onto `CharacterMover`/`CharacterBody` with full parity — knockback, platform riding, crate pushing — on Celeste's integer+remainder model (PR #25); trigger volumes and the entire `Joint` ECS layer were both inert end to end and were rebuilt and tested (PR #27); the close added five spatial queries, body sleeping, kept `substeps` at 4 on benchmark evidence, and froze `PhysicsMaterial`. Recurring shape: "declared and wired to nothing" (`fixed_rotation`, `gravity_scale`, the `return False` collision contract, `Joint`, `TriggerVolume`) and uniform test setup (every test a slow body already at rest). |
 | `pyguara/graphics` | 2026-09-06 | Audited in five slices: window boundary, components, backends, pipeline, assets. Window reported the requested size not the granted one; `Box`/`Circle` were hard-wired to pygame; the pygame stubs had drifted; a zero-height window produced a 450px viewport; nine-patch produced negative source rects. PRs #12, #14, #15, #17, #18. |
@@ -375,6 +392,134 @@ convert to explicit `is None` checks as each subsystem is audited.
 ---
 
 ## Iteration Log
+
+### `pyguara/audio` — CLOSED 2026-09-08 (branch `refactor/audio-audit`)
+
+One slice, ~1,700 lines (`manager`, `audio_system`, `audio_source_system`,
+`components`, `types`, the pygame backend + loaders). Every defect was
+reproduced with a probe against the **real** pygame-ce mixer (`SDL_AUDIODRIVER
+=dummy`) before being touched — which is how the headline one surfaced at
+all, since it is invisible to a mocked mixer.
+
+**Verification:** 1678 tests pass (up from 1658; the fix commit alone is
+1676, the docs commit adds 2 `test_docs_api` parametrisations for the new
+page); `ruff check .` clean; `ruff format --check` clean; `mypy pyguara`
+clean across 224 files; `mkdocs build --strict` exit 0; `test_docs_api.py`
+(52) passes. Fix commit verified standalone in a detached worktree.
+
+**F1 — SFX playback was dead end to end.** `PygameAudioSystem._play_sound`
+read the channel id with `played_channel.get_id()`. pygame-ce's
+`pygame.mixer.Channel` has **no `get_id()`** — the attribute is `.id`. So the
+call raised `AttributeError` on every real `play_sfx` /
+`play_sfx_at_position`, was caught by a blind
+`except (AttributeError, Exception)`, logged as "Error playing sound", and
+returned `None`. The sound had already been started by `native_sound.play()`
+one line earlier, so it played — untracked, unstoppable (caller got `None`),
+invisible to priority stealing / `set_channel_mix` / `stop_sfx` /
+`get_active_sound_count` (all of which read the never-populated
+`_playing_sounds`). **All 107 audio tests missed it**: `test_audio.py` and
+`test_audio_backend.py` `patch("pygame.mixer")` or hand a `MagicMock` as the
+`Sound`, and a Mock grows a `get_id()` on demand. The "fixtures that mock
+away the unit under test" smell, same shape as `test_config.py` mocking the
+filesystem. Fixed: acquire a `Channel`, call `channel.play(sound, loops=)` on
+it, id is `channel.id`; `except` narrowed to `pygame.error`.
+
+**F2 — loudness and pan were set on the shared `Sound`, not the channel.**
+`native_sound.set_volume(effective_volume)` where `native_sound` is the
+`AudioClip.native_handle` — one object the `ResourceManager` hands to every
+concurrent play of that clip. Probe: play one explosion near (vol 1.0) then
+another far (vol 0.16); the near one's loudness silently dropped to 0.16.
+`set_channel_mix` had the same bug on the update path. Fixed: volume+pan go
+on the channel via a `_set_channel_volume` helper — single-arg
+`set_volume(v)` when centred (also clears any stale split), two-arg
+`set_volume(l, r)` when panned. The `Sound` is never touched.
+
+**F3 — a recycled channel kept the previous sound's hard pan.** `_apply_pan`
+was only called when `abs(pan) > 0.01`, so a centred sound landing on a
+channel that last played a hard-panned one inherited its `(1.0, 0.0)` split.
+Fixed by F2's unconditional `_set_channel_volume`.
+
+**F4 — `AudioSourceSystem` never noticed a one-shot ending.** Nothing polled
+the mixer, so `_channel_id` / `_is_playing` were set once and cleared only by
+an explicit `stop()`. Consequences: `AudioSource.is_playing` reported `True`
+forever; a non-looping source could not be replayed (`_play_source`'s guard
+is `_is_playing and _channel_id is None`, and `_channel_id` never went
+`None`); the stale id kept getting `set_channel_mix` every frame, landing on
+whatever sound now owned that recycled channel. Fixed: new
+`IAudioSystem.is_channel_active(channel)` — `True` only while the exact sound
+this system started is still on that channel (verified by `get_busy()` **and**
+`get_sound() is` identity, reaping the tracking tables as a side effect) —
+called each frame by `AudioSourceSystem` to reconcile.
+
+**F5 — the F4 fix exposed an `auto_play` retrigger storm**, plus a latent
+falsy-`0` bug. With reconciliation clearing an ended one-shot,
+`auto_play and not _is_playing and not _channel_id` re-fired it every
+subsequent frame. Added an `_auto_played` latch (auto_play is "on awake",
+not loop). `not source._channel_id` also treated channel id **0** — a real
+channel — as "no channel"; changed to `is None`, matching the check four
+lines below it. A failed clip load now latches too, instead of hammering the
+loader once per frame.
+
+**F6 — `SpatialAudioConfig` had no validation.** `SpatialAudioConfig(
+max_distance=0)` constructed fine and `calculate_pan` then raised
+`ZeroDivisionError`; an inverted range (`max_distance < reference_distance`)
+gave a hard volume cliff dressed as a rolloff. `__post_init__` now rejects
+`reference_distance <= 0`, `max_distance <= reference_distance`, and negative
+`rolloff_factor` / `pan_strength`.
+
+**Also:** added `IAudioSystem.shutdown()` (idempotent `pygame.mixer.stop()` +
+`music.stop()` + `mixer.quit()`), wired as a step in `Application.shutdown()`
+— the mixer was previously never torn down. Removed
+`AudioManager._active_channels` (declared, written nowhere, `.clear()`d in
+cleanup — "wired to nothing"). `except (AttributeError, Exception)` →
+`except pygame.error`; two `try/except pygame.error: pass` →
+`contextlib.suppress`.
+
+**Phase B — verdict on the 107 existing tests (+18; `test_audio.py` and one
+integration test rewritten).**
+
+*`test_spatial_audio.py` (39) — the strong file.* Pure maths on
+`SpatialAudioConfig` / `AudioBus` / `AudioBusManager`, all through public
+surface, real assertions on real return values. Its one gap was the missing
+validation cases (F6) — added 3.
+
+*`test_audio.py` (34, was 30) — rewritten.* It did
+`patch("pygame.mixer")` for the whole module, so `Channel.id`, channel
+volume, the shared-`Sound` trap and F1 itself were unreachable — the mock
+supplied whatever attribute was asked for. Now runs the real dummy-driver
+mixer with real `Sound` buffers; only `pygame.mixer.music` (needs a file on
+disk) stays mocked. New tests: F1 (id names the busy channel), channel id 0
+is valid, F2 (concurrent plays don't share volume; `Sound` untouched), F3
+(recycled channel resets), `is_channel_active` across finish / reuse /
+unknown, `shutdown` idempotence. Learned that `Channel.get_volume()` only
+reflects a **single-arg** `set_volume`, so the panned split is verified via
+`_channel_stereo` as a pure unit.
+
+*`test_audio_components.py` (41, was 30) — mixed.* The `AudioSourceSystem`
+tests build a `MagicMock` audio system and drive real components/Entity
+Manager, which is honest for the ECS logic. Gaps were all uniform setup:
+every source was played and left playing — nothing simulated a sound
+*ending*, so F4/F5 had no test that could see them. Added finished-one-shot
+reconciliation, replay-after-end, the looping-source-not-reaped case, the
+`auto_play` latch, the failed-load latch, and channel-id-0.
+
+*`tests/integration/test_audio_backend.py` (5) — honest, thin.* Already
+dummy-driver + real mixer, but `test_play_sfx_mock` still handed a
+`MagicMock` as the `Sound`, dodging F1. Rewritten to a real `Sound`.
+
+**Phase C.** New `docs/systems/audio.md` (added to nav): the three layers,
+music, the SFX channel contract (including "id 0 is valid"), the one-shot
+lifecycle, spatial components + `SpatialAudioConfig` validation rules, buses,
+and the documented limitation that a bus/master volume change does not
+re-mix already-playing non-spatial SFX. `test_docs_api` and
+`mkdocs build --strict` pass. The subsystem had **no** doc page before.
+
+**Left open.** Bus / master / per-category volume changes re-apply to music
+and to spatial SFX (re-mixed every frame) but not to already-playing
+non-spatial SFX — a pygame-mixer limitation, documented rather than worked
+around. `calculate_pan` keys stereo spread off horizontal offset only
+(`test_pan_ignores_y_axis` pins this as intentional). `pygame_audio.py` and
+`loaders.py` import pygame — legitimately, they are the backend.
 
 ### `pyguara/input` — CLOSED 2026-09-08 (branch `refactor/input-audit`)
 

--- a/docs/systems/audio.md
+++ b/docs/systems/audio.md
@@ -1,0 +1,132 @@
+# Audio System
+
+`pyguara.audio` plays music and sound effects, with optional **spatial**
+(position-aware) playback and a **bus** hierarchy for grouped volume control.
+Game code never touches pygame's mixer directly.
+
+## Layers
+
+1. **`IAudioSystem`** (`pyguara.audio.audio_system`) — the backend contract:
+   music streaming, one-shot and looping SFX, spatial placement, buses,
+   per-channel mix updates. `PygameAudioSystem` is the shipped
+   implementation; it is registered as a singleton by the application
+   bootstrap.
+2. **`AudioManager`** (`pyguara.audio.manager`) — a convenience wrapper over
+   `IAudioSystem` that loads clips by path through the `ResourceManager`,
+   tracks the current music track, and forwards volume calls. Also a
+   bootstrap singleton.
+3. **`AudioSourceSystem`** (`pyguara.audio.audio_source_system`) — the ECS
+   system that drives `AudioSource` / `AudioEmitter` / `AudioListener`
+   components. A scene registers it automatically (priority 250).
+
+```python
+from pyguara.audio import AudioManager
+
+audio = container.get(AudioManager)
+audio.play_music("music/theme.ogg", loop=True)
+channel = audio.play_sfx("sfx/jump.wav", volume=0.8)
+```
+
+## Music
+
+`play_music(path, loop=True, fade_ms=1000)` streams one track at a time from
+disk (pygame's `mixer.music`). `stop_music`, `pause_music`, `resume_music`
+and `is_music_playing` control it; `get_current_music()` returns the path
+`AudioManager` last started, or `None`.
+
+Music volume follows the `music` bus and the `master` bus: changing either
+re-applies immediately to the playing stream.
+
+## Sound effects and channels
+
+`play_sfx(clip, volume, loops, priority, bus)` plays a clip on a mixer
+**channel** and returns that channel's id, or `None` if the clip is invalid
+or every channel is busy with an equal-or-higher priority sound.
+
+- **`loops`**: `0` plays once, `-1` loops forever, `n` repeats `n` extra
+  times.
+- **The returned id can be `0`.** Channel 0 is a real channel — test the
+  result against `None`, never for truthiness.
+- **`priority`** (`AudioPriority.LOW`…`CRITICAL`): when no channel is free, a
+  new sound steals the channel of the lowest-priority sound *below* its own
+  priority. Same-or-higher priority sounds are never interrupted.
+
+Loudness and stereo pan are applied to the **channel**, never to the `Sound`
+object — the `ResourceManager` hands every concurrent play of one clip the
+*same* `Sound`, so setting its volume would bleed across all of them.
+
+### One-shot lifecycle
+
+A one-shot sound finishes on its own with no callback. `IAudioSystem`
+exposes `is_channel_active(channel)`, which is `True` only while the exact
+sound this system started on that channel is still playing — it returns
+`False` once the sound has ended *or* the channel has been recycled by an
+unrelated sound. `AudioSourceSystem` calls it every frame to reconcile
+`AudioSource` state; you rarely call it directly.
+
+## Spatial audio
+
+Attach components to entities that also carry a `Transform`:
+
+| Component | Purpose |
+| --- | --- |
+| `AudioListener` | Marks the "ears" (usually the camera/player). One active listener per scene; its position drives every spatial calculation. |
+| `AudioSource` | A persistent or looping sound that follows its entity. `spatial=True` (default) attenuates and pans it by distance to the listener, updated every frame while it plays. |
+| `AudioEmitter` | A fire-and-forget one-shot at the entity's position. `remove_after_play=True` (default) drops the component once it has played. |
+
+```python
+entity.add_component(Transform(position=Vector2(400, 300)))
+entity.add_component(AudioSource(clip_path="sfx/engine_loop.wav", loop=True))
+entity.get_component(AudioSource).play()   # or auto_play=True / play_on_awake=True
+```
+
+`auto_play` fires **once**, when the source is first processed; a one-shot
+that ends is not restarted (use `loop=True` for that, or call `play()`
+again). `AudioSource.is_playing` reflects reality — it goes back to `False`
+when a non-looping sound ends.
+
+### `SpatialAudioConfig`
+
+Controls the distance model (`AudioSourceSystem.set_spatial_config`, or
+`PygameAudioSystem.set_spatial_config`):
+
+| Field | Meaning |
+| --- | --- |
+| `reference_distance` | Distance (world units) within which volume is 100%. Must be `> 0`. |
+| `max_distance` | Distance at which the sound is silent. Must be `> reference_distance`. |
+| `rolloff_factor` | How fast volume falls between the two (`1.0` ≈ realistic inverse-distance; `< 1` slower). Must be `>= 0`. |
+| `pan_strength` | Stereo spread from horizontal offset (`0.0` mono … `1.0` full). Must be `>= 0`. |
+
+Out-of-range values raise `ValueError` at construction — an inverted or zero
+range is a divide-by-zero in the pan maths and a hard volume cliff in the
+attenuation maths, not a soft degradation.
+
+## Buses and volume
+
+Four buses in a fixed hierarchy: `master` → `sfx` / `music` / `voice`
+(`AudioBusType`). Effective volume walks the chain
+(`bus.volume × … × master.volume`); a muted bus contributes `0`.
+
+```python
+audio_system.set_bus_volume(AudioBusType.SFX, 0.5)
+audio_system.set_bus_muted(AudioBusType.MASTER, True)
+```
+
+`set_master_volume` / `set_sfx_volume` / `set_music_volume` are shorthands
+for the `master` / `sfx` / `music` buses.
+
+!!! note "Known limitation"
+    A bus or master volume change re-applies to the music stream and to
+    spatial SFX (which are re-mixed every frame), but **not** to
+    already-playing *non-spatial* SFX — those keep the volume they were
+    started with until they end. Set bus volumes before triggering sounds,
+    or drive important sustained sounds through an `AudioSource`.
+
+## Backend notes
+
+`PygameAudioSystem` wraps `pygame.mixer` (pygame-ce). It allocates 32
+channels by default. `shutdown()` stops all audio and releases the device;
+it is idempotent and is called from `Application.shutdown()`.
+
+For headless use (tests, CI) set `SDL_AUDIODRIVER=dummy` before the mixer
+initialises — playback then advances in real time but produces no sound.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - Intelligence: ai/intelligence.md
   - Systems:
       - Animation: systems/animation.md
+      - Audio: systems/audio.md
       - Editor Tools: systems/editor.md
       - Input: systems/input.md
       - Resources: systems/resources.md

--- a/pyguara/application/application.py
+++ b/pyguara/application/application.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 import pygame
 
+from pyguara.audio.audio_system import IAudioSystem
 from pyguara.config.manager import ConfigManager
 from pyguara.di.container import DIContainer
 from pyguara.di.exceptions import ServiceNotFoundException
@@ -77,6 +78,7 @@ class Application:
         self._config_manager = container.get(ConfigManager)
         self._ui_manager = container.get(UIManager)
         self._coroutine_manager = container.get(CoroutineManager)
+        self._audio_system = container.get(IAudioSystem)  # type: ignore[type-abstract]
 
         # Retrieve Renderer
         self._world_renderer = container.get(IRenderer)  # type: ignore[type-abstract]
@@ -461,6 +463,7 @@ class Application:
 
         steps: list[tuple[str, Callable[[], None]]] = [
             ("scene cleanup", self._scene_manager.cleanup),
+            ("audio shutdown", self._audio_system.shutdown),
             ("window close", self._window.close),
         ]
         if self._render_graph is not None:

--- a/pyguara/audio/audio_source_system.py
+++ b/pyguara/audio/audio_source_system.py
@@ -15,6 +15,7 @@ from pyguara.common.types import Vector2
 from pyguara.log import get_logger
 
 if TYPE_CHECKING:
+    from pyguara.ecs.entity import Entity
     from pyguara.ecs.manager import EntityManager
     from pyguara.resources.manager import ResourceManager
     from pyguara.resources.types import AudioClip
@@ -104,13 +105,34 @@ class AudioSourceSystem:
             if not source:
                 continue
 
+            # Reconcile against reality first. A one-shot sound finishes with
+            # no callback and channel ids get recycled, so without this
+            # `is_playing` stays True forever, the stale id keeps receiving
+            # spatial mix updates meant for whatever now owns that channel,
+            # and the source can never be replayed. A looping sound stays
+            # active until it is explicitly stopped.
+            if (
+                source._channel_id is not None
+                and not source._stop_requested
+                and not self._audio_system.is_channel_active(source._channel_id)
+            ):
+                source._channel_id = None
+                source._is_playing = False
+
             # Handle stop requests
             if source._stop_requested:
                 self._stop_source(source)
                 continue
 
-            # Handle auto-play
-            if source.auto_play and not source._is_playing and not source._channel_id:
+            # Auto-play fires exactly once, the first frame the source is
+            # eligible; `_auto_played` latches so an ended one-shot is not
+            # immediately restarted here.
+            if (
+                source.auto_play
+                and not source._auto_played
+                and source._channel_id is None
+            ):
+                source._auto_played = True
                 source.play()
 
             # Handle play requests
@@ -158,7 +180,7 @@ class AudioSourceSystem:
         for entity, emitter in entities_to_remove_emitter:
             entity.remove_component(type(emitter))
 
-    def _play_source(self, source: AudioSource, entity: object) -> None:
+    def _play_source(self, source: AudioSource, entity: Entity) -> None:
         """Start playing an audio source.
 
         Args:
@@ -178,7 +200,7 @@ class AudioSourceSystem:
         loops = -1 if source.loop else 0
 
         if source.spatial:
-            transform = getattr(entity, "get_component", lambda t: None)(Transform)
+            transform = entity.get_component(Transform)
             if transform:
                 source._channel_id = self._audio_system.play_sfx_at_position(
                     clip,

--- a/pyguara/audio/audio_system.py
+++ b/pyguara/audio/audio_system.py
@@ -83,6 +83,24 @@ class IAudioSystem(Protocol):
         """
         ...
 
+    def is_channel_active(self, channel: int) -> bool:
+        """
+        Check whether a channel is still playing the sound this system started.
+
+        A one-shot sound finishes on its own with no callback, and channel ids
+        are recycled, so a caller holding an old id cannot tell "still playing"
+        from "finished" from "reused by an unrelated sound". This answers that:
+        True only while the exact sound started on this channel is still
+        playing.
+
+        Args:
+            channel: The channel ID returned by play_sfx/play_sfx_at_position.
+
+        Returns:
+            True if that sound is still playing, False otherwise.
+        """
+        ...
+
     def pause_sfx(self) -> None:
         """Pause all sound effects."""
         ...
@@ -232,5 +250,14 @@ class IAudioSystem(Protocol):
 
         Args:
             position: World position of the listener.
+        """
+        ...
+
+    def shutdown(self) -> None:
+        """
+        Stop all audio and release the underlying device.
+
+        Idempotent: a second call is a no-op. After this, playback methods
+        must not raise but need not produce sound.
         """
         ...

--- a/pyguara/audio/backends/pygame/pygame_audio.py
+++ b/pyguara/audio/backends/pygame/pygame_audio.py
@@ -1,5 +1,6 @@
 """Pygame implementation of the Audio System with spatial audio and bus support."""
 
+import contextlib
 import math
 
 import pygame
@@ -62,8 +63,13 @@ class PygameAudioSystem:
         self._spatial_config = SpatialAudioConfig()
         self._listener_position = Vector2(0, 0)
 
-        # Channel tracking for priority management
+        # Channel tracking for priority management. `_channel_sounds` mirrors
+        # `_playing_sounds` with the concrete Sound started on each channel, so
+        # a recycled channel id can be told apart from the sound it used to
+        # carry (see `is_channel_active`).
         self._playing_sounds: dict[int, PlayingSoundInfo] = {}
+        self._channel_sounds: dict[int, pygame.mixer.Sound] = {}
+        self._shut_down = False
 
         # Apply initial music volume
         pygame.mixer.music.set_volume(self._get_effective_music_volume())
@@ -138,56 +144,50 @@ class PygameAudioSystem:
         pan: float = 0.0,
     ) -> int | None:
         """Play a sound with all available options."""
+        native_sound = clip.native_handle
+
+        if not (hasattr(native_sound, "set_volume") and hasattr(native_sound, "play")):
+            logger.error("Resource '%s' is not a valid Sound", clip.path)
+            return None
+
+        base_volume = max(0.0, min(1.0, volume))
+
+        # Calculate effective volume through bus hierarchy
+        bus_name = self._bus_manager.get_bus_for_type(bus)
+        bus_volume = self._bus_manager.get_effective_volume(bus_name)
+        effective_volume = base_volume * bus_volume
+
+        # Find available channel or steal one
+        channel = self._get_available_channel(priority)
+        if channel is None:
+            logger.debug("No available channels for sound '%s'", clip.path)
+            return None
+
         try:
-            native_sound = clip.native_handle
-
-            if not (
-                hasattr(native_sound, "set_volume") and hasattr(native_sound, "play")
-            ):
-                logger.error("Resource '%s' is not a valid Sound", clip.path)
-                return None
-
-            # Calculate effective volume through bus hierarchy
-            bus_name = self._bus_manager.get_bus_for_type(bus)
-            bus_volume = self._bus_manager.get_effective_volume(bus_name)
-            effective_volume = volume * bus_volume
-
-            # Find available channel or steal one
-            channel = self._get_available_channel(priority)
-            if channel is None:
-                logger.debug("No available channels for sound '%s'", clip.path)
-                return None
-
-            # Set volume on the sound
-            native_sound.set_volume(effective_volume)
-
-            # Play on specific channel
-            played_channel = native_sound.play(loops=loops)
-            if played_channel is None:
-                return None
-
-            channel_id: int = played_channel.get_id()
-
-            # Apply stereo panning if supported and needed
-            if abs(pan) > 0.01:
-                self._apply_pan(played_channel, pan)
-
-            # Track playing sound
-            self._playing_sounds[channel_id] = PlayingSoundInfo(
-                channel_id=channel_id,
-                clip_path=clip.path,
-                priority=priority,
-                bus=bus,
-                base_volume=volume,
-                position=position,
-                is_spatial=position is not None,
-            )
-
-            return channel_id
-
-        except (AttributeError, Exception) as e:
+            # Loudness and stereo pan go on the CHANNEL, never the Sound: the
+            # Sound object is shared by every concurrent play of the same clip
+            # (ResourceManager caches it), so `sound.set_volume()` for one
+            # spatial instance silently rewrites every other one.
+            channel.play(native_sound, loops=loops)
+            self._set_channel_volume(channel, effective_volume, pan)
+            channel_id: int = channel.id
+        except pygame.error as e:
             logger.error("Error playing sound '%s': %s", clip.path, e, exc_info=True)
             return None
+
+        # Track playing sound
+        self._playing_sounds[channel_id] = PlayingSoundInfo(
+            channel_id=channel_id,
+            clip_path=clip.path,
+            priority=priority,
+            bus=bus,
+            base_volume=base_volume,
+            position=position,
+            is_spatial=position is not None,
+        )
+        self._channel_sounds[channel_id] = native_sound
+
+        return channel_id
 
     def _get_available_channel(
         self, priority: AudioPriority
@@ -228,7 +228,7 @@ class PygameAudioSystem:
 
         # Clean up finished channels
         for channel_id in finished_channels:
-            del self._playing_sounds[channel_id]
+            self._forget_channel(channel_id)
 
         # Return a finished channel if available
         if finished_channels:
@@ -242,7 +242,7 @@ class PygameAudioSystem:
             try:
                 channel = pygame.mixer.Channel(lowest_channel_id)
                 channel.stop()
-                del self._playing_sounds[lowest_channel_id]
+                self._forget_channel(lowest_channel_id)
                 logger.debug(
                     "Stole channel %d from lower priority sound", lowest_channel_id
                 )
@@ -252,57 +252,84 @@ class PygameAudioSystem:
 
         return None
 
-    def _apply_pan(self, channel: pygame.mixer.Channel, pan: float) -> None:
-        """Apply stereo panning to a channel.
+    @staticmethod
+    def _channel_stereo(volume: float, pan: float) -> tuple[float, float]:
+        """Split a mono volume into (left, right) channel gains for a pan.
 
         Args:
-            channel: The pygame channel.
-            pan: Pan value (-1.0 = left, 0.0 = center, 1.0 = right).
-        """
-        # Convert pan to left/right volumes
-        # pan = -1: left = 1.0, right = 0.0
-        # pan = 0: left = 1.0, right = 1.0
-        # pan = 1: left = 0.0, right = 1.0
-        if pan < 0:
-            left = 1.0
-            right = 1.0 + pan  # pan is negative, so this reduces right
-        else:
-            left = 1.0 - pan
-            right = 1.0
+            volume: Mono loudness (0.0 to 1.0).
+            pan: -1.0 = full left, 0.0 = centred, 1.0 = full right.
 
-        channel.set_volume(left, right)
+        Returns:
+            (left, right) gains, each `volume` scaled by that side's share.
+        """
+        pan = max(-1.0, min(1.0, pan))
+        if pan >= 0.0:
+            return volume * (1.0 - pan), volume
+        return volume, volume * (1.0 + pan)
+
+    @classmethod
+    def _set_channel_volume(
+        cls, channel: pygame.mixer.Channel, volume: float, pan: float
+    ) -> None:
+        """Apply loudness + pan to a channel.
+
+        A centred sound uses single-argument ``set_volume``, which also clears
+        any left/right split the channel kept from a previous, panned sound --
+        channels are recycled, so without this a centred sound inherits the
+        last one's hard pan.
+        """
+        if abs(pan) < 1e-3:
+            channel.set_volume(volume)
+        else:
+            left, right = cls._channel_stereo(volume, pan)
+            channel.set_volume(left, right)
+
+    def _forget_channel(self, channel_id: int) -> None:
+        """Drop all tracking for a channel that is no longer ours."""
+        self._playing_sounds.pop(channel_id, None)
+        self._channel_sounds.pop(channel_id, None)
+
+    def is_channel_active(self, channel: int) -> bool:
+        """Return True only while the sound this system started is still playing.
+
+        Reaps the tracking tables as a side effect when the sound has ended or
+        the channel has been recycled by an unrelated one.
+        """
+        expected = self._channel_sounds.get(channel)
+        if expected is not None:
+            try:
+                pg_channel = pygame.mixer.Channel(channel)
+                if pg_channel.get_busy() and pg_channel.get_sound() is expected:
+                    return True
+            except pygame.error:
+                pass
+        self._forget_channel(channel)
+        return False
 
     def set_channel_mix(self, channel: int, attenuation: float, pan: float) -> None:
         """Update volume attenuation and stereo pan for an already-playing channel."""
         info = self._playing_sounds.get(channel)
-        if info is None:
+        if info is None or not self.is_channel_active(channel):
             return
 
-        try:
-            pg_channel = pygame.mixer.Channel(channel)
-            sound = pg_channel.get_sound()
-            if sound is None or not pg_channel.get_busy():
-                return
+        bus_name = self._bus_manager.get_bus_for_type(info.bus)
+        bus_volume = self._bus_manager.get_effective_volume(bus_name)
+        attenuation = max(0.0, min(1.0, attenuation))
+        effective_volume = info.base_volume * attenuation * bus_volume
 
-            bus_name = self._bus_manager.get_bus_for_type(info.bus)
-            bus_volume = self._bus_manager.get_effective_volume(bus_name)
-            effective_volume = info.base_volume * attenuation * bus_volume
-
-            sound.set_volume(effective_volume)
-            self._apply_pan(pg_channel, pan)
-        except pygame.error:
-            pass
+        with contextlib.suppress(pygame.error):
+            self._set_channel_volume(
+                pygame.mixer.Channel(channel), effective_volume, pan
+            )
 
     # ========== Basic SFX Control ==========
 
     def stop_sfx(self, channel: int) -> None:
         """Stop a specific sound effect channel."""
-        try:
+        with contextlib.suppress(pygame.error):
             pygame.mixer.Channel(channel).stop()
-            if channel in self._playing_sounds:
-                del self._playing_sounds[channel]
-        except pygame.error:
-            pass
+        self._forget_channel(channel)
 
     def pause_sfx(self) -> None:
         """Pause all sound effects."""
@@ -431,17 +458,22 @@ class PygameAudioSystem:
 
     def cleanup_finished_channels(self) -> None:
         """Remove tracking for channels that have finished playing."""
-        finished = []
-        for channel_id in self._playing_sounds:
-            try:
-                channel = pygame.mixer.Channel(channel_id)
-                if not channel.get_busy():
-                    finished.append(channel_id)
-            except pygame.error:
-                finished.append(channel_id)
+        for channel_id in list(self._playing_sounds):
+            self.is_channel_active(channel_id)  # reaps as a side effect
 
-        for channel_id in finished:
-            del self._playing_sounds[channel_id]
+    def shutdown(self) -> None:
+        """Stop all audio and release the mixer device. Idempotent."""
+        if self._shut_down:
+            return
+        self._shut_down = True
+        try:
+            pygame.mixer.stop()
+            pygame.mixer.music.stop()
+            pygame.mixer.quit()
+        except pygame.error:
+            logger.debug("pygame.mixer already torn down", exc_info=True)
+        self._playing_sounds.clear()
+        self._channel_sounds.clear()
 
     def get_active_sound_count(self) -> int:
         """Get number of currently playing sounds."""

--- a/pyguara/audio/components.py
+++ b/pyguara/audio/components.py
@@ -50,6 +50,9 @@ class AudioSource(BaseComponent):
     _channel_id: int | None = field(default=None, repr=False, compare=False)
     _is_playing: bool = field(default=False, repr=False, compare=False)
     _stop_requested: bool = field(default=False, repr=False, compare=False)
+    # Latches once auto_play has fired, so a one-shot sound that ends is not
+    # immediately restarted by the auto_play path on the next frame.
+    _auto_played: bool = field(default=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         """Initialize the component."""

--- a/pyguara/audio/manager.py
+++ b/pyguara/audio/manager.py
@@ -48,9 +48,6 @@ class AudioManager:
         # Track loaded audio clips
         self._loaded_clips: dict[str, AudioClip] = {}
 
-        # Track active sound channels
-        self._active_channels: dict[str, int] = {}
-
         # Current music track
         self._current_music: str | None = None
 
@@ -245,8 +242,12 @@ class AudioManager:
     # ========== Cleanup ==========
 
     def cleanup(self) -> None:
-        """Clean up resources and stop all audio."""
+        """Stop music and drop cached clips.
+
+        Playing sound effects are owned by ``AudioSourceSystem`` and released
+        by its own ``cleanup()``; tearing down the shared mixer device is
+        ``IAudioSystem.shutdown()``, called at application shutdown.
+        """
         self.stop_music(fade_ms=0)
         self._loaded_clips.clear()
-        self._active_channels.clear()
         self._current_music = None

--- a/pyguara/audio/types.py
+++ b/pyguara/audio/types.py
@@ -84,6 +84,32 @@ class SpatialAudioConfig:
     rolloff_factor: float = 1.0
     pan_strength: float = 1.0
 
+    def __post_init__(self) -> None:
+        """Validate the configuration.
+
+        The attenuation and panning maths divide by ``reference_distance`` and
+        ``max_distance`` and assume ``max_distance`` is the outer edge, so a
+        zero or inverted range is not a quiet degradation -- it is a
+        ``ZeroDivisionError`` in ``calculate_pan`` and a hard volume cliff in
+        ``calculate_attenuation``. Reject it at construction instead.
+
+        Raises:
+            ValueError: If the distances or factors are out of range.
+        """
+        if self.reference_distance <= 0.0:
+            raise ValueError(
+                f"reference_distance must be > 0, got {self.reference_distance}"
+            )
+        if self.max_distance <= self.reference_distance:
+            raise ValueError(
+                f"max_distance ({self.max_distance}) must be greater than "
+                f"reference_distance ({self.reference_distance})"
+            )
+        if self.rolloff_factor < 0.0:
+            raise ValueError(f"rolloff_factor must be >= 0, got {self.rolloff_factor}")
+        if self.pan_strength < 0.0:
+            raise ValueError(f"pan_strength must be >= 0, got {self.pan_strength}")
+
     def calculate_attenuation(self, distance: float) -> float:
         """Calculate volume attenuation based on distance.
 

--- a/tests/integration/test_audio_backend.py
+++ b/tests/integration/test_audio_backend.py
@@ -3,7 +3,6 @@
 import os
 from collections.abc import Iterator
 from typing import Any
-from unittest.mock import MagicMock
 
 import pygame
 import pytest
@@ -63,22 +62,23 @@ class MockAudioClip(AudioClip):
         return self._native_sound
 
 
-def test_play_sfx_mock(audio_system: PygameAudioSystem) -> None:
-    """Audio system should play sound effects."""
-    # Mock native sound
-    mock_sound = MagicMock()
-    # Mock play to return a Channel object
-    mock_channel = MagicMock()
-    mock_channel.get_id.return_value = 1
-    mock_sound.play.return_value = mock_channel
+def test_play_sfx_real_sound(audio_system: PygameAudioSystem) -> None:
+    """Audio system plays a real Sound on a real channel and tracks its id.
 
-    clip = MockAudioClip("dummy.wav", mock_sound)
+    Uses a real ``pygame.mixer.Sound`` -- ``Channel.play`` rejects anything
+    else, which is how the ``Channel.get_id()``/``Channel.id`` regression hid
+    behind fully-mocked mixers for so long.
+    """
+    frames = int(44100 * 0.5)
+    sound = pygame.mixer.Sound(buffer=b"\x00\x00\x00\x00" * frames)
+    clip = MockAudioClip("dummy.wav", sound)
 
     channel_id = audio_system.play_sfx(clip)
 
-    assert channel_id == 1
-    mock_sound.play.assert_called_once()
-    mock_sound.set_volume.assert_called()
+    assert channel_id is not None
+    assert isinstance(channel_id, int)
+    assert pygame.mixer.Channel(channel_id).get_sound() is sound
+    assert audio_system.is_channel_active(channel_id)
 
 
 def test_play_sfx_invalid(audio_system: PygameAudioSystem) -> None:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,64 +1,82 @@
-"""Tests for the audio system."""
+"""Tests for the audio system.
 
+These drive the **real** pygame mixer under the ``dummy`` SDL driver with
+real ``Sound`` buffers. Only ``pygame.mixer.music`` -- the file-streaming API,
+which needs a real file on disk -- is mocked. The previous version of this
+file patched ``pygame.mixer`` wholesale, so channel ids, stereo volume, the
+shared-``Sound`` volume trap and ``Channel.id`` (the real attribute, vs the
+non-existent ``get_id()`` the backend called) were never exercised.
+"""
+
+import os
+from collections.abc import Iterator
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
-from pyguara.audio.backends.pygame.pygame_audio import PygameAudioSystem
-from pyguara.audio.manager import AudioManager
-from pyguara.resources.types import AudioClip
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pygame  # noqa: E402
+
+from pyguara.audio.backends.pygame.pygame_audio import PygameAudioSystem  # noqa: E402
+from pyguara.audio.manager import AudioManager  # noqa: E402
+from pyguara.resources.types import AudioClip  # noqa: E402
+
+_SAMPLE_RATE = 44100
 
 # ========== Fixtures ==========
 
 
-@pytest.fixture  # type: ignore[misc]
-def mock_pygame_mixer() -> Any:
-    """Mock pygame.mixer to avoid actual audio initialization."""
-    with patch("pygame.mixer") as mock_mixer:
-        # Setup default mocks
-        mock_mixer.get_init.return_value = True
-        mock_mixer.set_num_channels.return_value = None
-        mock_mixer.music = Mock()
-        mock_mixer.music.get_busy.return_value = False
-        mock_mixer.music.load.return_value = None
-        mock_mixer.music.play.return_value = None
-        mock_mixer.music.stop.return_value = None
-        mock_mixer.music.pause.return_value = None
-        mock_mixer.music.unpause.return_value = None
-        mock_mixer.music.fadeout.return_value = None
-        mock_mixer.music.set_volume.return_value = None
-        mock_mixer.pause.return_value = None
-        mock_mixer.unpause.return_value = None
-        mock_mixer.Channel.return_value.stop.return_value = None
-
-        yield mock_mixer
+@pytest.fixture(autouse=True, scope="module")
+def _mixer() -> Iterator[None]:
+    """Bring the real (dummy-driver) mixer up for the module."""
+    pygame.mixer.init(_SAMPLE_RATE, -16, 2, 512)
+    yield
+    pygame.mixer.quit()
 
 
-@pytest.fixture  # type: ignore[misc]
-def audio_system(mock_pygame_mixer: Any) -> PygameAudioSystem:
-    """Create a PygameAudioSystem instance with mocked pygame."""
-    return PygameAudioSystem()
+@pytest.fixture
+def mock_music() -> Iterator[Any]:
+    """Mock only the music-streaming API; channels stay real."""
+    with patch("pygame.mixer.music") as music:
+        music.get_busy.return_value = False
+        yield music
 
 
-@pytest.fixture  # type: ignore[misc]
-def mock_audio_clip() -> AudioClip:
-    """Create a mock audio clip for testing."""
-    clip = Mock(spec=AudioClip)
-    clip.path = "test_sound.wav"
+def _make_clip(path: str = "test_sound.wav", seconds: float = 1.0) -> AudioClip:
+    """Build a real AudioClip wrapping a real Sound of `seconds` of silence."""
+    frames = int(_SAMPLE_RATE * seconds)
+    sound = pygame.mixer.Sound(buffer=b"\x00\x00\x00\x00" * frames)
 
-    # Mock pygame Sound object
-    mock_sound = Mock()
-    mock_sound.set_volume = Mock()
-    mock_sound.play = Mock(return_value=Mock(get_id=Mock(return_value=0)))
+    class _Clip(AudioClip):
+        @property
+        def duration(self) -> float:
+            return seconds
 
-    clip.native_handle = mock_sound
-    return clip
+        @property
+        def native_handle(self) -> pygame.mixer.Sound:
+            return sound
+
+    return _Clip(path)
 
 
-@pytest.fixture  # type: ignore[misc]
+@pytest.fixture
+def audio_system(mock_music: Any) -> Iterator[PygameAudioSystem]:
+    """A PygameAudioSystem on the real mixer, isolated between tests."""
+    system = PygameAudioSystem(num_channels=8)
+    yield system
+    pygame.mixer.stop()
+
+
+@pytest.fixture
+def audio_clip() -> AudioClip:
+    return _make_clip()
+
+
+@pytest.fixture
 def audio_manager(audio_system: PygameAudioSystem) -> AudioManager:
-    """Create an AudioManager instance."""
     return AudioManager(audio_system)
 
 
@@ -66,226 +84,333 @@ def audio_manager(audio_system: PygameAudioSystem) -> AudioManager:
 
 
 def test_master_volume_control(audio_system: PygameAudioSystem) -> None:
-    """Test master volume getter and setter."""
-    # Default volume should be 1.0
+    """Master volume getter/setter, with clamping."""
     assert audio_system.get_master_volume() == 1.0
 
-    # Set new volume
     audio_system.set_master_volume(0.5)
     assert audio_system.get_master_volume() == 0.5
 
-    # Test clamping
-    audio_system.set_master_volume(1.5)  # Above max
+    audio_system.set_master_volume(1.5)
     assert audio_system.get_master_volume() == 1.0
 
-    audio_system.set_master_volume(-0.5)  # Below min
+    audio_system.set_master_volume(-0.5)
     assert audio_system.get_master_volume() == 0.0
 
 
 def test_sfx_volume_control(audio_system: PygameAudioSystem) -> None:
-    """Test SFX volume getter and setter."""
-    # Default volume should be 1.0
+    """SFX volume getter/setter, with clamping."""
     assert audio_system.get_sfx_volume() == 1.0
 
-    # Set new volume
     audio_system.set_sfx_volume(0.7)
     assert audio_system.get_sfx_volume() == 0.7
 
-    # Test clamping
     audio_system.set_sfx_volume(2.0)
     assert audio_system.get_sfx_volume() == 1.0
 
 
-def test_music_volume_control(
-    audio_system: PygameAudioSystem, mock_pygame_mixer: Any
-) -> None:
-    """Test music volume getter and setter."""
-    # Default volume should be 1.0
+def test_music_volume_control(audio_system: PygameAudioSystem, mock_music: Any) -> None:
+    """Music volume getter/setter pushes the effective volume to the stream."""
     assert audio_system.get_music_volume() == 1.0
 
-    # Set new volume
     audio_system.set_music_volume(0.3)
     assert audio_system.get_music_volume() == 0.3
-
-    # Verify pygame.mixer.music.set_volume was called with effective volume
-    mock_pygame_mixer.music.set_volume.assert_called()
-
-
-def test_volume_hierarchy(audio_system: PygameAudioSystem) -> None:
-    """Test that master volume affects both SFX and music."""
-    audio_system.set_master_volume(0.5)
-    audio_system.set_sfx_volume(0.8)
-    audio_system.set_music_volume(0.6)
-
-    assert audio_system.get_master_volume() == 0.5
-    assert audio_system.get_sfx_volume() == 0.8
-    assert audio_system.get_music_volume() == 0.6
-
-    # Effective volumes should be: master * category
-    # This will be verified in play methods
+    mock_music.set_volume.assert_called()
 
 
 # ========== SFX Playback Tests ==========
 
 
-def test_play_sfx(audio_system: PygameAudioSystem, mock_audio_clip: AudioClip) -> None:
-    """Test playing a sound effect."""
-    channel_id = audio_system.play_sfx(mock_audio_clip, volume=0.8)
+def test_play_sfx_plays_on_the_channel_it_returns(
+    audio_system: PygameAudioSystem, audio_clip: AudioClip
+) -> None:
+    """The returned id names the channel actually carrying our sound.
 
-    # Verify sound was played
-    mock_audio_clip.native_handle.set_volume.assert_called_once()
-    mock_audio_clip.native_handle.play.assert_called_once_with(loops=0)
+    Regression: the backend called ``Channel.get_id()`` (does not exist on
+    pygame-ce), so every real ``play_sfx`` raised, was swallowed, and returned
+    ``None`` while the sound played on untracked.
+    """
+    channel_id = audio_system.play_sfx(audio_clip, volume=0.8)
 
-    # Should return a channel ID
     assert channel_id is not None
+    assert isinstance(channel_id, int)
+    pg = pygame.mixer.Channel(channel_id)
+    assert pg.get_busy()
+    assert pg.get_sound() is audio_clip.native_handle
 
 
-def test_play_sfx_with_loops(
-    audio_system: PygameAudioSystem, mock_audio_clip: AudioClip
+def test_play_sfx_channel_id_zero_is_valid(
+    audio_system: PygameAudioSystem, audio_clip: AudioClip
 ) -> None:
-    """Test playing a looping sound effect."""
-    audio_system.play_sfx(mock_audio_clip, volume=1.0, loops=3)
+    """Channel 0 is a real channel; it must come back as 0, not be treated
+    as falsy/absent."""
+    channel_id = audio_system.play_sfx(audio_clip)
+    assert channel_id == 0
+    assert audio_system.is_channel_active(0)
 
-    # Verify loops parameter was passed
-    mock_audio_clip.native_handle.play.assert_called_once_with(loops=3)
 
-
-def test_play_sfx_volume_application(
-    audio_system: PygameAudioSystem, mock_audio_clip: AudioClip
+def test_play_sfx_loops_forever_when_requested(
+    audio_system: PygameAudioSystem,
 ) -> None:
-    """Test that SFX volume is correctly applied."""
+    """loops=-1 keeps a short clip busy well past its own length."""
+    import time
+
+    clip = _make_clip(seconds=0.05)
+    channel_id = audio_system.play_sfx(clip, loops=-1)
+    assert channel_id is not None
+    time.sleep(0.2)
+    assert pygame.mixer.Channel(channel_id).get_busy()
+
+
+def test_play_sfx_centred_volume_is_set_on_the_channel_not_the_sound(
+    audio_system: PygameAudioSystem, audio_clip: AudioClip
+) -> None:
+    """Effective volume = clip * sfx * master, applied to the channel; the
+    shared Sound object is left untouched.
+
+    ``Channel.get_volume()`` only reflects a single-argument ``set_volume``
+    (the centred path), so a non-spatial clip is used here.
+    """
     audio_system.set_master_volume(0.5)
     audio_system.set_sfx_volume(0.8)
 
-    audio_system.play_sfx(mock_audio_clip, volume=0.6)
+    channel_id = audio_system.play_sfx(audio_clip, volume=0.6)
+    assert channel_id is not None
 
-    # Effective volume should be: 0.6 * 0.8 * 0.5 = 0.24
-    expected_volume = 0.6 * 0.8 * 0.5
-    mock_audio_clip.native_handle.set_volume.assert_called_once_with(expected_volume)
-
-
-def test_stop_sfx(audio_system: PygameAudioSystem, mock_pygame_mixer: Any) -> None:
-    """Test stopping a specific SFX channel."""
-    audio_system.stop_sfx(0)
-
-    # Verify Channel(0).stop() was called
-    mock_pygame_mixer.Channel.assert_called_once_with(0)
-    mock_pygame_mixer.Channel.return_value.stop.assert_called_once()
-
-
-def test_pause_resume_sfx(
-    audio_system: PygameAudioSystem, mock_pygame_mixer: Any
-) -> None:
-    """Test pausing and resuming all sound effects."""
-    audio_system.pause_sfx()
-    mock_pygame_mixer.pause.assert_called_once()
-
-    audio_system.resume_sfx()
-    mock_pygame_mixer.unpause.assert_called_once()
-
-
-# ========== Spatial Channel Mix Tests ==========
-
-
-def test_set_channel_mix_updates_volume_and_pan(
-    audio_system: PygameAudioSystem,
-    mock_pygame_mixer: Any,
-    mock_audio_clip: AudioClip,
-) -> None:
-    """Test that set_channel_mix pushes attenuation and pan to a playing channel."""
-    mock_pygame_mixer.Channel.return_value.get_busy.return_value = True
-    mock_pygame_mixer.Channel.return_value.get_sound.return_value = (
-        mock_audio_clip.native_handle
+    expected = 0.6 * 0.8 * 0.5
+    assert pygame.mixer.Channel(channel_id).get_volume() == pytest.approx(
+        expected, abs=0.02
     )
+    # D2: the ResourceManager-cached Sound must never have its volume touched.
+    assert audio_clip.native_handle.get_volume() == pytest.approx(1.0)
 
-    channel_id = audio_system.play_sfx(mock_audio_clip, volume=1.0)
+
+def test_channel_stereo_split_is_pure_and_symmetric() -> None:
+    """The pan -> (left, right) maths, tested directly (the applied split is
+    not observable through ``Channel.get_volume()``)."""
+    assert PygameAudioSystem._channel_stereo(1.0, 0.0) == (1.0, 1.0)
+    assert PygameAudioSystem._channel_stereo(1.0, 1.0) == (0.0, 1.0)
+    assert PygameAudioSystem._channel_stereo(1.0, -1.0) == (1.0, 0.0)
+    l_r, r_r = PygameAudioSystem._channel_stereo(0.8, 0.5)
+    l_l, r_l = PygameAudioSystem._channel_stereo(0.8, -0.5)
+    assert (l_r, r_r) == (r_l, l_l)  # mirror image
+    # clamped
+    assert PygameAudioSystem._channel_stereo(1.0, 5.0) == (0.0, 1.0)
+
+
+def test_concurrent_plays_of_one_clip_do_not_share_volume(
+    audio_system: PygameAudioSystem,
+) -> None:
+    """Two spatial plays of the SAME cached clip must not fight over one
+    shared ``Sound.set_volume`` (D2)."""
+    from pyguara.audio.types import SpatialAudioConfig
+    from pyguara.common.types import Vector2
+
+    audio_system.set_spatial_config(
+        SpatialAudioConfig(max_distance=1000, reference_distance=100)
+    )
+    clip = _make_clip(seconds=1.0)
+
+    near = audio_system.play_sfx_at_position(
+        clip, Vector2(0, 0), Vector2(0, 0), volume=1.0
+    )
+    far = audio_system.play_sfx_at_position(
+        clip, Vector2(600, 0), Vector2(0, 0), volume=1.0
+    )
+    assert near is not None and far is not None and near != far
+
+    # The near play is centred, so its channel volume is observable and must
+    # still be full despite the quieter far play that followed.
+    assert pygame.mixer.Channel(near).get_volume() == pytest.approx(1.0, abs=0.02)
+    # And the clip's Sound was never used as the volume knob.
+    assert clip.native_handle.get_volume() == pytest.approx(1.0)
+
+
+def test_recycled_channel_does_not_inherit_previous_pan(
+    audio_system: PygameAudioSystem,
+) -> None:
+    """A centred sound landing on a reused channel resets the stereo split
+    instead of keeping the last sound's hard pan (D3).
+
+    A stale two-argument split leaves ``Channel.get_volume()`` reading 1.0
+    (it ignores stereo separation); the centred play must drive it to its
+    own volume.
+    """
+    from pyguara.audio.types import SpatialAudioConfig
+    from pyguara.common.types import Vector2
+
+    one_channel = PygameAudioSystem(num_channels=1)
+    one_channel.set_spatial_config(SpatialAudioConfig(max_distance=10000))
+    try:
+        one_channel.play_sfx_at_position(
+            _make_clip("left.wav", 0.05),
+            Vector2(-9000, 0),
+            Vector2(0, 0),
+            volume=1.0,
+        )
+        pygame.mixer.Channel(0).stop()
+
+        centred = one_channel.play_sfx(_make_clip("mid.wav", 0.5), volume=0.5)
+        assert centred == 0
+        assert pygame.mixer.Channel(0).get_volume() == pytest.approx(0.5, abs=0.02)
+    finally:
+        pygame.mixer.stop()
+
+
+def test_stop_sfx_stops_and_forgets_the_channel(
+    audio_system: PygameAudioSystem, audio_clip: AudioClip
+) -> None:
+    channel_id = audio_system.play_sfx(audio_clip)
+    assert channel_id is not None
+    assert audio_system.is_channel_active(channel_id)
+
+    audio_system.stop_sfx(channel_id)
+    assert not pygame.mixer.Channel(channel_id).get_busy()
+    assert not audio_system.is_channel_active(channel_id)
+
+
+def test_invalid_clip_returns_none(audio_system: PygameAudioSystem) -> None:
+    class _Broken(AudioClip):
+        @property
+        def duration(self) -> float:
+            return 0.0
+
+        @property
+        def native_handle(self) -> Any:
+            return None
+
+    assert audio_system.play_sfx(_Broken("broken.wav")) is None
+
+
+def test_pause_resume_sfx(audio_system: PygameAudioSystem) -> None:
+    # The dummy SDL driver does not reflect pause() in get_busy(), so assert
+    # the calls route through to the mixer.
+    with (
+        patch("pygame.mixer.pause") as pause,
+        patch("pygame.mixer.unpause") as unpause,
+    ):
+        audio_system.pause_sfx()
+        audio_system.resume_sfx()
+    pause.assert_called_once()
+    unpause.assert_called_once()
+
+
+# ========== is_channel_active ==========
+
+
+def test_is_channel_active_false_for_unknown_channel(
+    audio_system: PygameAudioSystem,
+) -> None:
+    assert audio_system.is_channel_active(5) is False
+
+
+def test_is_channel_active_false_once_sound_finishes(
+    audio_system: PygameAudioSystem,
+) -> None:
+    import time
+
+    channel_id = audio_system.play_sfx(_make_clip(seconds=0.05))
+    assert channel_id is not None
+    assert audio_system.is_channel_active(channel_id)
+
+    time.sleep(0.25)
+    assert audio_system.is_channel_active(channel_id) is False
+
+
+def test_is_channel_active_false_when_channel_reused_by_other_sound(
+    audio_system: PygameAudioSystem,
+) -> None:
+    one = PygameAudioSystem(num_channels=1)
+    try:
+        first = one.play_sfx(_make_clip("first.wav", 2.0))
+        assert first == 0
+        pygame.mixer.Channel(0).stop()
+        # Something unrelated grabs channel 0 directly.
+        pygame.mixer.Channel(0).play(_make_clip("other.wav", 2.0).native_handle)
+        assert one.is_channel_active(0) is False
+    finally:
+        pygame.mixer.stop()
+
+
+# ========== set_channel_mix ==========
+
+
+def test_set_channel_mix_updates_channel_volume(
+    audio_system: PygameAudioSystem, audio_clip: AudioClip
+) -> None:
+    channel_id = audio_system.play_sfx(audio_clip, volume=1.0)
     assert channel_id is not None
 
     audio_system.set_channel_mix(channel_id, attenuation=0.4, pan=0.0)
-
-    # base_volume(1.0) * attenuation(0.4) * bus_volume(1.0) = 0.4
-    mock_audio_clip.native_handle.set_volume.assert_called_with(0.4)
-    # pan=0.0 is centered: full volume on both stereo channels.
-    mock_pygame_mixer.Channel.return_value.set_volume.assert_called_with(1.0, 1.0)
+    assert pygame.mixer.Channel(channel_id).get_volume() == pytest.approx(0.4, abs=0.02)
 
 
 def test_set_channel_mix_ignores_finished_channel(
     audio_system: PygameAudioSystem,
-    mock_pygame_mixer: Any,
-    mock_audio_clip: AudioClip,
 ) -> None:
-    """A channel that finished playing must not receive a stale mix update."""
-    mock_pygame_mixer.Channel.return_value.get_busy.return_value = True
-    channel_id = audio_system.play_sfx(mock_audio_clip, volume=1.0)
+    import time
+
+    channel_id = audio_system.play_sfx(_make_clip(seconds=0.05), volume=1.0)
     assert channel_id is not None
-    mock_audio_clip.native_handle.set_volume.reset_mock()
-
-    mock_pygame_mixer.Channel.return_value.get_busy.return_value = False
+    time.sleep(0.25)
+    # Must not raise, must not resurrect volume on a dead channel.
     audio_system.set_channel_mix(channel_id, attenuation=0.4, pan=0.0)
-
-    mock_audio_clip.native_handle.set_volume.assert_not_called()
+    assert audio_system.is_channel_active(channel_id) is False
 
 
 def test_set_channel_mix_ignores_unknown_channel(
-    audio_system: PygameAudioSystem, mock_pygame_mixer: Any
+    audio_system: PygameAudioSystem,
 ) -> None:
-    """A channel id this system never played must be a silent no-op."""
-    audio_system.set_channel_mix(99, attenuation=0.5, pan=0.5)
+    audio_system.set_channel_mix(99, attenuation=0.5, pan=0.5)  # no raise
 
-    mock_pygame_mixer.Channel.assert_not_called()
+
+# ========== shutdown ==========
+
+
+def test_shutdown_is_idempotent_and_stops_audio() -> None:
+    system = PygameAudioSystem(num_channels=4)
+    system.play_sfx(_make_clip(seconds=1.0), loops=-1)
+
+    system.shutdown()
+    system.shutdown()  # second call is a no-op, must not raise
+
+    # Bring the module mixer back for the remaining tests.
+    pygame.mixer.init(_SAMPLE_RATE, -16, 2, 512)
 
 
 # ========== Music Playback Tests ==========
 
 
-def test_play_music(audio_system: PygameAudioSystem, mock_pygame_mixer: Any) -> None:
-    """Test playing background music."""
+def test_play_music(audio_system: PygameAudioSystem, mock_music: Any) -> None:
     audio_system.play_music("music/bgm.ogg", loop=True, fade_ms=1000)
 
-    # Verify music was loaded and played
-    mock_pygame_mixer.music.load.assert_called_once_with("music/bgm.ogg")
-    mock_pygame_mixer.music.play.assert_called_once_with(loops=-1, fade_ms=1000)
-    mock_pygame_mixer.music.set_volume.assert_called()
+    mock_music.load.assert_called_once_with("music/bgm.ogg")
+    mock_music.play.assert_called_once_with(loops=-1, fade_ms=1000)
+    mock_music.set_volume.assert_called()
 
 
-def test_play_music_no_loop(
-    audio_system: PygameAudioSystem, mock_pygame_mixer: Any
-) -> None:
-    """Test playing non-looping music."""
-    audio_system.play_music("music/theme.mp3", loop=False)
-
-    # Verify loops=0 for non-looping
-    mock_pygame_mixer.music.play.assert_called_once_with(loops=0, fade_ms=1000)
+def test_play_music_no_loop(audio_system: PygameAudioSystem, mock_music: Any) -> None:
+    audio_system.play_music("music/theme.ogg", loop=False)
+    mock_music.play.assert_called_once_with(loops=0, fade_ms=1000)
 
 
-def test_stop_music(audio_system: PygameAudioSystem, mock_pygame_mixer: Any) -> None:
-    """Test stopping music."""
+def test_stop_music(audio_system: PygameAudioSystem, mock_music: Any) -> None:
     audio_system.stop_music(fade_ms=500)
+    mock_music.fadeout.assert_called_once_with(500)
 
-    mock_pygame_mixer.music.fadeout.assert_called_once_with(500)
 
-
-def test_pause_resume_music(
-    audio_system: PygameAudioSystem, mock_pygame_mixer: Any
-) -> None:
-    """Test pausing and resuming music."""
+def test_pause_resume_music(audio_system: PygameAudioSystem, mock_music: Any) -> None:
     audio_system.pause_music()
-    mock_pygame_mixer.music.pause.assert_called_once()
+    mock_music.pause.assert_called_once()
 
     audio_system.resume_music()
-    mock_pygame_mixer.music.unpause.assert_called_once()
+    mock_music.unpause.assert_called_once()
 
 
-def test_is_music_playing(
-    audio_system: PygameAudioSystem, mock_pygame_mixer: Any
-) -> None:
-    """Test checking if music is playing."""
-    # Mock music as not playing
-    mock_pygame_mixer.music.get_busy.return_value = False
+def test_is_music_playing(audio_system: PygameAudioSystem, mock_music: Any) -> None:
+    mock_music.get_busy.return_value = False
     assert not audio_system.is_music_playing()
 
-    # Mock music as playing
-    mock_pygame_mixer.music.get_busy.return_value = True
+    mock_music.get_busy.return_value = True
     assert audio_system.is_music_playing()
 
 
@@ -293,39 +418,27 @@ def test_is_music_playing(
 
 
 def test_audio_manager_initialization(audio_manager: AudioManager) -> None:
-    """Test AudioManager initializes correctly."""
-    assert audio_manager is not None
     assert audio_manager.get_master_volume() == 1.0
     assert audio_manager.get_current_music() is None
 
 
-def test_audio_manager_play_music(
-    audio_manager: AudioManager, mock_pygame_mixer: Any
-) -> None:
-    """Test AudioManager music playback."""
+def test_audio_manager_play_music(audio_manager: AudioManager, mock_music: Any) -> None:
     audio_manager.play_music("music/bgm.ogg")
 
-    # Verify music was played
-    mock_pygame_mixer.music.load.assert_called_once_with("music/bgm.ogg")
-    mock_pygame_mixer.music.play.assert_called_once()
-
-    # Verify current music is tracked
+    mock_music.load.assert_called_once_with("music/bgm.ogg")
+    mock_music.play.assert_called_once()
     assert audio_manager.get_current_music() == "music/bgm.ogg"
 
 
-def test_audio_manager_stop_music(
-    audio_manager: AudioManager, mock_pygame_mixer: Any
-) -> None:
-    """Test AudioManager stops music and clears tracking."""
+def test_audio_manager_stop_music(audio_manager: AudioManager, mock_music: Any) -> None:
     audio_manager.play_music("music/bgm.ogg")
     audio_manager.stop_music()
 
-    mock_pygame_mixer.music.fadeout.assert_called_once()
+    mock_music.fadeout.assert_called_once()
     assert audio_manager.get_current_music() is None
 
 
 def test_audio_manager_volume_control(audio_manager: AudioManager) -> None:
-    """Test AudioManager volume controls."""
     audio_manager.set_master_volume(0.7)
     assert audio_manager.get_master_volume() == 0.7
 
@@ -337,92 +450,63 @@ def test_audio_manager_volume_control(audio_manager: AudioManager) -> None:
 
 
 def test_audio_manager_pause_resume(
-    audio_manager: AudioManager, mock_pygame_mixer: Any
+    audio_manager: AudioManager, mock_music: Any
 ) -> None:
-    """Test AudioManager pause and resume."""
     audio_manager.pause_music()
-    mock_pygame_mixer.music.pause.assert_called_once()
+    mock_music.pause.assert_called_once()
 
     audio_manager.resume_music()
-    mock_pygame_mixer.music.unpause.assert_called_once()
-
-    audio_manager.pause_all_sfx()
-    mock_pygame_mixer.pause.assert_called_once()
-
-    audio_manager.resume_all_sfx()
-    mock_pygame_mixer.unpause.assert_called_once()
+    mock_music.unpause.assert_called_once()
 
 
-def test_audio_manager_cleanup(
-    audio_manager: AudioManager, mock_pygame_mixer: Any
+def test_audio_manager_cleanup_stops_music_and_clears_tracking(
+    audio_manager: AudioManager, mock_music: Any
 ) -> None:
-    """Test AudioManager cleanup."""
     audio_manager.play_music("music/bgm.ogg")
     audio_manager.cleanup()
 
-    # Verify music was stopped
-    mock_pygame_mixer.music.fadeout.assert_called_with(0)
-
-    # Verify tracking was cleared
+    mock_music.fadeout.assert_called_with(0)
     assert audio_manager.get_current_music() is None
 
 
 def test_audio_manager_play_sfx_clip(
-    audio_manager: AudioManager, mock_audio_clip: AudioClip
+    audio_manager: AudioManager, audio_clip: AudioClip
 ) -> None:
-    """Test AudioManager playing SFX clip."""
-    channel_id = audio_manager.play_sfx_clip(mock_audio_clip, volume=0.8)
-
-    # Verify sound was played
-    mock_audio_clip.native_handle.play.assert_called_once()
+    channel_id = audio_manager.play_sfx_clip(audio_clip, volume=0.8)
     assert channel_id is not None
+    assert pygame.mixer.Channel(channel_id).get_sound() is audio_clip.native_handle
 
 
 def test_audio_manager_stop_sfx(
-    audio_manager: AudioManager, mock_pygame_mixer: Any
+    audio_manager: AudioManager, audio_clip: AudioClip
 ) -> None:
-    """Test AudioManager stopping SFX channel."""
-    audio_manager.stop_sfx(0)
+    channel_id = audio_manager.play_sfx_clip(audio_clip, loops=-1)
+    assert channel_id is not None
+    audio_manager.stop_sfx(channel_id)
+    assert not pygame.mixer.Channel(channel_id).get_busy()
 
-    mock_pygame_mixer.Channel.assert_called_once_with(0)
-    mock_pygame_mixer.Channel.return_value.stop.assert_called_once()
 
-
-# ========== Integration Tests ==========
+# ========== Integration ==========
 
 
 def test_full_audio_workflow(
-    audio_manager: AudioManager,
-    mock_audio_clip: AudioClip,
-    mock_pygame_mixer: Any,
+    audio_manager: AudioManager, audio_clip: AudioClip, mock_music: Any
 ) -> None:
-    """Test a complete audio workflow."""
-    # Set volumes
     audio_manager.set_master_volume(0.8)
     audio_manager.set_sfx_volume(0.7)
     audio_manager.set_music_volume(0.5)
 
-    # Play music
     audio_manager.play_music("music/bgm.ogg", loop=True)
-    assert (
-        audio_manager.is_music_playing() or not audio_manager.is_music_playing()
-    )  # Depends on mock
-
-    # Play SFX
-    channel = audio_manager.play_sfx_clip(mock_audio_clip, volume=1.0)
+    channel = audio_manager.play_sfx_clip(audio_clip, volume=1.0)
     assert channel is not None
+    assert pygame.mixer.Channel(channel).get_busy()
 
-    # Pause everything
     audio_manager.pause_music()
     audio_manager.pause_all_sfx()
-
-    # Resume everything
     audio_manager.resume_music()
     audio_manager.resume_all_sfx()
 
-    # Stop music
     audio_manager.stop_music()
     assert audio_manager.get_current_music() is None
 
-    # Cleanup
     audio_manager.cleanup()

--- a/tests/test_audio_components.py
+++ b/tests/test_audio_components.py
@@ -162,10 +162,16 @@ class TestAudioSourceSystem:
 
     @pytest.fixture
     def audio_system(self):
-        """Create a mock audio system."""
+        """Create a mock audio system.
+
+        `is_channel_active` defaults to True: unless a test says otherwise the
+        sound is treated as still playing, so the frame-by-frame reconcile in
+        AudioSourceSystem is a no-op.
+        """
         mock = MagicMock()
         mock.play_sfx.return_value = 1  # Return channel ID
         mock.play_sfx_at_position.return_value = 2
+        mock.is_channel_active.return_value = True
         return mock
 
     @pytest.fixture
@@ -467,3 +473,133 @@ class TestAudioSourceSystem:
         assert emitter.played is True
         audio_system.play_sfx.assert_called()  # Non-spatial
         audio_system.play_sfx_at_position.assert_not_called()
+
+    # ---- finished-sound reconciliation (D8) -------------------------------
+
+    def _play_started_source(self, entity_manager, system, **source_kwargs):
+        entity = entity_manager.create_entity()
+        entity.add_component(Transform(position=Vector2(0, 0)))
+        source = AudioSource(clip_path="s.wav", spatial=False, **source_kwargs)
+        entity.add_component(source)
+        source.play()
+        system.update(0.016)
+        return entity, source
+
+    def test_finished_oneshot_is_reconciled(
+        self, entity_manager, audio_system, resource_manager, system
+    ):
+        """When the backend reports the channel is no longer active, the
+        source stops claiming it is playing (a one-shot ends with no
+        callback, so nothing else clears this)."""
+        _, source = self._play_started_source(entity_manager, system)
+        assert source._channel_id is not None and source.is_playing
+
+        audio_system.is_channel_active.return_value = False
+        system.update(0.016)
+
+        assert source._channel_id is None
+        assert source.is_playing is False
+
+    def test_finished_oneshot_no_longer_mixes_the_dead_channel(
+        self, entity_manager, audio_system, resource_manager, system
+    ):
+        """A stale channel id must stop receiving spatial mix updates once
+        the sound has ended -- otherwise it rewrites whatever now owns it."""
+        entity = entity_manager.create_entity()
+        entity.add_component(Transform(position=Vector2(50, 0)))
+        source = AudioSource(clip_path="s.wav", spatial=True)
+        entity.add_component(source)
+        source.play()
+        system.update(0.016)  # channel 2
+        system.update(0.016)  # spatial mix pushed
+        assert audio_system.set_channel_mix.called
+
+        audio_system.set_channel_mix.reset_mock()
+        audio_system.is_channel_active.return_value = False
+        system.update(0.016)
+        system.update(0.016)
+
+        audio_system.set_channel_mix.assert_not_called()
+
+    def test_finished_oneshot_can_be_replayed(
+        self, entity_manager, audio_system, resource_manager, system
+    ):
+        """After a one-shot ends, calling play() again actually restarts it
+        (the channel id no longer sticks)."""
+        _, source = self._play_started_source(entity_manager, system)
+        audio_system.is_channel_active.return_value = False
+        system.update(0.016)  # reconcile -> cleared
+
+        audio_system.is_channel_active.return_value = True
+        audio_system.play_sfx.reset_mock()
+        source.play()
+        system.update(0.016)
+
+        audio_system.play_sfx.assert_called_once()
+        assert source._channel_id is not None
+
+    def test_looping_source_is_not_reconciled_away(
+        self, entity_manager, audio_system, resource_manager, system
+    ):
+        """A looping source stays active as long as the backend says so."""
+        _, source = self._play_started_source(entity_manager, system, loop=True)
+        for _ in range(5):
+            system.update(0.016)
+        assert source._channel_id is not None
+        assert source.is_playing
+
+    # ---- auto_play latch (exposed by D8's fix) --------------------------
+
+    def test_auto_play_fires_once_not_again_after_the_sound_ends(
+        self, entity_manager, audio_system, resource_manager, system
+    ):
+        """auto_play is 'play on awake', not 'loop': once the one-shot ends
+        and is reconciled, it must not restart on its own."""
+        entity = entity_manager.create_entity()
+        entity.add_component(Transform(position=Vector2(0, 0)))
+        source = AudioSource(clip_path="s.wav", spatial=False, auto_play=True)
+        entity.add_component(source)
+
+        system.update(0.016)
+        assert audio_system.play_sfx.call_count == 1
+
+        audio_system.is_channel_active.return_value = False
+        system.update(0.016)  # reconcile
+        for _ in range(3):
+            system.update(0.016)
+
+        assert audio_system.play_sfx.call_count == 1  # never re-triggered
+
+    def test_failed_load_does_not_retry_every_frame(
+        self, entity_manager, audio_system, resource_manager, system
+    ):
+        """A source whose clip fails to load latches instead of hammering
+        the loader once per frame."""
+        resource_manager.load.side_effect = Exception("missing")
+        entity = entity_manager.create_entity()
+        entity.add_component(Transform(position=Vector2(0, 0)))
+        source = AudioSource(clip_path="nope.wav", spatial=False, auto_play=True)
+        entity.add_component(source)
+
+        for _ in range(5):
+            system.update(0.016)
+
+        assert resource_manager.load.call_count == 1
+
+    def test_channel_id_zero_is_honoured(
+        self, entity_manager, audio_system, resource_manager, system
+    ):
+        """Channel id 0 is a real channel: an auto_play source already on
+        channel 0 is not treated as 'no channel' and re-triggered."""
+        audio_system.play_sfx.return_value = 0
+        entity = entity_manager.create_entity()
+        entity.add_component(Transform(position=Vector2(0, 0)))
+        source = AudioSource(clip_path="s.wav", spatial=False, auto_play=True)
+        entity.add_component(source)
+
+        system.update(0.016)
+        system.update(0.016)
+        system.update(0.016)
+
+        assert source._channel_id == 0
+        assert audio_system.play_sfx.call_count == 1

--- a/tests/test_spatial_audio.py
+++ b/tests/test_spatial_audio.py
@@ -111,6 +111,22 @@ class TestSpatialAudioConfig:
         assert config.rolloff_factor == 0.5
         assert config.pan_strength == 0.8
 
+    def test_zero_reference_distance_is_rejected(self) -> None:
+        """reference_distance == 0 would divide by zero in calculate_pan."""
+        with pytest.raises(ValueError, match="reference_distance"):
+            SpatialAudioConfig(reference_distance=0.0)
+
+    def test_max_distance_must_exceed_reference_distance(self) -> None:
+        """An inverted range is a hard volume cliff, not a soft rolloff."""
+        with pytest.raises(ValueError, match="max_distance"):
+            SpatialAudioConfig(max_distance=50.0, reference_distance=100.0)
+
+    def test_negative_factors_are_rejected(self) -> None:
+        with pytest.raises(ValueError, match="rolloff_factor"):
+            SpatialAudioConfig(rolloff_factor=-1.0)
+        with pytest.raises(ValueError, match="pan_strength"):
+            SpatialAudioConfig(pan_strength=-0.5)
+
 
 class TestSpatialAudioAttenuation:
     """Test distance-based attenuation calculations."""


### PR DESCRIPTION
Subsystem audit — `pyguara/audio` (see `REFACTOR_STATE.md`). Independent branch off `main`; not stacked.

## Phase A — defects (each reproduced against the real pygame-ce mixer before fixing)

- **F1 — SFX playback was dead end to end.** `PygameAudioSystem._play_sound` read the channel id with `played_channel.get_id()`; pygame-ce's `Channel` has no `get_id()` (it is `.id`). Every real `play_sfx`/`play_sfx_at_position` raised `AttributeError`, was swallowed by `except (AttributeError, Exception)`, and returned `None` while the sound played on untracked — invisible to priority stealing, `set_channel_mix`, `stop_sfx`. Hidden because all 107 audio tests `patch("pygame.mixer")` wholesale or pass a `MagicMock` as the `Sound` (the "mock away the unit under test" smell).
- **F2 — loudness/pan set on the shared `Sound`, not the channel.** The `ResourceManager` hands every concurrent play of one clip the same `Sound`, so `sound.set_volume()` for one spatial instance rewrote every other. Now applied to the channel via `_set_channel_volume`.
- **F3 — recycled channel kept the previous sound's hard pan** (pan was only applied when `abs(pan) > 0.01`). Fixed by F2's unconditional channel volume.
- **F4 — `AudioSourceSystem` never detected a finished one-shot.** `is_playing` reported `True` forever, a non-looping source could not be replayed, and the stale channel id kept receiving `set_channel_mix` — landing on whatever recycled the channel. New `IAudioSystem.is_channel_active(channel)` (get_busy + get_sound identity), reconciled every frame.
- **F5 — the F4 fix exposed an `auto_play` retrigger storm** + a latent falsy-`0` bug: `not source._channel_id` treated channel id `0` as "no channel". Added an `_auto_played` latch; guards use `is None`. Failed clip loads now latch instead of retrying per frame.
- **F6 — `SpatialAudioConfig` had no validation.** `max_distance=0` → `ZeroDivisionError` in `calculate_pan`; inverted range → attenuation cliff. `__post_init__` rejects it.
- Added `IAudioSystem.shutdown()` (idempotent `pygame.mixer.quit()`), wired into `Application.shutdown()` — the mixer was never torn down. Removed dead `AudioManager._active_channels`.

## Phase B — tests (+20; 1658 → 1678, fix commit alone 1676)

`test_audio.py` rewritten to drive the real dummy-driver mixer with real `Sound` buffers (only `pygame.mixer.music` stays mocked). `test_audio_components.py` gains finished-sound / replay / latch / channel-0 coverage. `test_spatial_audio.py` gains the validation cases. `test_audio_backend.py::test_play_sfx_mock` given a real `Sound`.

## Phase C — docs

New `docs/systems/audio.md` (the subsystem had no page): the three layers, the SFX channel contract (id `0` is valid), the one-shot lifecycle, spatial components + `SpatialAudioConfig` rules, buses, and the documented limitation that a bus/master volume change does not re-mix already-playing non-spatial SFX.

## Verification

`pytest` 1678 pass · `ruff check .` clean · `ruff format --check` clean · `mypy pyguara` clean · `mkdocs build --strict` exit 0. Fix commit verified standalone in a detached worktree.

PR is final — nothing else coming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5