### PR TITLE
refactor(animation): honest tween value types, frame catch-up, one-shot completion

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -63,9 +63,30 @@ how the subject is *constructed*, not just what is asserted.
 
 ## Active Subsystem
 
-**None — `pyguara/audio` closed 2026-09-08 (branch `refactor/audio-audit`).**
-Next in the queue is `pyguara/animation`. Open `REFACTOR_STATE.md` "How to
-resume" and take it.
+**None — `pyguara/animation` closed 2026-09-08 (branch
+`refactor/animation-audit`).** Next in the queue is `pyguara/resources`
+(loaders, meta, hot reload). Open `REFACTOR_STATE.md` "How to resume" and
+take it.
+
+`pyguara/animation` in one slice, both halves (tween/easing in
+`pyguara/animation`, and the sprite-animation FSM in
+`pyguara/graphics/{animation_system.py,components/animation.py}`, only
+"surveyed" during the graphics audit): **`Tween` accepted only `float`
+scalars and `tuple`s** — `Tween(0, 100, 1.0)` (int), a `list`, mixed
+int/float, or a `Color` all constructed fine then crashed on the first
+`update()` with a bare `AssertionError` (`_interpolate` used
+`assert isinstance(x, float)` as runtime validation). `Tween` was a
+value-equality `@dataclass`, so `TweenManager.remove(b)` removed an equal-
+but-different tween `a`. `Animator.update()` advanced at most one frame per
+call (`if`, not `while`), so a lag spike dropped frames and drifted
+permanently behind. `AnimationStateMachine` re-fired `on_complete` and the
+transition check every frame a non-looping clip sat finished (a callback
+storm for any terminal state). `AnimationClip` had no validation
+(`frame_rate=0` → `ZeroDivisionError`, `frames=[]` → `IndexError`).
+`TransitionCondition.IMMEDIATE` was declared but `_check_transitions()` had
+no branch for it. `Scene.update_animations()` — documented as the way to
+tick animations — double-updated everything now that `AnimationSystem` is
+auto-registered; removed. See the iteration log entry below.
 
 `pyguara/audio` in one slice: **SFX playback was dead end to end** —
 `PygameAudioSystem._play_sound` called `Channel.get_id()`, which pygame-ce
@@ -172,7 +193,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
       (branch `refactor/physics-queries-sleep-close`)
 - [x] `pyguara/input` — input manager, rebinding *(done)*
 - [x] `pyguara/audio` — audio manager, spatial audio *(done)*
-- [ ] `pyguara/animation` — tween, easing, FSM
+- [x] `pyguara/animation` — tween, easing, FSM *(done)*
 - [ ] `pyguara/resources` — loaders, meta, hot reload
 - [ ] `pyguara/persistence` — save/load, migration
 - [ ] `pyguara/ai` — FSM, steering, pathfinding, navmesh, behaviour trees
@@ -193,6 +214,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/animation` | 2026-09-08 | One slice, both halves (`pyguara/animation` tween+easing, plus the sprite-animation FSM in `pyguara/graphics` only surveyed during the graphics audit). **`Tween` accepted only `float` scalars / `tuple`s**: `Tween(0, 100, 1.0)`, a `list`, mixed int/float, or a `Color` constructed fine then crashed on first `update()` with a bare `AssertionError` (`_interpolate` used `assert isinstance(x, float)` as validation, stripped under `-O`). `Tween` was a value-equality `@dataclass`, so `TweenManager.remove(b)` removed an equal-but-different `a` — now `@dataclass(eq=False)`. `Animator.update()` advanced ≤1 frame per call (`if`, not `while`) so a lag spike dropped frames and drifted behind forever while `_current_time` grew unbounded — now O(1) catch-up. `AnimationStateMachine` re-fired `on_complete` + the transition check every frame a non-looping clip sat finished (callback storm for any terminal state) — fixed with a `_completion_handled` latch reset on transition. `AnimationClip` gained `__post_init__` validation (`frame_rate<=0` → `ZeroDivisionError`, `frames=[]` → `IndexError`). `TransitionCondition.IMMEDIATE` was declared but `_check_transitions()` had no branch — now honoured (fires on entry). `Scene.update_animations()` removed: its docstring told games to call it from `scene.update()`, but `AnimationSystem` has been auto-registered on the scene's `SystemManager` since wayfinder ticket 24, so following the docs double-updated every animation; it had no real callers. Recurring shapes: "assert as runtime validation", "identity vs value" (the gamepad-index shape), "one advance per frame" (the audio/application shape), the `on_complete` retrigger storm (audio F5), "no `__post_init__`" (audio F6 / physics config), "declared and wired to nothing" (`IMMEDIATE`), and uniform test setup — every tween test used float `0.0→100.0`, every FSM test stepped `dt == 1/frame_rate` exactly and stopped updating on the completion frame. Left open: a single huge `dt` still resolves only one loop boundary per `Tween.update()` (catches up over later frames, documented); `Color` tweening unsupported (documented); `_allow_methods = True` on both FSM components stays CC-6. |
 | `pyguara/audio` | 2026-09-08 | One slice. **SFX playback was dead end to end**: the pygame backend called `Channel.get_id()` (pygame-ce has `Channel.id`), so every real `play_sfx`/`play_sfx_at_position` raised, was swallowed by `except (AttributeError, Exception)`, and returned `None` while the sound played on untracked — hidden because all 107 audio tests `patch("pygame.mixer")` wholesale. Loudness/pan were set on the ResourceManager-shared `Sound` not the channel, so concurrent plays of one clip corrupted each other and recycled channels kept the last sound's hard pan. `AudioSourceSystem` never detected a finished one-shot — `is_playing` lied forever, a source could not be replayed, and stale channel ids kept receiving spatial mix updates meant for whatever reused the channel; fixed with a new `IAudioSystem.is_channel_active()` reconciled each frame, plus an `_auto_played` latch (auto_play is "on awake", not loop — the fix exposed a retrigger storm). `SpatialAudioConfig` gained `__post_init__` validation (0 → `ZeroDivisionError` in `calculate_pan`; inverted range → attenuation cliff). Added `IAudioSystem.shutdown()` (idempotent `pygame.mixer.quit()`), wired into `Application.shutdown()`. Recurring shapes: "mock away the unit under test" (the whole `test_audio.py`) and "declared and wired to nothing" (`AudioManager._active_channels`, removed). Left open: bus/master volume changes don't re-mix already-playing non-spatial SFX (mixer limitation, documented). |
 | `pyguara/input` | 2026-09-08 | One slice. `InputContext` was inert end to end — `InputManager._context` was pinned to `GAMEPLAY` with no setter, so three of four contexts and the `context=` arg on `bind_input()` could never fire; `test_context_switching` only passed by poking the private attr. Gamepad identity was the pygame device index, not the SDL instance id, so unplugging a non-last pad flagged the wrong one and kept a stale handle. `rebind(SWAP)` returned `SWAPPED` when the action had no prior key and it had really just unbound the other; `RebindResult.CONFLICT` was unreachable (ERROR raises). `OnAction`/`OnRawKey`/`OnMouse` events were frozen at `timestamp=0.0` — the idiom the `events` audit already killed. Recurring shapes again: "declared and wired to nothing" (contexts, the whole rebind/serialize surface has no `InputManager` entry point — added `bindings`) and uniform test setup (every gamepad test unplugged only the last pad; every swap test pre-bound both actions). Phase B also found the softer test smells — assertions on `_controllers` privates, `assert x is not None` on a list literal, `assert not raises` as the only check — and rewrote them. `input/manager.py` stays a CC-11 / issue #9 offender (raw pygame events) — parked. |
 | `pyguara/physics` | 2026-09-08 | Judged as *game* physics. Four slices: substepping stops ordinary-speed tunnelling (PR #24); characters moved off dynamic bodies onto `CharacterMover`/`CharacterBody` with full parity — knockback, platform riding, crate pushing — on Celeste's integer+remainder model (PR #25); trigger volumes and the entire `Joint` ECS layer were both inert end to end and were rebuilt and tested (PR #27); the close added five spatial queries, body sleeping, kept `substeps` at 4 on benchmark evidence, and froze `PhysicsMaterial`. Recurring shape: "declared and wired to nothing" (`fixed_rotation`, `gravity_scale`, the `return False` collision contract, `Joint`, `TriggerVolume`) and uniform test setup (every test a slow body already at rest). |
@@ -392,6 +414,138 @@ convert to explicit `is None` checks as each subsystem is audited.
 ---
 
 ## Iteration Log
+
+### `pyguara/animation` — CLOSED 2026-09-08 (branch `refactor/animation-audit`)
+
+One slice, ~1,100 lines across both halves: `pyguara/animation/{easing,tween}.py`
+and the sprite-animation FSM in
+`pyguara/graphics/{animation_system.py,components/animation.py}` — the latter
+was only "read and probed on degenerate input" during graphics slice 5, never
+audited. Every defect was reproduced with a probe against the real code before
+being touched.
+
+**Verification:** 1714 tests pass (up from 1678; +36 across the three
+animation test files, 102 → 138). `ruff check .` clean; `ruff format --check`
+clean; `mypy pyguara` clean across 224 files; `mkdocs build --strict` exit 0;
+`test_docs_api.py` (52) passes. Each commit verified standalone in a detached
+worktree.
+
+**F1 — `Tween` accepted only `float` scalars and `tuple`s.**
+`Tween(0, 100, 1.0)` (int — the natural call), a `list`, mixed int/float, and
+`Color` all constructed fine, then crashed on the first `update()` with a
+bare `AssertionError` (empty message): `_interpolate` used
+`assert isinstance(self.start_value, float)` as runtime validation.
+`__post_init__` checked tuple-vs-tuple shape and length but never that a
+scalar was a number, and never rejected a non-`tuple` sequence. Under `-O`
+the asserts vanish and `list` misbehaves silently. Fixed: `__post_init__`
+classifies each endpoint as number-or-sequence (`_is_scalar` / `_is_sequence`
+`TypeGuard`s), rejects anything else (`Color`) with a clear `TypeError`, and
+`_interpolate` handles `int`/`list` without asserts. `Vector2` keeps working
+(it is a `pymunk.Vec2d`, a `tuple` subclass) but yields a plain `tuple` —
+documented.
+
+**F2 — `Tween` was a value-equality `@dataclass`.** Two independently
+created tweens with identical config compared `==`, so
+`TweenManager.remove(b)` removed the first equal element `a` (returned
+`True`, left `b`); `TweenManager.update()`'s internal `self._tweens.remove`
+had the same hazard. Bites any bag of identical fire-and-forget tweens
+(fade-outs, hit flashes). `@dataclass(eq=False)` restores identity equality
+(and makes `Tween` hashable again). "Identity vs value" — the gamepad-index
+shape from the `input` audit.
+
+**F3 — `Animator.update()` advanced at most one frame per call.** `if
+self._current_time >= seconds_per_frame`, not `while`. A 10fps clip given
+`update(0.5)` advanced one frame, not five; `_current_time` then climbed
+unbounded (0.4, 0.8, …). Any host slower than the clip's `frame_rate`, or any
+lag spike, silently dropped frames and fell permanently behind; a
+non-looping clip's `is_finished` was delayed arbitrarily. Replaced with an
+O(1) whole-frames-owed computation that wraps a looping clip with `%` and
+clamps a non-looping one to the last frame. Same "one advance per frame"
+shape as the audio one-shot reconciliation and the `application` event
+budget.
+
+**F4 — `AnimationStateMachine` re-fired `on_complete` and re-ran
+`_check_transitions()` every frame while a non-looping clip sat finished.**
+`Animator.is_finished` latches `True` for a non-looping clip until a new clip
+plays; the FSM gated purely on that flag. A terminal state with no
+`ANIMATION_END` transition (a death pose) → `on_complete` called 60×/s
+(probe: 9 calls in 10 frames). Fixed with a `_completion_handled` latch,
+reset in `transition_to()`. Exact shape of the audio F5 `_auto_played` latch.
+
+**F5 — `AnimationClip` had no validation.** `frame_rate=0` →
+`ZeroDivisionError` mid-`update()`; `frame_rate<0` → advances every frame,
+`_current_time` drifts negative; `frames=[]` → `IndexError` in `_apply_frame`
+on `play()`. `__post_init__` rejects all three at construction. Same
+"no `__post_init__`" pattern as `SpatialAudioConfig` (audio F6) and
+`PhysicsConfig`.
+
+**F6 — `TransitionCondition.IMMEDIATE` was declared but unreachable.**
+`_check_transitions()` only handled `ANIMATION_END`, and was only *called*
+when `is_finished`. An `IMMEDIATE` transition in a state's `transitions` list
+was silently never taken (probe: A→B IMMEDIATE, stuck in A). Now
+`_check_transitions()` runs every frame and honours `IMMEDIATE` (fires on the
+tick after entry) as well as `ANIMATION_END` (fires on finish); still one
+transition per update, priority-ordered. "Declared and wired to nothing."
+
+**F7 — `Scene.update_animations()` removed.** Its docstring Example told
+games to call it from `scene.update()`. But `AnimationSystem` has been
+auto-registered on every scene's `SystemManager` (priority 300, ticked at the
+fixed timestep) since wayfinder ticket 24 (`a934c8f`) — later than this
+method (`76a0203`). Following the doc updated every animation **twice per
+frame** (once fixed-rate, once variable-rate). Zero real callers. Touches
+`pyguara/scene`, but it is squarely a stale animation API.
+
+**F8 (Phase C) — `docs/systems/animation.md` was wrong.** Its usage example
+tweened `Vector2` and claimed `Color` works (`Color` crashes; `Vector2`
+yields a bare tuple); it said the `TweenManager` "is handled automatically by
+the `AnimationSystem`" — `AnimationSystem` never touches `TweenManager` and
+nothing in the engine does, so a reader got a tween that never advanced;
+easing, `Animator`, `AnimationClip` and the entire state machine were
+undocumented. Rewritten to cover both halves accurately, including the
+"you must tick `TweenManager` yourself" note, the identity-equality
+guarantee, the frame catch-up, the once-per-completion callback, and
+`IMMEDIATE` vs `ANIMATION_END`. `test_docs_api` won't catch a behavioural
+claim like this — CC-10 family.
+
+**Phase B — verdict on the 102 existing tests (+36; nothing rewritten
+wholesale, three `AnimationSystem` asserts moved off private state).**
+
+*`test_animation_easing.py` (48) — the strong file.* Endpoints for every
+`EasingType`, ease-in monotonicity, elastic/back overshoot, `ease()` input
+clamping, `isinstance(result, float)`. Real assertions on real returns
+through the public surface. Only gap was the two properties it never pinned:
+`ease_out` as the mirror of `ease_in`, and midpoint continuity for the
+`ease_in_out_*` family. Added both (10 params each).
+
+*`test_animation_tween.py` (30) — broad but uniform.* Every test built the
+subject with `start_value=0.0, end_value=100.0` (float) or `(0.0, 0.0)`
+tuples — never an int, list, `Vector2` or `Color`, so F1 was unreachable.
+Every `TweenManager` removal/query test used a single tween or tweens with
+deliberately *different* duration/end so no two were ever equal — F2
+invisible. `test_infinite_loop` stepped exactly one `duration` per `update()`
+so big-`dt` was never exercised. Added `TestTweenValueTypes` (int / mixed /
+list / `Vector2` / `Color`-rejected / str-rejected), two identity-isolation
+tests for the manager, and a test pinning the single-huge-`dt` one-cycle
+catch-up.
+
+*`test_animation_fsm.py` (24) — mixed.* `test_animator_is_finished` and the
+auto-transition tests stepped a uniform 10fps clip at `dt == 0.1` exactly, so
+F3 had no test that could see it; `test_state_machine_on_complete_callback`
+stopped updating *on* the completion frame, so F4's storm was invisible.
+`IMMEDIATE`, empty frames and zero `frame_rate` untested. The three
+`AnimationSystem` tests asserted on `animator._current_frame_index` (private
+— the tracker's named smell). Added multi-frame catch-up, the non-looping
+large-`dt` clamp, held-past-completion (fires once), replay re-arms,
+`IMMEDIATE`-on-entry, and `AnimationClip` validation; the `AnimationSystem`
+asserts now observe the driven `Sprite.texture`.
+
+**Left open.** A single `Tween.update(dt)` spanning many loops still resolves
+one loop boundary and carries the overshoot forward (catches up over the next
+few frames, no state lost) — a proper fix raises per-cycle-callback design
+questions; documented and pinned by a test. `Color` tweening is unsupported
+(tween its components / packed tuple) — documented. `_allow_methods = True`
+on `Animator` and `AnimationStateMachine` stays CC-6. `ease()` rebuilds its
+dispatch dict on every call — micro-perf, not touched.
 
 ### `pyguara/audio` — CLOSED 2026-09-08 (branch `refactor/audio-audit`)
 

--- a/docs/systems/animation.md
+++ b/docs/systems/animation.md
@@ -1,40 +1,184 @@
-# Animation System
+# Animation
 
-The Animation system (`pyguara.animation`) provides powerful tweening capabilities for smooth state transitions.
+PyGuara's animation code comes in two independent halves:
+
+| Half | Module | Animates |
+| --- | --- | --- |
+| **Tweening** | `pyguara.animation` | any number or sequence of numbers over time |
+| **Sprite animation** | `pyguara.graphics.components.animation` | a `Sprite`'s texture, frame by frame |
+
+They share nothing but the name. Pick whichever fits; a project often uses both.
+
+---
 
 ## Tweening
 
-The `Tween` class allows you to animate any numeric property (float or tuple of floats) over time using easing functions.
-
-### Features
-
-*   **Flexible Targets**: Animate `Vector2`, `Color`, or simple `float` values.
-*   **Easing Functions**: Includes standard easings (Linear, EaseInQuad, EaseOutBounce, etc.).
-*   **Lifecycle Control**: Start, Pause, Resume, Stop, and Loop animations.
-*   **Yoyo Mode**: Automatically reverse animation on loop.
-*   **Callbacks**: `on_update` and `on_complete` hooks.
-
-### Usage
+A `Tween` interpolates a value from `start_value` to `end_value` over
+`duration` seconds, shaped by an easing function.
 
 ```python
-from pyguara.animation.tween import Tween, TweenManager
-from pyguara.animation.easing import EasingType
+from pyguara.animation import Tween, TweenManager, EasingType
 
-# Create a tween
 tween = Tween(
-    start_value=Vector2(0, 0),
-    end_value=Vector2(100, 100),
+    start_value=(0.0, 0.0),
+    end_value=(100.0, 50.0),
     duration=1.0,
     easing=EasingType.EASE_OUT_QUAD,
-    loops=-1,  # Infinite
-    yoyo=True  # Ping-pong
 )
-
-# Register with manager (usually injected)
-tween_manager.add(tween)
 tween.start()
+
+# every frame:
+tween.update(dt)
+x, y = tween.current_value
 ```
 
-## Integration
+### Endpoint types
 
-The `TweenManager` should be updated every frame. In a standard setup, this is handled automatically by the `AnimationSystem`.
+The two endpoints must have the **same shape**:
+
+* **two numbers** (`int` or `float`) &mdash; `current_value` is a `float`;
+* **two equal-length sequences** of numbers (`tuple` or `list`) &mdash;
+  `current_value` is a `tuple`.
+
+`Vector2` is a `tuple` subclass, so it tweens &mdash; but you get a plain
+`tuple` back, so wrap it if you need the type: `Vector2(*tween.current_value)`.
+`Color` and other non-sequence objects are **not** supported; tween their
+components, or the packed `(r, g, b, a)` tuple. A mismatched or unsupported
+endpoint raises at construction, not mid-playback.
+
+### Lifecycle
+
+| Call | Effect |
+| --- | --- |
+| `start()` | begin (or restart from the top) |
+| `pause()` / `resume()` | freeze / unfreeze; `update()` still returns "alive" |
+| `stop()` | reset to `IDLE`; `update()` becomes a no-op until `start()` |
+| `update(dt)` | advance; returns `False` once the tween has completed |
+
+Read-only: `current_value`, `progress` (0&ndash;1), `is_playing`, `is_complete`.
+
+### Delay, loops, yoyo
+
+* `delay` &mdash; seconds to wait after `start()` before the first movement.
+  Applied once; loop repeats do not re-wait.
+* `loops` &mdash; `0` plays once, `-1` loops forever, `N` plays once and then
+  repeats `N` more times (`N + 1` playthroughs total).
+* `yoyo` &mdash; on each loop, swap the direction instead of snapping back to
+  the start, so the value ping-pongs.
+* `on_update(value)` fires every frame the tween moves; `on_complete()` fires
+  once, only at final completion (never on an intermediate loop, never on an
+  infinite loop).
+
+A single `update(dt)` whose `dt` spans several whole loops resolves **one**
+loop boundary and carries the remaining time forward, catching up over the
+next few frames rather than firing every boundary at once. Clamp `dt` upstream
+if a lag spike must not stutter a tween.
+
+### TweenManager
+
+`TweenManager` owns a bag of tweens, ticks them, and drops each one when it
+completes.
+
+```python
+from pyguara.animation import Tween, TweenManager
+
+manager = TweenManager()
+manager.add(tween)   # returns the tween, for chaining
+tween.start()
+
+# in your system's update():
+manager.update(dt)
+```
+
+**Nothing in the engine updates a `TweenManager` for you** &mdash; call
+`manager.update(dt)` from a system or scene you own. Two `Tween` instances are
+equal only when they are the *same* object, so a manager can hold many
+identically configured tweens (five enemies flashing white) without them
+aliasing each other. `pause_all()`, `resume_all()`, `stop_all()`, `clear()`,
+`tween_count` and `active_tweens` round out the surface. `stop_all()` also
+clears; a tween that is `add()`ed but never `start()`ed (or is `stop()`ped)
+stays in the bag until you `remove()` or `clear()` it.
+
+### Easing
+
+`pyguara.animation.easing` provides `EasingType` and 31 functions across the
+usual families &mdash; quad, cubic, quart, quint, sine, expo, circ, elastic,
+back, bounce, each in in / out / in-out. Call one directly, or go through
+`ease(t, easing_type)`, which clamps `t` to `[0, 1]` first. Elastic and back
+deliberately overshoot outside `[0, 1]`; the rest stay within it.
+
+---
+
+## Sprite animation
+
+A **clip** is an ordered list of textures plus a frame rate. An **`Animator`**
+plays one clip at a time and writes the current frame onto a `Sprite`.
+
+```python
+from pyguara.graphics.components.animation import AnimationClip, Animator
+
+animator = Animator(sprite)
+animator.add_clip(AnimationClip("run", run_frames, frame_rate=12.0, loop=True))
+animator.add_clip(AnimationClip("hit", hit_frames, frame_rate=20.0, loop=False))
+
+animator.play("run")             # no-op if "run" is already playing
+animator.play("run", force_reset=True)  # restart from frame 0
+```
+
+`AnimationClip` rejects an empty frame list or a non-positive `frame_rate` at
+construction. `Animator.update(dt)` catches up **every** whole frame the `dt`
+covers, so a lag spike or a host slower than the clip's `frame_rate` does not
+drop frames or drift behind. A non-looping clip stops on its last frame;
+`is_finished` then reports `True` (and `is_playing` `False`). `play()` an
+unknown clip name logs a warning and does nothing.
+
+### State machine
+
+`AnimationStateMachine` sits on top of an `Animator`: one **state** per clip,
+with transitions between them.
+
+```python
+from pyguara.graphics.components.animation import (
+    AnimationState,
+    AnimationStateMachine,
+    AnimationTransition,
+    TransitionCondition,
+)
+
+fsm = AnimationStateMachine(sprite, animator)
+fsm.add_state(AnimationState("idle", idle_clip))
+fsm.add_state(
+    AnimationState(
+        "attack",
+        attack_clip,
+        transitions=[
+            AnimationTransition(
+                "attack", "idle", TransitionCondition.ANIMATION_END
+            )
+        ],
+        on_complete=lambda: print("attack done"),
+    )
+)
+fsm.set_default_state("idle")     # enters the state and starts its clip
+
+fsm.transition_to("attack")      # manual switch; returns False if already there
+```
+
+* `AnimationState` carries `on_enter`, `on_exit` and `on_complete` callbacks.
+  `on_complete` fires **once** when a non-looping clip finishes, not every
+  frame it then sits on its last frame; re-entering the state re-arms it.
+* `AnimationTransition.condition` is either `ANIMATION_END` (fires once the
+  state's clip finishes) or `IMMEDIATE` (fires on the tick after the state is
+  entered &mdash; useful for a one-shot intro that hands off to a loop).
+  `priority` breaks ties; the highest-priority eligible transition wins, and
+  at most one transition fires per update.
+* `current_state_name` reports where the machine is.
+
+### AnimationSystem
+
+`AnimationSystem` is registered automatically on every `Scene`'s
+`SystemManager` (priority 300) and ticked at the fixed timestep. Each tick it
+updates every `AnimationStateMachine`, then every standalone `Animator` whose
+entity does **not** also have a state machine (the machine drives its own
+animator). You do not call it, and you should not update animators a second
+time from scene code.

--- a/pyguara/animation/tween.py
+++ b/pyguara/animation/tween.py
@@ -1,9 +1,9 @@
 """Tween system for animating values over time."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Any
+from typing import Any, TypeGuard
 
 from pyguara.animation.easing import EasingType, ease
 
@@ -17,11 +17,31 @@ class TweenState(Enum):
     COMPLETE = auto()
 
 
-@dataclass
+def _is_scalar(value: object) -> TypeGuard[float]:
+    """Return True for a plain number (int/float, but not bool)."""
+    return isinstance(value, int | float) and not isinstance(value, bool)
+
+
+def _is_sequence(value: object) -> TypeGuard[Sequence[float]]:
+    """Return True for a tuple/list of values (Vector2 is a tuple subclass)."""
+    return isinstance(value, tuple | list)
+
+
+@dataclass(eq=False)
 class Tween:
     """Animates a value from start to end over a duration.
 
     Supports different easing functions, delays, loops, and callbacks.
+
+    The endpoints must be either two numbers (``int``/``float``) or two
+    equal-length sequences of numbers (``tuple``/``list``). ``Vector2`` works
+    because it is a ``tuple`` subclass, but ``current_value`` is then a plain
+    ``tuple`` -- wrap it if you need the original type back. ``Color`` and
+    other non-sequence objects are not supported; tween their components.
+
+    Two ``Tween`` instances are equal only if they are the *same* object, so a
+    ``TweenManager`` can hold many identically configured tweens without them
+    aliasing each other.
 
     Example:
         >>> # Animate position from (0, 0) to (100, 50) over 1 second
@@ -58,17 +78,34 @@ class Tween:
         if self.duration <= 0:
             raise ValueError("Duration must be positive")
 
-        # Ensure start and end have same structure
-        if isinstance(self.start_value, tuple) != isinstance(self.end_value, tuple):
+        # Reject types that are neither a number nor a sequence (e.g. Color).
+        for label, value in (
+            ("start_value", self.start_value),
+            ("end_value", self.end_value),
+        ):
+            if not _is_sequence(value) and not _is_scalar(value):
+                raise TypeError(
+                    f"{label} must be a number or a sequence of numbers, "
+                    f"got {type(value).__name__}"
+                )
+
+        start_seq = _is_sequence(self.start_value)
+        end_seq = _is_sequence(self.end_value)
+
+        # Ensure start and end have the same shape.
+        if start_seq != end_seq:
             raise ValueError(
-                "start_value and end_value must both be float or both be tuple"
+                "start_value and end_value must both be numbers or both be sequences"
             )
 
-        if isinstance(self.start_value, tuple) and isinstance(self.end_value, tuple):
-            if len(self.start_value) != len(self.end_value):
-                raise ValueError(
-                    "start_value and end_value tuples must have same length"
-                )
+        if (
+            _is_sequence(self.start_value)
+            and _is_sequence(self.end_value)
+            and len(self.start_value) != len(self.end_value)
+        ):
+            raise ValueError(
+                "start_value and end_value sequences must have the same length"
+            )
 
     def start(self) -> None:
         """Start or restart the tween."""
@@ -138,21 +175,18 @@ class Tween:
         return self.state == TweenState.PLAYING
 
     def _interpolate(self, t: float) -> None:
-        """Interpolate between start and end values."""
-        if isinstance(self.start_value, tuple) and isinstance(self.end_value, tuple):
-            # Tuple interpolation
+        """Interpolate between start and end values.
+
+        Sequence endpoints always yield a plain ``tuple``; scalar endpoints
+        always yield a ``float`` (``__post_init__`` guarantees the shapes match).
+        """
+        start, end = self.start_value, self.end_value
+        if _is_sequence(start) and _is_sequence(end):
             self.current_value = tuple(
-                self.start_value[i] + (self.end_value[i] - self.start_value[i]) * t
-                for i in range(len(self.start_value))
+                s + (e - s) * t for s, e in zip(start, end, strict=True)
             )
-        else:
-            # Scalar interpolation
-            # At this point both must be floats due to validation in __post_init__
-            assert isinstance(self.start_value, float)
-            assert isinstance(self.end_value, float)
-            self.current_value = (
-                self.start_value + (self.end_value - self.start_value) * t
-            )
+        elif _is_scalar(start) and _is_scalar(end):
+            self.current_value = start + (end - start) * t
 
     def _handle_completion(self) -> None:
         """Handle tween completion and looping."""

--- a/pyguara/graphics/components/animation.py
+++ b/pyguara/graphics/components/animation.py
@@ -21,6 +21,16 @@ class AnimationClip:
     frame_rate: float = 10.0  # Frames per second
     loop: bool = True
 
+    def __post_init__(self) -> None:
+        """Reject clips that cannot be played (empty, or non-positive rate)."""
+        if not self.frames:
+            raise ValueError(f"AnimationClip '{self.name}' has no frames")
+        if self.frame_rate <= 0:
+            raise ValueError(
+                f"AnimationClip '{self.name}' frame_rate must be positive, "
+                f"got {self.frame_rate}"
+            )
+
 
 class Animator(BaseComponent):
     """Component that manages playback of AnimationClips.
@@ -79,31 +89,38 @@ class Animator(BaseComponent):
         self._apply_frame()
 
     def update(self, dt: float) -> None:
-        """Advance the animation timer."""
+        """Advance the animation timer.
+
+        Catches up all whole frames owed for ``dt`` in one call, so a lag
+        spike or a host running slower than the clip's ``frame_rate`` does not
+        silently drop frames or fall permanently behind.
+        """
         if not self._playing or not self._current_clip:
             return
 
         self._current_time += dt
 
-        # Calculate duration of a single frame
+        # Duration of a single frame; frame_rate is > 0 (AnimationClip validates).
         seconds_per_frame = 1.0 / self._current_clip.frame_rate
+        if self._current_time < seconds_per_frame:
+            return
 
-        if self._current_time >= seconds_per_frame:
-            # Move to next frame
-            self._current_time -= seconds_per_frame
-            self._current_frame_index += 1
+        frames_advanced = int(self._current_time / seconds_per_frame)
+        self._current_time -= frames_advanced * seconds_per_frame
 
-            # Handle Looping
-            total_frames = len(self._current_clip.frames)
+        total_frames = len(self._current_clip.frames)
+        raw_index = self._current_frame_index + frames_advanced
 
-            if self._current_frame_index >= total_frames:
-                if self._current_clip.loop:
-                    self._current_frame_index = 0
-                else:
-                    self._current_frame_index = total_frames - 1
-                    self._playing = False  # Stop at end
+        if raw_index < total_frames:
+            self._current_frame_index = raw_index
+        elif self._current_clip.loop:
+            self._current_frame_index = raw_index % total_frames
+        else:
+            self._current_frame_index = total_frames - 1
+            self._current_time = 0.0
+            self._playing = False  # Stop at end
 
-            self._apply_frame()
+        self._apply_frame()
 
     def _apply_frame(self) -> None:
         """Update the visual Sprite component with the current texture."""
@@ -209,6 +226,9 @@ class AnimationStateMachine(BaseComponent):
         self._states: dict[str, AnimationState] = {}
         self._current_state: AnimationState | None = None
         self._default_state: str | None = None
+        # Latch so on_complete / ANIMATION_END fire once per clip completion,
+        # not every frame the finished clip sits on its last frame.
+        self._completion_handled: bool = False
 
     def add_state(self, state: AnimationState) -> None:
         """
@@ -264,6 +284,7 @@ class AnimationStateMachine(BaseComponent):
 
         # Enter new state
         self._current_state = target_state
+        self._completion_handled = False
 
         # Call on_enter callback
         if target_state.on_enter:
@@ -287,14 +308,15 @@ class AnimationStateMachine(BaseComponent):
         if not self._current_state:
             return
 
-        # Check if animation finished
-        if self._animator.is_finished:
-            # Call on_complete callback
+        # Fire the completion callback once, on the frame the clip finishes.
+        if self._animator.is_finished and not self._completion_handled:
+            self._completion_handled = True
             if self._current_state.on_complete:
                 self._current_state.on_complete()
 
-            # Check for automatic transitions
-            self._check_transitions()
+        # Check for automatic transitions every frame (IMMEDIATE fires as soon
+        # as the state is entered; ANIMATION_END only once the clip finishes).
+        self._check_transitions()
 
     def _check_transitions(self) -> None:
         """Check if any transitions should trigger based on current conditions."""
@@ -307,15 +329,14 @@ class AnimationStateMachine(BaseComponent):
         )
 
         for transition in sorted_transitions:
-            # Check if condition is met
-            should_transition = False
+            should_transition = (
+                transition.condition == TransitionCondition.IMMEDIATE
+                or (
+                    transition.condition == TransitionCondition.ANIMATION_END
+                    and self._animator.is_finished
+                )
+            )
 
-            if transition.condition == TransitionCondition.ANIMATION_END:
-                # Transition when animation finishes
-                if self._animator.is_finished:
-                    should_transition = True
-
-            # Execute transition if condition met
             if should_transition:
                 self.transition_to(transition.to_state)
                 break  # Only execute one transition per update

--- a/pyguara/scene/base.py
+++ b/pyguara/scene/base.py
@@ -13,7 +13,6 @@ from pyguara.ecs.events import EntityDestroyed
 from pyguara.ecs.manager import EntityManager
 from pyguara.events.dispatcher import EventDispatcher
 from pyguara.graphics.animation_system import AnimationSystem
-from pyguara.graphics.components.animation import AnimationStateMachine, Animator
 from pyguara.graphics.components.camera import Camera2D
 from pyguara.graphics.components.sprite import Sprite
 from pyguara.graphics.pipeline.render_system import RenderSystem
@@ -128,33 +127,6 @@ class Scene(ABC):
             entity: The entity that was just removed.
         """
         self.event_dispatcher.dispatch(EntityDestroyed(entity=entity, source=self))
-
-    def update_animations(self, dt: float) -> None:
-        """
-        Update all animation components in the scene.
-
-        Automatically updates all Animator and AnimationStateMachine components.
-        Call this in your scene's update() method to enable automatic animation updates.
-
-        Args:
-            dt (float): Delta time in seconds.
-
-        Example:
-            def update(self, dt: float) -> None:
-                self.update_animations(dt)  # Update all animations
-                # ... rest of scene logic
-        """
-        # Update AnimationStateMachine components (higher priority)
-        for entity in self.entity_manager.get_entities_with(AnimationStateMachine):
-            fsm = entity.get_component(AnimationStateMachine)
-            fsm.update(dt)
-
-        # Update standalone Animator components (if not controlled by FSM)
-        for entity in self.entity_manager.get_entities_with(Animator):
-            # Skip if entity also has AnimationStateMachine (FSM updates animator)
-            if not entity.has_component(AnimationStateMachine):
-                animator = entity.get_component(Animator)
-                animator.update(dt)
 
     @abstractmethod
     def on_enter(self) -> None:

--- a/tests/test_animation_easing.py
+++ b/tests/test_animation_easing.py
@@ -258,6 +258,63 @@ class TestEaseFunction:
             assert ease(1.0, easing_type) == pytest.approx(1.0, abs=1e-6)
 
 
+class TestEasingReflection:
+    """ease_out(t) should be the mirror of ease_in: 1 - ease_in(1 - t)."""
+
+    @pytest.mark.parametrize(
+        ("in_type", "out_type"),
+        [
+            (EasingType.EASE_IN_QUAD, EasingType.EASE_OUT_QUAD),
+            (EasingType.EASE_IN_CUBIC, EasingType.EASE_OUT_CUBIC),
+            (EasingType.EASE_IN_QUART, EasingType.EASE_OUT_QUART),
+            (EasingType.EASE_IN_QUINT, EasingType.EASE_OUT_QUINT),
+            (EasingType.EASE_IN_SINE, EasingType.EASE_OUT_SINE),
+            (EasingType.EASE_IN_EXPO, EasingType.EASE_OUT_EXPO),
+            (EasingType.EASE_IN_CIRC, EasingType.EASE_OUT_CIRC),
+            (EasingType.EASE_IN_BACK, EasingType.EASE_OUT_BACK),
+            (EasingType.EASE_IN_BOUNCE, EasingType.EASE_OUT_BOUNCE),
+        ],
+    )
+    def test_out_is_mirror_of_in(self, in_type, out_type):
+        """ease_out(t) == 1 - ease_in(1 - t) across the domain."""
+        for i in range(21):
+            t = i / 20.0
+            assert ease(t, out_type) == pytest.approx(
+                1.0 - ease(1.0 - t, in_type), abs=1e-9
+            )
+
+
+class TestEaseInOutContinuity:
+    """The ease_in_out_* family must not jump at the t=0.5 handover."""
+
+    @pytest.mark.parametrize(
+        "easing_type",
+        [
+            EasingType.EASE_IN_OUT_QUAD,
+            EasingType.EASE_IN_OUT_CUBIC,
+            EasingType.EASE_IN_OUT_QUART,
+            EasingType.EASE_IN_OUT_QUINT,
+            EasingType.EASE_IN_OUT_SINE,
+            EasingType.EASE_IN_OUT_EXPO,
+            EasingType.EASE_IN_OUT_CIRC,
+            EasingType.EASE_IN_OUT_BACK,
+            EasingType.EASE_IN_OUT_BOUNCE,
+            EasingType.EASE_IN_OUT_ELASTIC,
+        ],
+    )
+    def test_no_discontinuity_at_midpoint(self, easing_type):
+        """The two piecewise halves must meet at t=0.5 (no jump).
+
+        A tiny epsilon keeps steep-but-continuous curves (circ has a vertical
+        tangent here) from reading as a break; a real piecewise bug jumps by
+        ~0.1 or more.
+        """
+        below = ease(0.5 - 1e-9, easing_type)
+        above = ease(0.5 + 1e-9, easing_type)
+        assert below == pytest.approx(above, abs=1e-3)
+        assert ease(0.5, easing_type) == pytest.approx(0.5, abs=1e-2)
+
+
 class TestEasingMonotonicity:
     """Test that ease-in functions are monotonically increasing."""
 

--- a/tests/test_animation_fsm.py
+++ b/tests/test_animation_fsm.py
@@ -34,6 +34,22 @@ class MockTexture(Texture):
         return None
 
 
+# ===== AnimationClip Tests =====
+
+
+def test_animation_clip_rejects_empty_frames():
+    """A clip with no frames cannot be played -- reject it at construction."""
+    with pytest.raises(ValueError, match="has no frames"):
+        AnimationClip("broken", [], frame_rate=10.0)
+
+
+@pytest.mark.parametrize("rate", [0.0, -10.0])
+def test_animation_clip_rejects_nonpositive_frame_rate(rate):
+    """frame_rate <= 0 is a ZeroDivisionError / reversed playback waiting to happen."""
+    with pytest.raises(ValueError, match="frame_rate must be positive"):
+        AnimationClip("broken", [MockTexture()], frame_rate=rate)
+
+
 # ===== Animator Tests =====
 
 
@@ -56,6 +72,38 @@ def test_animator_properties():
     assert animator.is_playing is True
     assert animator.current_clip_name == "idle"
     assert animator.is_finished is False
+
+
+def test_animator_catches_up_multiple_frames_in_one_update():
+    """A dt larger than one frame period should advance every frame it covers."""
+    sprite = Sprite(MockTexture())
+    animator = Animator(sprite)
+    frames = [MockTexture(f"run_{i}") for i in range(8)]
+    animator.add_clip(AnimationClip("run", frames, frame_rate=10.0, loop=True))
+    animator.play("run")
+
+    # 10 FPS => 0.1s/frame. A 0.45s lag spike should land on frame 4, not 1.
+    animator.update(0.45)
+    assert sprite.texture is frames[4]
+
+    # A dt that wraps past the end of a looping clip lands correctly.
+    animator.update(0.6)  # +6 frames from 4 => 10 => wraps to 2
+    assert sprite.texture is frames[2]
+
+
+def test_animator_non_looping_clamps_on_a_large_dt():
+    """A huge dt on a non-looping clip stops on the last frame, not past it."""
+    sprite = Sprite(MockTexture())
+    animator = Animator(sprite)
+    frames = [MockTexture(f"a_{i}") for i in range(3)]
+    animator.add_clip(AnimationClip("attack", frames, frame_rate=10.0, loop=False))
+    animator.play("attack")
+
+    animator.update(5.0)  # far past the 0.3s clip
+
+    assert sprite.texture is frames[-1]
+    assert animator.is_playing is False
+    assert animator.is_finished is True
 
 
 def test_animator_is_finished():
@@ -324,6 +372,82 @@ def test_state_machine_on_complete_callback():
     assert len(completed) == 1
 
 
+def test_state_machine_on_complete_fires_once_when_held_past_completion():
+    """A terminal state must not re-fire on_complete every subsequent frame."""
+    sprite = Sprite(MockTexture())
+    animator = Animator(sprite)
+    fsm = AnimationStateMachine(sprite, animator)
+
+    completed = []
+    clip = AnimationClip(
+        "death",
+        [MockTexture(f"death_{i}") for i in range(2)],
+        frame_rate=10.0,
+        loop=False,
+    )
+    # No ANIMATION_END transition: the FSM will sit on this finished clip.
+    state = AnimationState("death", clip, on_complete=lambda: completed.append(True))
+    fsm.add_state(state)
+    fsm.set_default_state("death")
+
+    for _ in range(20):
+        fsm.update(0.1)
+
+    assert completed == [True]  # exactly one, not one-per-frame
+
+
+def test_state_machine_on_complete_refires_after_replaying_the_state():
+    """Re-entering a terminal state arms its completion callback again."""
+    sprite = Sprite(MockTexture())
+    animator = Animator(sprite)
+    fsm = AnimationStateMachine(sprite, animator)
+
+    completed = []
+    clip = AnimationClip(
+        "hit", [MockTexture(f"hit_{i}") for i in range(2)], frame_rate=10.0, loop=False
+    )
+    fsm.add_state(AnimationState("hit", clip, on_complete=lambda: completed.append(1)))
+    fsm.set_default_state("hit")
+
+    for _ in range(5):
+        fsm.update(0.1)
+    assert len(completed) == 1
+
+    fsm.transition_to("hit", force=True)  # replay
+    for _ in range(5):
+        fsm.update(0.1)
+    assert len(completed) == 2
+
+
+def test_state_machine_immediate_transition_fires_on_entry():
+    """An IMMEDIATE transition in a state's list is taken on the next update."""
+    sprite = Sprite(MockTexture())
+    animator = Animator(sprite)
+    fsm = AnimationStateMachine(sprite, animator)
+
+    intro_to_loop = AnimationTransition(
+        from_state="intro",
+        to_state="loop",
+        condition=TransitionCondition.IMMEDIATE,
+    )
+    fsm.add_state(
+        AnimationState(
+            "intro",
+            AnimationClip("intro", [MockTexture("intro")], loop=True),
+            transitions=[intro_to_loop],
+        )
+    )
+    fsm.add_state(
+        AnimationState("loop", AnimationClip("loop", [MockTexture("loop")], loop=True))
+    )
+
+    fsm.set_default_state("intro")
+    assert fsm.current_state_name == "intro"
+
+    fsm.update(0.016)
+    assert fsm.current_state_name == "loop"
+
+
 def test_state_machine_transition_priority():
     """State machine should respect transition priority."""
     sprite = Sprite(MockTexture())
@@ -381,23 +505,19 @@ def test_animation_system_updates_animator():
     sprite = Sprite(MockTexture())
     animator = Animator(sprite)
 
-    clip = AnimationClip(
-        "idle", [MockTexture(f"idle_{i}") for i in range(4)], frame_rate=10.0
-    )
-    animator.add_clip(clip)
+    frames = [MockTexture(f"idle_{i}") for i in range(4)]
+    animator.add_clip(AnimationClip("idle", frames, frame_rate=10.0))
     animator.play("idle")
-
-    assert animator._current_frame_index == 0
+    assert sprite.texture is frames[0]
 
     entity_manager = EntityManager()
     entity = entity_manager.create_entity()
     entity.add_component(animator)
 
-    system = AnimationSystem(entity_manager)
-    system.update(0.1)
+    AnimationSystem(entity_manager).update(0.1)
 
-    # Animator should have advanced to the next frame
-    assert animator._current_frame_index == 1
+    # One frame period elapsed -> the driven sprite shows the next frame.
+    assert sprite.texture is frames[1]
 
 
 def test_animation_system_updates_state_machine():
@@ -408,53 +528,42 @@ def test_animation_system_updates_state_machine():
     animator = Animator(sprite)
     fsm = AnimationStateMachine(sprite, animator)
 
-    clip = AnimationClip(
-        "idle", [MockTexture(f"idle_{i}") for i in range(4)], frame_rate=10.0
+    frames = [MockTexture(f"idle_{i}") for i in range(4)]
+    fsm.add_state(
+        AnimationState("idle", AnimationClip("idle", frames, frame_rate=10.0))
     )
-    state = AnimationState("idle", clip)
-    fsm.add_state(state)
     fsm.set_default_state("idle")
-
-    assert animator._current_frame_index == 0
+    assert sprite.texture is frames[0]
 
     entity_manager = EntityManager()
     entity = entity_manager.create_entity()
     entity.add_component(fsm)
 
-    system = AnimationSystem(entity_manager)
-    system.update(0.1)
+    AnimationSystem(entity_manager).update(0.1)
 
-    # State machine should have been updated (which updates the animator)
-    assert animator._current_frame_index == 1
+    assert sprite.texture is frames[1]
 
 
 def test_animation_system_prioritizes_state_machine():
-    """AnimationSystem should prioritize FSM over standalone Animator."""
+    """AnimationSystem should update an FSM-driven animator exactly once."""
     from pyguara.ecs.manager import EntityManager
 
     sprite = Sprite(MockTexture())
     animator = Animator(sprite)
     fsm = AnimationStateMachine(sprite, animator)
 
-    clip = AnimationClip(
-        "idle", [MockTexture(f"idle_{i}") for i in range(4)], frame_rate=10.0
+    frames = [MockTexture(f"idle_{i}") for i in range(4)]
+    fsm.add_state(
+        AnimationState("idle", AnimationClip("idle", frames, frame_rate=10.0))
     )
-    state = AnimationState("idle", clip)
-    fsm.add_state(state)
     fsm.set_default_state("idle")
-
-    assert animator._current_frame_index == 0
 
     entity_manager = EntityManager()
     entity = entity_manager.create_entity()
     entity.add_component(animator)
     entity.add_component(fsm)
 
-    system = AnimationSystem(entity_manager)
+    AnimationSystem(entity_manager).update(0.1)
 
-    # Should only update FSM (which updates animator internally)
-    # This prevents double-updating the animator
-    system.update(0.1)
-
-    # Verify it was updated once (should be on frame 1)
-    assert animator._current_frame_index == 1
+    # Frame 1, not frame 2: the entity's Animator is not also updated directly.
+    assert sprite.texture is frames[1]

--- a/tests/test_animation_tween.py
+++ b/tests/test_animation_tween.py
@@ -34,13 +34,15 @@ class TestTweenCreation:
             Tween(start_value=0.0, end_value=100.0, duration=-1.0)
 
     def test_mismatched_types_raises_error(self):
-        """start_value and end_value must have same type."""
-        with pytest.raises(ValueError, match="must both be float or both be tuple"):
+        """start_value and end_value must have same shape."""
+        with pytest.raises(
+            ValueError, match="must both be numbers or both be sequences"
+        ):
             Tween(start_value=0.0, end_value=(100.0, 50.0), duration=1.0)
 
     def test_mismatched_tuple_length_raises_error(self):
-        """Tuple start_value and end_value must have same length."""
-        with pytest.raises(ValueError, match="tuples must have same length"):
+        """Sequence start_value and end_value must have same length."""
+        with pytest.raises(ValueError, match="sequences must have the same length"):
             Tween(start_value=(0.0, 0.0), end_value=(100.0,), duration=1.0)
 
 

--- a/tests/test_animation_tween.py
+++ b/tests/test_animation_tween.py
@@ -4,6 +4,7 @@ import pytest
 
 from pyguara.animation.easing import EasingType
 from pyguara.animation.tween import Tween, TweenManager, TweenState
+from pyguara.common.types import Color, Vector2
 
 
 class TestTweenCreation:
@@ -44,6 +45,57 @@ class TestTweenCreation:
         """Sequence start_value and end_value must have same length."""
         with pytest.raises(ValueError, match="sequences must have the same length"):
             Tween(start_value=(0.0, 0.0), end_value=(100.0,), duration=1.0)
+
+
+class TestTweenValueTypes:
+    """Endpoints may be ints, floats, tuples or lists -- but not arbitrary objects."""
+
+    def test_int_scalar_endpoints(self):
+        """Plain-int endpoints must interpolate to a float, not crash."""
+        tween = Tween(start_value=0, end_value=100, duration=1.0)
+        tween.start()
+        tween.update(0.5)
+        assert tween.current_value == pytest.approx(50.0)
+        assert isinstance(tween.current_value, float)
+
+    def test_mixed_int_and_float_scalars(self):
+        """One int and one float endpoint is still a valid scalar tween."""
+        tween = Tween(start_value=0, end_value=100.0, duration=1.0)
+        tween.start()
+        tween.update(0.25)
+        assert tween.current_value == pytest.approx(25.0)
+
+    def test_list_endpoints_behave_like_tuple(self):
+        """A list of numbers is accepted; the result is a plain tuple."""
+        tween = Tween(start_value=[0.0, 10.0], end_value=[100.0, 20.0], duration=1.0)
+        tween.start()
+        tween.update(0.5)
+        assert tween.current_value == pytest.approx((50.0, 15.0))
+        assert isinstance(tween.current_value, tuple)
+
+    def test_vector2_endpoints_work_as_tuple(self):
+        """Vector2 is a tuple subclass, so it tweens (yielding a bare tuple)."""
+        tween = Tween(
+            start_value=Vector2(0, 0), end_value=Vector2(100, 50), duration=1.0
+        )
+        tween.start()
+        tween.update(0.5)
+        x, y = tween.current_value
+        assert (x, y) == pytest.approx((50.0, 25.0))
+
+    def test_color_endpoints_rejected(self):
+        """Color is neither number nor sequence -- reject it at construction."""
+        with pytest.raises(TypeError, match="number or a sequence of numbers"):
+            Tween(
+                start_value=Color(0, 0, 0),
+                end_value=Color(255, 255, 255),
+                duration=1.0,
+            )
+
+    def test_string_endpoint_rejected(self):
+        """Any non-number, non-sequence value is rejected with a clear error."""
+        with pytest.raises(TypeError, match="start_value must be a number"):
+            Tween(start_value="nope", end_value="also nope", duration=1.0)
 
 
 class TestTweenLifecycle:
@@ -238,6 +290,22 @@ class TestTweenLooping:
             still_playing = tween.update(1.0)
             assert still_playing is True
             assert tween.state == TweenState.PLAYING
+
+    def test_single_huge_dt_consumes_one_cycle_and_keeps_overshoot(self):
+        """A dt spanning many cycles advances one cycle now and catches up later.
+
+        This pins current behaviour: `update()` resolves at most one loop
+        boundary per call but preserves the remaining time, so subsequent
+        frames burn the backlog down rather than losing it.
+        """
+        tween = Tween(start_value=0.0, end_value=1.0, duration=0.1, loops=-1)
+        tween.start()
+
+        tween.update(1.0)  # ten durations in one frame
+
+        assert tween.current_loop == 1
+        assert tween.elapsed == pytest.approx(0.9)  # overshoot retained
+        assert tween.state == TweenState.PLAYING
 
 
 class TestTweenYoyo:
@@ -471,6 +539,33 @@ class TestTweenManager:
         removed = manager.remove(tween)
 
         assert removed is False
+
+    def test_identically_configured_tweens_do_not_alias(self):
+        """Two tweens with the same config are distinct; remove() is by identity."""
+        manager = TweenManager()
+        a = Tween(start_value=1.0, end_value=0.0, duration=0.3)
+        b = Tween(start_value=1.0, end_value=0.0, duration=0.3)
+        manager.add(a)
+        manager.add(b)
+
+        assert manager.remove(b) is True
+        remaining = manager.active_tweens
+        assert len(remaining) == 1
+        assert remaining[0] is a  # not b, and not "some equal tween"
+
+    def test_auto_remove_drops_the_finished_instance_not_an_equal_one(self):
+        """update() must reap the exact tween that finished, not an equal sibling."""
+        manager = TweenManager()
+        finished = Tween(start_value=0.0, end_value=1.0, duration=1.0)
+        idle_twin = Tween(start_value=0.0, end_value=1.0, duration=1.0)
+        finished.start()  # idle_twin is left IDLE
+        manager.add(finished)
+        manager.add(idle_twin)
+
+        manager.update(1.0)  # `finished` completes; `idle_twin` never started
+
+        assert manager.tween_count == 1
+        assert manager.active_tweens[0] is idle_twin
 
     def test_update_all_tweens(self):
         """Should update all tweens."""


### PR DESCRIPTION
Subsystem audit iteration for **`pyguara/animation`** — both halves: tween/easing in `pyguara/animation`, and the sprite-animation FSM in `pyguara/graphics/{animation_system.py,components/animation.py}` that was only *surveyed* during the graphics audit. Independent branch off `main`; not stacked on anything.

Every defect was reproduced with a probe against the real code before being fixed. Full suite **1714 pass** (up from 1678); `ruff check .`, `ruff format --check`, `mypy pyguara` (224 files), `mkdocs build --strict`, `test_docs_api` all clean. The `fix:` and `test:` commits were each verified standalone in a detached worktree (1678 / 1714).

## Phase A — fixes (`77e968a`)

- **`Tween` accepted only `float` scalars and `tuple`s.** `Tween(0, 100, 1.0)` (int), a `list`, mixed int/float, or a `Color` all constructed fine then crashed on the first `update()` with a bare `AssertionError` — `_interpolate` used `assert isinstance(x, float)` as runtime validation (stripped under `-O`). `__post_init__` now classifies each endpoint as number-or-sequence, rejects anything else (`Color`) with a clear `TypeError`, and `_interpolate` handles `int`/`list` without asserts. `Vector2` keeps working (tuple subclass), yielding a plain tuple.
- **`Tween` was a value-equality `@dataclass`**, so `TweenManager.remove(b)` removed an equal-but-different tween `a`. Now `@dataclass(eq=False)` — identity equality — so a manager can hold many identically configured tweens without them aliasing.
- **`Animator.update()` advanced at most one frame per call** (`if`, not `while`): a lag spike or a host slower than the clip's `frame_rate` silently dropped frames and drifted permanently behind while `_current_time` grew unbounded. Now catches up every whole frame owed for `dt` in O(1).
- **`AnimationStateMachine` re-fired `on_complete`** and the transition check every frame a non-looping clip sat finished (a callback storm for any terminal state). A `_completion_handled` latch, reset on transition, fires it once.
- **`AnimationClip` had no validation:** `frame_rate=0` → `ZeroDivisionError`, `frame_rate<0` → runs backwards, `frames=[]` → `IndexError` on `play()`. A `__post_init__` rejects all three at construction.
- **`TransitionCondition.IMMEDIATE` was declared but `_check_transitions()` had no branch for it** — silently never taken. The check now runs every frame and honours `IMMEDIATE` (fires on entry) as well as `ANIMATION_END`.
- **`Scene.update_animations()` removed.** Its docstring told games to call it from `scene.update()`, but `AnimationSystem` has been auto-registered on the scene's `SystemManager` (priority 300, fixed timestep) since wayfinder ticket 24 — following the docs double-updated every animation. Zero real callers. (Touches `pyguara/scene`; squarely a stale animation API.)

## Phase B — tests (`3a311a6`, +36; 102 → 138)

Recurring blind spot again: **uniform setup**. Every tween test built the subject with float `0.0 → 100.0`, so int/list/`Color` endpoints were unreachable; `TweenManager` removal tests always used tweens with different config, so two equal tweens never coexisted. Every FSM test stepped `dt == 1/frame_rate` exactly and stopped updating on the completion frame, so the frame ceiling and the `on_complete` storm had no test that could see them. Three `AnimationSystem` asserts were on `animator._current_frame_index` (private) — rewritten onto the driven `Sprite.texture`.

Added: `TestTweenValueTypes`, manager identity-isolation, single-huge-`dt` catch-up, easing reflection + `ease_in_out_*` midpoint continuity, `Animator` multi-frame catch-up + non-looping clamp, held-past-completion (fires once) + replay re-arms, `IMMEDIATE`-on-entry, `AnimationClip` validation.

## Phase C — docs (`74655e7`, `8910b17`)

`docs/systems/animation.md` covered only tweening and got it wrong (tweened `Vector2`/`Color`, claimed `AnimationSystem` ticks the `TweenManager` — it doesn't, nothing does). Rewritten to cover both halves accurately. Tracker updated.

## Left open

- A single `Tween.update(dt)` spanning many loops still resolves one loop boundary and carries the overshoot forward (catches up over later frames, no state lost) — a full fix raises per-cycle-callback design questions. Documented and pinned by a test.
- `Color` tweening unsupported (tween its components) — documented.
- `_allow_methods = True` on `Animator` / `AnimationStateMachine` stays CC-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5