### PR TITLE
refactor(resources): asset lifecycle, .meta pipeline, docs

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -63,10 +63,58 @@ how the subject is *constructed*, not just what is asserted.
 
 ## Active Subsystem
 
-**None — `pyguara/animation` closed 2026-09-08 (branch
-`refactor/animation-audit`).** Next in the queue is `pyguara/resources`
-(loaders, meta, hot reload). Open `REFACTOR_STATE.md` "How to resume" and
-take it.
+**None — `pyguara/resources` closed 2026-09-08 (branch
+`refactor/resources-audit`).** Next in the queue is `pyguara/persistence`
+(save/load, migration). Open `REFACTOR_STATE.md` "How to resume" and take it.
+
+`pyguara/resources` in one slice, ~1,100 lines (`manager`, `meta`,
+`loader`, `types`, `data`, `data_loader`, `exceptions`; hot reload itself
+lives downstream in `pyguara/dev`). No headline crash like audio's dead
+SFX — the subsystem was in better shape — but the same recurring shapes.
+**Reference counting was internally inconsistent and wired to nothing**:
+`load()` auto-incremented on every call including cache hits, `release()`
+auto-unloaded at 0, so `unload_unused()` ("cleanup between scenes") could
+never evict a resource anything used and a released one was already gone —
+dead code. No engine caller of acquire/release/unload/unload_unused;
+`AudioManager` `load()`s per play, so the count climbed forever.
+`Resource._ref_count` was a *third*, entirely dead counter. Reworked (user
+chose "fix the model + add reload()"): `load()` is a pure cache-get, the
+resource enters unpinned (0); `acquire()`/`release()` pin; `unload_unused()`
+now meaningfully sweeps. `index_directory()` **silently resolved a stem
+collision to whichever file the walk hit last** — now the ambiguous bare
+stem is dropped with a warning, full-name keys always win. `MetaLoader`
+**cached parsed meta by path with no invalidation** (stale after a disk
+change — wrong under hot reload) and the path-only key **swallowed the
+`expected_type` mismatch warning** after the first call — now mtime-pinned
++ re-read on change + `invalidate()`, and the type check runs every call.
+`DataResource`'s docstring claimed "hot-reloaded by the ResourceManager"
+with **no reload API** — added `ResourceManager.reload()` (re-run loader,
+re-read `.meta`, swap in place, keep count). The **`.meta` import pipeline
+was ~70% scaffolding** (`AudioMeta`/`SpritesheetMeta` had no consumer, GL
+loader hardcoded `LINEAR`) — wired end to end per the user's choice:
+`Resource.import_meta` carries the resolved sidecar, `GLTextureLoader`
+honours `filter` (and its default flips to `NEAREST`, matching the pygame
+path — the two backends disagreed), the audio backend applies
+`AudioMeta.volume_db` as a per-asset channel gain, `SpriteSheet` gained
+`margin`/`spacing` (previously meaningless everywhere) + `slice_from_meta`.
+Recurring shapes: "declared and wired to nothing" (the whole ref-count
+half; `AudioMeta`; `_ref_count`), "identity vs value" absent here, and
+uniform test setup — `test_resources.py` asserted on `_reference_counts` /
+`_cache` / `_path_index` privates and hand-poked an impossible state into
+`test_unload_unused`; every `test_meta.py` test used a fresh `MetaLoader()`
+so the stale-cache bug had no test that could see it. See the iteration
+log entry below.
+
+**Left open.** `AudioMeta.loop_start/loop_end/normalize/load_mode`,
+`TextureMeta.mipmaps/wrap_s/wrap_t` still have no consumer — they need
+streaming / DSP / GL-state work past a single slice (authoring-layer gap,
+sibling of #37). Under the new lifecycle the audio system should
+`acquire()` clips it wants to survive a between-scene `unload_unused()` —
+a small `pyguara/audio` follow-up (no behaviour change today: nothing
+calls `unload_unused()` yet). `ResourceManager` has no lock on
+`_cache`/`_reference_counts` (check-then-act) — no concurrent caller exists,
+parked as CC. `load_atlas()` still re-parses its JSON on every call (no
+`Atlas` cache) — perf nicety, not a defect.
 
 `pyguara/animation` in one slice, both halves (tween/easing in
 `pyguara/animation`, and the sprite-animation FSM in
@@ -194,7 +242,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 - [x] `pyguara/input` — input manager, rebinding *(done)*
 - [x] `pyguara/audio` — audio manager, spatial audio *(done)*
 - [x] `pyguara/animation` — tween, easing, FSM *(done)*
-- [ ] `pyguara/resources` — loaders, meta, hot reload
+- [x] `pyguara/resources` — loaders, meta, hot reload *(done)*
 - [ ] `pyguara/persistence` — save/load, migration
 - [ ] `pyguara/ai` — FSM, steering, pathfinding, navmesh, behaviour trees
 
@@ -214,6 +262,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/resources` | 2026-09-08 | One slice (`manager`, `meta`, `loader`, `types`, `data`, `data_loader`; hot reload lives downstream in `pyguara/dev`). No headline crash — better shape than recent subsystems — but the recurring shapes held. **Reference counting was internally inconsistent and wired to nothing**: `load()` auto-incremented on every call incl. cache hits, `release()` auto-unloaded at 0, so `unload_unused()` could never evict anything in use and a released resource was already gone — dead. No engine caller of acquire/release/unload/unload_unused; `AudioManager` `load()`s per play → count climbs forever. `Resource._ref_count` was a *third* dead counter. Reworked (user: "fix the model + add reload()"): `load()` is a pure cache-get → unpinned (0); `acquire()`/`release()` pin; `unload_unused()` now sweeps. `index_directory()` **silently resolved a stem collision to the last file walked** — now the ambiguous bare stem is dropped with a warning, full-name keys always win. `MetaLoader` **cached parsed meta by path with no invalidation** (stale after a disk change — wrong under hot reload) and the path-only key **swallowed the `expected_type` mismatch warning** after the first call — now mtime-pinned + re-read + `invalidate()`, check runs every call. `DataResource` docstring claimed "hot-reloaded by the ResourceManager" with **no reload API** — added `ResourceManager.reload()` (re-run loader, re-read `.meta`, swap in place, keep count). The **`.meta` import pipeline was ~70% scaffolding** (`AudioMeta`/`SpritesheetMeta` had no consumer, GL loader hardcoded `LINEAR`) — wired end to end (user: "wire it up in this slice"): `Resource.import_meta` carries the resolved sidecar; `GLTextureLoader` honours `filter` (default flips to `NEAREST`, matching the pygame path); audio backend applies `AudioMeta.volume_db` as a per-asset channel gain; `SpriteSheet` gained `margin`/`spacing` (previously meaningless) + `slice_from_meta`. Recurring shapes: "declared and wired to nothing" (the whole ref-count half; `AudioMeta`; `_ref_count`) and uniform test setup (`test_resources.py` asserted on `_reference_counts`/`_cache`/`_path_index` privates and hand-poked an impossible state into `test_unload_unused`; every `test_meta.py` test used a fresh `MetaLoader()`). Tests +21. Left open: `AudioMeta.loop_*`/`normalize`/`load_mode`, `TextureMeta.mipmaps`/`wrap_*` still unconsumed (need streaming/DSP/GL-state — authoring-layer gap, sibling of #37); audio should `acquire()` its clips under the new model (small `pyguara/audio` follow-up, no behaviour change today); no lock on the cache dicts (no concurrent caller, parked CC). |
 | `pyguara/animation` | 2026-09-08 | One slice, both halves (`pyguara/animation` tween+easing, plus the sprite-animation FSM in `pyguara/graphics` only surveyed during the graphics audit). **`Tween` accepted only `float` scalars / `tuple`s**: `Tween(0, 100, 1.0)`, a `list`, mixed int/float, or a `Color` constructed fine then crashed on first `update()` with a bare `AssertionError` (`_interpolate` used `assert isinstance(x, float)` as validation, stripped under `-O`). `Tween` was a value-equality `@dataclass`, so `TweenManager.remove(b)` removed an equal-but-different `a` — now `@dataclass(eq=False)`. `Animator.update()` advanced ≤1 frame per call (`if`, not `while`) so a lag spike dropped frames and drifted behind forever while `_current_time` grew unbounded — now O(1) catch-up. `AnimationStateMachine` re-fired `on_complete` + the transition check every frame a non-looping clip sat finished (callback storm for any terminal state) — fixed with a `_completion_handled` latch reset on transition. `AnimationClip` gained `__post_init__` validation (`frame_rate<=0` → `ZeroDivisionError`, `frames=[]` → `IndexError`). `TransitionCondition.IMMEDIATE` was declared but `_check_transitions()` had no branch — now honoured (fires on entry). `Scene.update_animations()` removed: its docstring told games to call it from `scene.update()`, but `AnimationSystem` has been auto-registered on the scene's `SystemManager` since wayfinder ticket 24, so following the docs double-updated every animation; it had no real callers. Recurring shapes: "assert as runtime validation", "identity vs value" (the gamepad-index shape), "one advance per frame" (the audio/application shape), the `on_complete` retrigger storm (audio F5), "no `__post_init__`" (audio F6 / physics config), "declared and wired to nothing" (`IMMEDIATE`), and uniform test setup — every tween test used float `0.0→100.0`, every FSM test stepped `dt == 1/frame_rate` exactly and stopped updating on the completion frame. Left open: a single huge `dt` still resolves only one loop boundary per `Tween.update()` (catches up over later frames, documented); `Color` tweening unsupported (documented); `_allow_methods = True` on both FSM components stays CC-6. |
 | `pyguara/audio` | 2026-09-08 | One slice. **SFX playback was dead end to end**: the pygame backend called `Channel.get_id()` (pygame-ce has `Channel.id`), so every real `play_sfx`/`play_sfx_at_position` raised, was swallowed by `except (AttributeError, Exception)`, and returned `None` while the sound played on untracked — hidden because all 107 audio tests `patch("pygame.mixer")` wholesale. Loudness/pan were set on the ResourceManager-shared `Sound` not the channel, so concurrent plays of one clip corrupted each other and recycled channels kept the last sound's hard pan. `AudioSourceSystem` never detected a finished one-shot — `is_playing` lied forever, a source could not be replayed, and stale channel ids kept receiving spatial mix updates meant for whatever reused the channel; fixed with a new `IAudioSystem.is_channel_active()` reconciled each frame, plus an `_auto_played` latch (auto_play is "on awake", not loop — the fix exposed a retrigger storm). `SpatialAudioConfig` gained `__post_init__` validation (0 → `ZeroDivisionError` in `calculate_pan`; inverted range → attenuation cliff). Added `IAudioSystem.shutdown()` (idempotent `pygame.mixer.quit()`), wired into `Application.shutdown()`. Recurring shapes: "mock away the unit under test" (the whole `test_audio.py`) and "declared and wired to nothing" (`AudioManager._active_channels`, removed). Left open: bus/master volume changes don't re-mix already-playing non-spatial SFX (mixer limitation, documented). |
 | `pyguara/input` | 2026-09-08 | One slice. `InputContext` was inert end to end — `InputManager._context` was pinned to `GAMEPLAY` with no setter, so three of four contexts and the `context=` arg on `bind_input()` could never fire; `test_context_switching` only passed by poking the private attr. Gamepad identity was the pygame device index, not the SDL instance id, so unplugging a non-last pad flagged the wrong one and kept a stale handle. `rebind(SWAP)` returned `SWAPPED` when the action had no prior key and it had really just unbound the other; `RebindResult.CONFLICT` was unreachable (ERROR raises). `OnAction`/`OnRawKey`/`OnMouse` events were frozen at `timestamp=0.0` — the idiom the `events` audit already killed. Recurring shapes again: "declared and wired to nothing" (contexts, the whole rebind/serialize surface has no `InputManager` entry point — added `bindings`) and uniform test setup (every gamepad test unplugged only the last pad; every swap test pre-bound both actions). Phase B also found the softer test smells — assertions on `_controllers` privates, `assert x is not None` on a list literal, `assert not raises` as the only check — and rewrote them. `input/manager.py` stays a CC-11 / issue #9 offender (raw pygame events) — parked. |
@@ -415,6 +464,167 @@ convert to explicit `is None` checks as each subsystem is audited.
 ---
 
 ## Iteration Log
+
+### `pyguara/resources` — CLOSED 2026-09-08 (branch `refactor/resources-audit`)
+
+One slice, ~1,100 lines: `resources/{manager,meta,loader,types,data,
+exceptions}.py` + `resources/loaders/data_loader.py`. Hot reload as a
+*mechanism* lives downstream in `pyguara/dev` (Tier 4); this slice covered
+the reload primitive the ResourceManager owes it. Every defect reproduced
+with a probe against the real code first.
+
+**Verification:** 1735 tests pass (up from 1714; +21 across
+`test_resources.py` — rewritten — `test_meta.py`, `test_audio.py`,
+`test_graphics_spritesheet.py`). `ruff check .` clean; `ruff format --check`
+clean; `mypy pyguara` clean across 225 files; `mkdocs build --strict`
+exit 0; `test_docs_api.py` (52) passes. Both commits verified standalone in
+a detached worktree (`git worktree add --detach`, `uv sync --extra dev`):
+1735 / 1735.
+
+Two upfront decisions put to the user (both shape the whole PR): F1 → "fix
+the model + add `reload()`"; F4 → "wire it up in this slice".
+
+**F1 — the reference-counting lifecycle was internally inconsistent and
+wired to nothing.** `load()` auto-incremented the count on *every* call,
+including cache hits ("Auto-increment ref count on load"); `release()`
+auto-unloaded at 0. So `unload_unused()` — documented "useful for cleanup
+between scenes" — could never evict a resource anything still held (those
+are at ≥1), and a properly released one was already gone (evicted at 0). It
+was dead. Probe: `load()`×2 of one asset → count 2; `unload_unused()` → 0
+freed. No engine code calls `acquire`/`release`/`unload`/`unload_unused`;
+`AudioManager` / `AudioSourceSystem` call `load()` per play, so the
+audio-clip count climbed monotonically forever. `Resource._ref_count`
+(types.py) was a *third* counter, assigned once in `__init__` and read
+nowhere. New model: `load()` is a pure cache-get — the resource enters the
+cache **unpinned** (count 0) and a repeated `load()` does not change that;
+`acquire()`/`release()` are the explicit balanced pin API; `release()`
+below 0 raises `ValueError` ("you didn't acquire"); `unload_unused()` now
+meaningfully sweeps everything unpinned. Removed `_ref_count`.
+`test_reference_counting_basic` / `test_acquire_release` /
+`test_release_zero_refcount_error` / `test_force_unload` / `test_cache_stats`
+pinned the old model — rewritten.
+
+**F2 — `index_directory()` silently resolved a stem collision to whichever
+file the walk hit last.** `chars/hero.png` and `fx/hero.png` both claim the
+bare name `hero`; the second overwrites the first with no warning (whereas
+`register_loader` *does* warn on an extension clash). `load("hero", …)`
+then returns the wrong file. Probe confirmed. Now: on collision the
+ambiguous bare stem is removed from the index and a warning names both
+paths; the unambiguous full-name keys (`hero.png`) are always kept, so the
+caller resolves the clash with the full name or path.
+
+**F3 — `MetaLoader` cached parsed meta by path with no invalidation, and
+the cache swallowed the `expected_type` warning.** After a `.meta` changed
+on disk, `load_meta()` kept returning the stale object (probe); the only
+escape was the process-wide `clear_cache()`, which `ResourceManager` never
+called — wrong in the hot-reload context this subsystem owns. And because
+the cache key was the path alone, `load_meta(p)` then `load_meta(p,
+OtherType)` served the cached object and skipped the type-mismatch warning
+entirely. Now: each cache entry is pinned to the `.meta` file's mtime and
+re-read when it changes; a deleted file drops the entry; the
+`expected_type` check runs on *every* call including cache hits; and
+`MetaLoader.invalidate(path)` forces a re-read (called by `reload()`).
+
+**F5 — `DataResource` docstring claimed "hot-reloaded by the
+ResourceManager"; no reload API existed.** Added `ResourceManager.reload()`:
+re-runs the loader (re-reading the `.meta` sidecar via `invalidate()`),
+type-checks the result against the previously cached instance, swaps it
+into the cache in place, and preserves the reference count. Callers holding
+the *old* instance keep that stale object — documented; this is what a
+file-watching loop does. `_load_from_disk()` extracted so `load()` (miss)
+and `reload()` share the loader+meta+type-check path.
+
+**F4 — the `.meta` import pipeline was ~70% scaffolding.** `AudioMeta`
+(fully built + tested — dB math, loop points) had **no consumer**:
+`PygameSoundLoader` was not meta-aware. `SpritesheetMeta` had no consumer.
+`GLTextureLoader` was not meta-aware and hardcoded `moderngl.LINEAR`,
+ignoring `TextureMeta.get_filter_mode()` — the one setting the pygame
+loader's own comment says GL is meant to honour. Wired end to end:
+- `Resource.import_meta` — a settable slot carrying the resolved sidecar;
+  `ResourceManager._load_from_disk()` attaches it after a meta-aware load
+  so systems read import settings there instead of round-tripping the
+  manager.
+- `GLTextureLoader` is meta-aware and maps `filter` → `moderngl.NEAREST` /
+  `LINEAR`. **Its default flips from LINEAR to NEAREST** — matching the
+  pygame image path (the two backends silently disagreed) and
+  `TextureMeta`'s own default for a pixel-art engine. Called out as an
+  intentional backend-alignment change, not a silent regression.
+- `PygameSoundLoader` is meta-aware; `load_mode: stream` warns (clips via
+  the ResourceManager are always fully decoded — that is `play_music`'s
+  job). The pygame audio backend multiplies `AudioMeta.volume_db`'s linear
+  gain into the **channel** volume per play (never the shared `Sound` —
+  respecting the audio audit's D2 fix).
+- `SpriteSheet.slice_grid()` gained `margin` / `spacing` (grid maths now
+  `margin + i*(frame+spacing)`) — `SpritesheetMeta.margin`/`spacing` were
+  meaningless everywhere before — and raises on a non-positive frame size
+  instead of `ZeroDivisionError`. `SpriteSheet.slice_from_meta(meta)` reads
+  the geometry off a `SpritesheetMeta`.
+
+**Minor.** `get_cache_stats() -> dict[str, Any]` with a real field spec in
+the docstring (was bare `dict`). Portuguese comments in `manager.py` /
+`audio/backends/pygame/loaders.py` translated. `load_atlas()` now
+`acquire()`s its texture (under the new model `load()` no longer pins it,
+so `unload_unused()` could pull it out from under the atlas). Curated
+`__all__` on `pyguara.resources` and a new `loaders/__init__.py` (CC-8) —
+no import cycle exposed.
+
+**Phase B — verdict on the 69 existing tests (+21; `test_resources.py`
+rewritten, nothing else wholesale).**
+
+*`test_meta.py` (55, +5) — the strong file.* Real `tmp_path` files, real
+save/load round-trips, all through the public surface — none of the
+"mock away the filesystem" smell. Its one blind spot was **uniform
+setup**: every test built a fresh `MetaLoader()`, so nothing reloaded the
+same loader after a disk change and F3 was unreachable;
+`test_load_meta_caches_result` actively pinned the stale behaviour as
+intended. Added: reparse-on-mtime-change, drop-cache-on-delete,
+`invalidate()`, and the cache-hit `expected_type` warning.
+
+*`test_resources.py` (14 → rewritten, now ~40) — the weak file.* Decent
+behavioural coverage of ref counting, but: every test built the manager
+the same way (`MockLoader`, no real files); assertions read
+`manager._reference_counts[...]` / `._cache` / `._path_index` (the
+tracker's named private-state smell) rather than `get_cache_stats()`;
+`test_indexing` mocked `Path.rglob` (mock-away-the-filesystem — so F2 was
+unreachable); and `test_unload_unused` *hand-poked*
+`manager._reference_counts["res1.mock"] = 0` and re-inserted into `_cache`
+to manufacture a state the public API cannot produce — proving the method
+works only against an impossible input. Rewritten: real `tmp_path` files, a
+`MockLoader` that counts its own calls, assertions via `get_cache_stats()`,
+and new coverage for the F1 lifecycle, `reload()` (incl. changed meta), the
+F2 collision, and meta-aware load + `import_meta` attach through the
+manager.
+
+*`tests/test_graphics_spritesheet.py` (+3), `tests/test_audio.py` (+1).*
+`SpriteSheet` margin/spacing + `slice_from_meta` + zero-dim rejection; the
+`AudioMeta.volume_db` → channel gain path on the real dummy-driver mixer.
+`GLTextureLoader`'s filter branch is not covered — no headless GL context
+in CI (issue #19 shape: a real adapter, read-audited only).
+
+**Phase C.** `docs/systems/resources.md` (15 lines) documented `load()`,
+type safety, caching and indexing — and **nothing else**: no
+reference-counting API, no `.meta` system (a module with its own test
+file), no `reload()`, `load_atlas()` or `get_cache_stats()`. It also
+carried a stale duplicated **"Audio System"** section (`systems/audio.md`
+owns that since the audio audit) and a **"Persistence"** section belonging
+to that subsystem. Rewritten: loader table, the name index + collision
+rule, the `load()`/`acquire()`/`release()`/`unload_unused()` lifecycle,
+`reload()` and its stale-holder caveat, the `.meta` pipeline with an honest
+per-type table of what each setting *currently* affects, atlases,
+`get_cache_stats()`. Audio and persistence sections dropped —
+`pyguara/persistence` is next in the queue and gets its own page.
+
+**Left open.** `AudioMeta.loop_start` / `loop_end` / `normalize` /
+`load_mode` and `TextureMeta.mipmaps` / `wrap_s` / `wrap_t` still have no
+consumer — honoring them needs real streaming / DSP / GL-state work beyond
+a single slice (authoring-layer gap, sibling of #37). Under the new
+lifecycle the audio system should `acquire()` the clips it wants to survive
+a between-scene `unload_unused()` — a small `pyguara/audio` follow-up, no
+behaviour change today (nothing calls `unload_unused()`). `ResourceManager`
+does check-then-act on `_cache` / `_reference_counts` with no lock — no
+concurrent caller exists, parked as CC (the DI audit's shape, if resource
+loading ever moves to a background thread). `load_atlas()` still re-parses
+its JSON every call (no `Atlas` cache) — a perf nicety, not a defect.
 
 ### `pyguara/animation` — CLOSED 2026-09-08 (branch `refactor/animation-audit`)
 

--- a/docs/systems/resources.md
+++ b/docs/systems/resources.md
@@ -1,36 +1,116 @@
 # Resource Management
 
-The `ResourceManager` (`pyguara.resources`) is the central asset hub.
+The `ResourceManager` (`pyguara.resources`) is the central asset hub: one
+cache, one place that knows how to turn a file path into a typed engine
+object.
 
-## Features
+```python
+from pyguara.resources import ResourceManager, Texture
 
-- **Unified Access**: Load assets via `manager.load("path/to/asset.png", Texture)`.
-- **Type Safety**: Enforces return types (raises error if you load a Sound as a Texture).
-- **Caching**: Implements the Flyweight pattern to ensure assets are loaded only once.
-- **Indexing**: Scans directories to allow loading files by filename (e.g., "player") instead of full path.
+manager = container.get(ResourceManager)
+hero = manager.load("assets/chars/hero.png", Texture)
+```
 
-## Loaders
-The system uses the **Strategy Pattern** for loading different file types.
-- `JsonLoader`: Loads `.json` into `DataResource`.
-- `PygameImageLoader`: Loads images into `Texture`.
-- `PygameSoundLoader`: Loads audio into `AudioClip`.
+## Loading and caching
 
----
+`load(path_or_name, resource_type)` resolves the path, returns the cached
+instance on a hit, or runs the registered loader on a miss and caches the
+result. It is type-safe: asking for a `Texture` when the file loaded as an
+`AudioClip` raises `TypeError` immediately (on the miss *and* on a later
+cache hit with a mismatched type).
 
-# Audio System
+Loaders are registered per extension (the **Strategy pattern**). The
+bootstrap wires:
 
-The `IAudioSystem` (`pyguara.audio`) protocol abstracts audio playback.
+| Loader | Extensions | Produces |
+| --- | --- | --- |
+| `JsonLoader` | `.json`, `.manifest`, `.config` | `DataResource` |
+| `PygameImageLoader` / `GLTextureLoader` | `.png`, `.jpg`, `.jpeg`, `.bmp`, `.tga` | `Texture` |
+| `PygameSoundLoader` | `.wav`, `.ogg`, `.mp3` | `AudioClip` |
+| `PrefabLoader` | `.prefab` | prefab data |
 
-- **SFX**: "Fire and forget" sound effects (`play_sfx`).
-- **Music**: Streamed audio with looping and fading (`play_music`).
-- **Backends**: Currently implemented via `PygameAudioSystem`.
+Registering a second loader for an extension logs a warning and wins.
 
----
+## Naming: `index_directory`
 
-# Persistence
+`index_directory(root)` scans a tree and lets you load an asset by its bare
+name instead of its full path:
 
-The persistence layer (`pyguara.persistence`) handles Saving and Loading game data.
+```python
+manager.index_directory("assets")
+hero = manager.load("hero", Texture)          # -> assets/chars/hero.png
+```
 
-- **Serialization**: Supports JSON (default) and Binary/Pickle formats.
-- **Integrity**: Calculates MD5 checksums to detect save file corruption.
-- **Metadata**: Stores timestamps, engine version, and save version alongside data for migration support.
+Both the stem (`hero`) and the full filename (`hero.png`) are indexed. If two
+files under the tree share a stem (`chars/hero.png` and `fx/hero.png`), the
+bare name is **ambiguous**: it is dropped and a warning names both paths. The
+full-name keys still work, so load the colliding asset as `"hero.png"` or by
+its full path.
+
+## Lifecycle: reference counting
+
+A `load()` is a cache *get*, not a claim. The resource enters the cache
+**unpinned** (reference count 0), and a repeated `load()` of the same asset
+does not change that.
+
+| Call | Effect |
+| --- | --- |
+| `acquire(name)` | +1. Pin the resource so `unload_unused()` cannot evict it. |
+| `release(name)` | −1. Must balance an `acquire()`. Dropping to 0 evicts immediately. Releasing something at 0 raises `ValueError`. |
+| `unload_unused()` | Evict every resource at count 0. Call it between scenes. Returns the count freed. |
+| `unload(name, force=True)` | Evict now, whatever the count. |
+| `unload(name)` | Decrement like `release()`, but tolerant: a no-op if the name is unknown. |
+
+`acquire()` / `release()` on an unloaded name raise `KeyError`.
+
+So the pattern for an asset a scene must hold for its whole life is
+`load()` then `acquire()` in `on_enter()`, and `release()` (or a blanket
+`unload_unused()`) in `on_exit()`.
+
+## Hot reload: `reload`
+
+`reload(name)` re-runs the loader for a cached resource, re-reading its
+`.meta` sidecar too, and swaps the new instance into the cache. The
+reference count is preserved.
+
+Callers that already hold the **previous** instance keep that stale object —
+`reload()` swaps the cache entry, it does not mutate the old object. Call
+`load()` again after a reload to pick up the new one. This is what a
+file-watching hot-reload loop does.
+
+## `.meta` sidecar import settings
+
+An asset `hero.png` can carry a sibling `hero.png.meta` (JSON) describing how
+to import it. A meta-aware loader receives the parsed settings; the resolved
+object is also attached to the resource as `resource.import_meta` for systems
+that need it after load.
+
+```json
+{ "type": "texture", "filter": "nearest", "premultiply_alpha": true }
+```
+
+`type` may be omitted when the extension implies it (`.png` → `texture`,
+`.ogg` → `audio`). Unknown fields are ignored; an invalid file logs a warning
+and is treated as "no meta". The `MetaLoader` caches by path and re-reads
+when the file's mtime changes; `MetaLoader.invalidate(path)` forces a re-read
+and `save_meta()` writes one back.
+
+| Meta type | Fields | What currently consumes it |
+| --- | --- | --- |
+| `TextureMeta` | `filter`, `premultiply_alpha`, `srgb`, `mipmaps`, `wrap_s`, `wrap_t` | `PygameImageLoader` applies `premultiply_alpha`/`srgb`; `GLTextureLoader` applies `filter` (nearest ↔ linear). `mipmaps`/`wrap_*` are not applied yet. |
+| `AudioMeta` | `volume_db`, `load_mode`, `loop_start`, `loop_end`, `normalize` | The audio system applies `volume_db` as a per-asset gain per play. `load_mode: stream` warns (clips are always fully decoded — use `play_music`). `loop_*`/`normalize` are not applied yet. |
+| `SpritesheetMeta` | `frame_width`, `frame_height`, `margin`, `spacing`, `filter` | `SpriteSheet.slice_from_meta(meta)` reads the grid geometry (`margin`/`spacing` included). `filter` is not applied. |
+
+## Atlases
+
+`load_atlas(texture_path, json_path)` loads a packed-sprite texture plus a
+JSON region map and returns an `Atlas`. It `acquire()`s the underlying
+texture so `unload_unused()` will not pull it out from under the atlas; drop
+it with `unload(texture_path, force=True)`. A malformed region map raises
+`InvalidMetadataError` with line/column info.
+
+## Introspection
+
+`get_cache_stats()` returns `{"resource_count", "total_references",
+"resources": {path: {"type", "ref_count"}}}` — useful for a debug overlay or
+a leak check between scenes.

--- a/pyguara/audio/backends/pygame/loaders.py
+++ b/pyguara/audio/backends/pygame/loaders.py
@@ -2,29 +2,53 @@
 
 import pygame
 
+from pyguara.log import get_logger
+from pyguara.resources.meta import AssetMeta, AudioLoadMode, AudioMeta
 from pyguara.resources.types import Resource
 
 from .types import PygameAudioClip
 
+logger = get_logger(__name__)
+
 
 class PygameSoundLoader:
-    """
-    Loads .wav and .ogg files into PygameAudioClip objects.
+    """Load .wav, .ogg and .mp3 files into PygameAudioClip objects.
 
-    Pygame suporta mp3, mas ogg/wav são preferidos para loops e SFX.
+    ogg/wav are preferred over mp3 for loops and SFX.
+
+    Meta-aware: an ``AudioMeta`` sidecar is resolved and attached to the clip
+    as ``clip.import_meta``. The audio system reads ``volume_db`` from there
+    per play. A clip is always fully decoded into memory; ``load_mode:
+    stream`` is only meaningful for music (``play_music``), so it is warned
+    about rather than honoured here.
     """
 
     @property
     def supported_extensions(self) -> list[str]:
-        """Return the list of support audio formats."""
+        """Return the list of supported audio formats."""
         return [".wav", ".ogg", ".mp3"]
 
     def load(self, path: str) -> Resource:
-        """
-        Load the sound file into memory.
+        """Load the sound file into memory with default settings."""
+        return self.load_with_meta(path, None)
+
+    def load_with_meta(self, path: str, meta: AssetMeta | None) -> Resource:
+        """Load the sound file into memory.
+
+        Args:
+            path: Full path to the audio file.
+            meta: Optional AudioMeta sidecar settings.
 
         Raises:
             pygame.error: If the format is unsupported or file is corrupted.
         """
+        if isinstance(meta, AudioMeta) and meta.get_load_mode() is AudioLoadMode.STREAM:
+            logger.warning(
+                "'%s' requests load_mode 'stream', but clips loaded via "
+                "ResourceManager are always fully decoded. Use play_music() "
+                "for streamed audio.",
+                path,
+            )
+
         sound = pygame.mixer.Sound(path)
         return PygameAudioClip(path, sound)

--- a/pyguara/audio/backends/pygame/pygame_audio.py
+++ b/pyguara/audio/backends/pygame/pygame_audio.py
@@ -14,6 +14,7 @@ from pyguara.audio.types import (
 )
 from pyguara.common.types import Vector2
 from pyguara.log import get_logger
+from pyguara.resources.meta import AudioMeta
 from pyguara.resources.types import AudioClip
 
 logger = get_logger(__name__)
@@ -152,10 +153,18 @@ class PygameAudioSystem:
 
         base_volume = max(0.0, min(1.0, volume))
 
+        # Per-asset import gain from an AudioMeta sidecar (volume_db), if any.
+        import_meta = clip.import_meta
+        import_gain = (
+            import_meta.get_volume_multiplier()
+            if isinstance(import_meta, AudioMeta)
+            else 1.0
+        )
+
         # Calculate effective volume through bus hierarchy
         bus_name = self._bus_manager.get_bus_for_type(bus)
         bus_volume = self._bus_manager.get_effective_volume(bus_name)
-        effective_volume = base_volume * bus_volume
+        effective_volume = max(0.0, min(1.0, base_volume * import_gain * bus_volume))
 
         # Find available channel or steal one
         channel = self._get_available_channel(priority)

--- a/pyguara/graphics/backends/moderngl/loaders.py
+++ b/pyguara/graphics/backends/moderngl/loaders.py
@@ -4,6 +4,7 @@ import pygame
 
 import moderngl
 from pyguara.graphics.backends.moderngl.texture import GLTexture
+from pyguara.resources.meta import AssetMeta, TextureFilter, TextureMeta
 from pyguara.resources.types import Resource
 
 
@@ -13,6 +14,10 @@ class GLTextureLoader:
     Uses pygame.image to load the file, then uploads the pixel data
     to the GPU via ModernGL. The resulting GLTexture can be used
     with the ModernGLRenderer for hardware-accelerated drawing.
+
+    Meta-aware: honours ``TextureMeta.filter`` (``nearest`` -> point
+    sampling, ``linear`` -> bilinear). Other TextureMeta fields (mipmaps,
+    wrap modes) are not applied yet.
     """
 
     def __init__(self, ctx: moderngl.Context) -> None:
@@ -29,6 +34,10 @@ class GLTextureLoader:
         return [".png", ".jpg", ".jpeg", ".bmp", ".tga"]
 
     def load(self, path: str) -> Resource:
+        """Load an image file and create a GPU texture with default settings."""
+        return self.load_with_meta(path, None)
+
+    def load_with_meta(self, path: str, meta: AssetMeta | None) -> Resource:
         """Load an image file and create a GPU texture.
 
         The image is loaded via pygame, flipped vertically (OpenGL uses
@@ -36,6 +45,7 @@ class GLTextureLoader:
 
         Args:
             path: Full path to the image file.
+            meta: Optional TextureMeta; ``filter`` selects point vs bilinear.
 
         Returns:
             A GLTexture resource ready for rendering.
@@ -44,6 +54,8 @@ class GLTextureLoader:
             FileNotFoundError: If the file doesn't exist.
             pygame.error: If the image format is unsupported.
         """
+        texture_meta = meta if isinstance(meta, TextureMeta) else TextureMeta()
+
         # Load the image using pygame
         surface = pygame.image.load(path)
 
@@ -65,7 +77,10 @@ class GLTextureLoader:
         gl_texture = self._ctx.texture((width, height), 4, data)
 
         # Set texture parameters
-        gl_texture.filter = (moderngl.LINEAR, moderngl.LINEAR)
+        if texture_meta.get_filter_mode() is TextureFilter.NEAREST:
+            gl_texture.filter = (moderngl.NEAREST, moderngl.NEAREST)
+        else:
+            gl_texture.filter = (moderngl.LINEAR, moderngl.LINEAR)
         gl_texture.swizzle = "BGRA"  # pygame uses BGRA internally
 
         return GLTexture(path, gl_texture, width, height)

--- a/pyguara/graphics/spritesheet.py
+++ b/pyguara/graphics/spritesheet.py
@@ -11,6 +11,7 @@ and a TextureFactory protocol for creating backend-specific textures.
 from PIL import Image
 
 from pyguara.graphics.protocols import TextureFactory
+from pyguara.resources.meta import SpritesheetMeta
 from pyguara.resources.types import Texture
 
 
@@ -78,8 +79,35 @@ class SpriteSheet:
         """Get the height of the sprite sheet in pixels."""
         return self._image.height
 
+    def slice_from_meta(self, meta: SpritesheetMeta, count: int = 0) -> list[Texture]:
+        """Slice the sheet using a SpritesheetMeta sidecar's grid settings.
+
+        Reads ``frame_width``, ``frame_height``, ``margin`` and ``spacing``
+        from the meta. ``filter`` is a texture-import setting and is not
+        applied here.
+
+        Args:
+            meta: The spritesheet import settings.
+            count: Maximum number of frames to extract (0 = all that fit).
+
+        Returns:
+            List of Texture objects, one per extracted frame.
+        """
+        return self.slice_grid(
+            meta.frame_width,
+            meta.frame_height,
+            count=count,
+            margin=meta.margin,
+            spacing=meta.spacing,
+        )
+
     def slice_grid(
-        self, frame_width: int, frame_height: int, count: int = 0
+        self,
+        frame_width: int,
+        frame_height: int,
+        count: int = 0,
+        margin: int = 0,
+        spacing: int = 0,
     ) -> list[Texture]:
         """Slice the sprite sheet into a grid of equal-sized frames.
 
@@ -90,13 +118,22 @@ class SpriteSheet:
             frame_height: Height of a single frame in pixels.
             count: Maximum number of frames to extract. If 0, extracts all
                    frames that fit in the grid.
+            margin: Blank border in pixels between the sheet edge and the
+                    first row/column of frames.
+            spacing: Blank gutter in pixels between adjacent frames.
 
         Returns:
             List of Texture objects, one for each extracted frame.
         """
-        # Calculate grid dimensions
-        cols = self._image.width // frame_width
-        rows = self._image.height // frame_height
+        if frame_width <= 0 or frame_height <= 0:
+            raise ValueError("frame_width and frame_height must be positive")
+
+        # Calculate grid dimensions, accounting for margin and inter-frame
+        # spacing: n frames occupy n*frame + (n-1)*spacing, plus 2*margin.
+        stride_x = frame_width + spacing
+        stride_y = frame_height + spacing
+        cols = max(0, (self._image.width - 2 * margin + spacing) // stride_x)
+        rows = max(0, (self._image.height - 2 * margin + spacing) // stride_y)
 
         total_possible = cols * rows
         frames_to_load = count if count > 0 else total_possible
@@ -110,8 +147,8 @@ class SpriteSheet:
                     break
 
                 # Calculate the crop box (left, upper, right, lower)
-                left = x * frame_width
-                upper = y * frame_height
+                left = margin + x * stride_x
+                upper = margin + y * stride_y
                 right = left + frame_width
                 lower = upper + frame_height
 

--- a/pyguara/resources/__init__.py
+++ b/pyguara/resources/__init__.py
@@ -4,19 +4,41 @@ Handles loading, caching, and lifecycle of game resources including
 textures, audio clips, atlases, and other assets.
 """
 
+from pyguara.resources.data import DataResource
 from pyguara.resources.exceptions import (
     InvalidMetadataError,
     ResourceError,
     ResourceLoadError,
 )
+from pyguara.resources.loader import IMetaAwareLoader, IResourceLoader
+from pyguara.resources.loaders.data_loader import JsonLoader
 from pyguara.resources.manager import ResourceManager
-from pyguara.resources.types import Resource, Texture
+from pyguara.resources.meta import (
+    AssetMeta,
+    AudioMeta,
+    MetaLoader,
+    SpritesheetMeta,
+    TextureMeta,
+    get_meta_loader,
+)
+from pyguara.resources.types import AudioClip, Resource, Texture
 
 __all__ = [
+    "AssetMeta",
+    "AudioClip",
+    "AudioMeta",
+    "DataResource",
+    "IMetaAwareLoader",
+    "IResourceLoader",
     "InvalidMetadataError",
+    "JsonLoader",
+    "MetaLoader",
     "Resource",
     "ResourceError",
     "ResourceLoadError",
     "ResourceManager",
+    "SpritesheetMeta",
     "Texture",
+    "TextureMeta",
+    "get_meta_loader",
 ]

--- a/pyguara/resources/loaders/__init__.py
+++ b/pyguara/resources/loaders/__init__.py
@@ -1,0 +1,5 @@
+"""Concrete resource loader strategies."""
+
+from pyguara.resources.loaders.data_loader import JsonLoader
+
+__all__ = ["JsonLoader"]

--- a/pyguara/resources/manager.py
+++ b/pyguara/resources/manager.py
@@ -12,7 +12,7 @@ of truth for all game assets. It handles:
 import json
 import os
 from pathlib import Path
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from pyguara.common.types import Rect
 from pyguara.graphics.atlas import Atlas, AtlasRegion
@@ -31,6 +31,19 @@ T = TypeVar("T", bound=Resource)
 
 class ResourceManager:
     """Orchestrate the loading, caching, and lifecycle of game resources.
+
+    Lifecycle model:
+        - ``load()`` is a cache-get. On a miss it reads from disk and caches
+          the result; on a hit it returns the cached instance. Either way the
+          resource sits in the cache **unpinned** (reference count 0).
+        - ``acquire()`` / ``release()`` are the explicit pin API. They must be
+          balanced. A ``release()`` that drops the count to 0 evicts the
+          resource immediately.
+        - ``unload_unused()`` evicts every resource whose count is 0. Call it
+          between scenes to drop everything nothing has acquired.
+        - ``unload(path, force=True)`` evicts regardless of the count.
+        - ``reload()`` re-reads a cached resource from disk and swaps the
+          cached instance in place, keeping the reference count.
 
     The ResourceManager supports asset metadata via `.meta` sidecar files.
     When loading a resource, it checks for a corresponding `.meta` file
@@ -71,10 +84,9 @@ class ResourceManager:
             loader (IResourceLoader): The loader instance to register.
         """
         for ext in loader.supported_extensions:
-            # Normaliza para lowercase para evitar erros (PNG vs png)
+            # Normalise to lowercase so "PNG" and "png" resolve alike.
             clean_ext = ext.lower()
 
-            # Opcional: Aviso se já existir um loader para essa extensão
             if clean_ext in self._extension_map:
                 logger.warning("Overwriting loader for extension: %s", clean_ext)
 
@@ -87,6 +99,12 @@ class ResourceManager:
         This allows requesting assets by name (e.g., 'hero') instead of full path
         (e.g., 'assets/chars/hero.png'), mimicking Godot's resource system.
 
+        Two files that share a stem (``chars/hero.png`` and ``fx/hero.png``)
+        would both claim the bare name ``hero``. That is ambiguous, so the
+        bare-stem entry is dropped and a warning is logged naming both paths;
+        the unambiguous full-name keys (``hero.png``) are always kept. Resolve
+        the clash by loading the colliding asset via its full name or path.
+
         Args:
             root_path (str): The directory to scan.
             recursive (bool): If True, scans subdirectories as well.
@@ -98,15 +116,35 @@ class ResourceManager:
 
         iterator = path_obj.rglob("*") if recursive else path_obj.glob("*")
 
+        ambiguous_stems: set[str] = set()
+
         for file_path in iterator:
             if file_path.is_file():
                 extension = file_path.suffix.lower()
                 # Only index files we know how to load
-                if extension in self._extension_map:
-                    filename = file_path.stem  # e.g., 'hero' from 'hero.png'
-                    self._path_index[filename] = str(file_path)
-                    # Also index the full filename just in case
-                    self._path_index[file_path.name] = str(file_path)
+                if extension not in self._extension_map:
+                    continue
+
+                str_path = str(file_path)
+                stem = file_path.stem  # e.g., 'hero' from 'hero.png'
+                existing = self._path_index.get(stem)
+                if existing is not None and existing != str_path:
+                    logger.warning(
+                        "Ambiguous asset name '%s': both '%s' and '%s' claim it; "
+                        "load one by its full name or path.",
+                        stem,
+                        existing,
+                        str_path,
+                    )
+                    ambiguous_stems.add(stem)
+                elif stem not in ambiguous_stems:
+                    self._path_index[stem] = str_path
+
+                # The full filename is unambiguous; always index it.
+                self._path_index[file_path.name] = str_path
+
+        for stem in ambiguous_stems:
+            self._path_index.pop(stem, None)
 
     def load(self, path_or_name: str, resource_type: type[T]) -> T:
         """
@@ -138,23 +176,47 @@ class ResourceManager:
                     f"Resource '{path_or_name}' is cached as {type(res).__name__}, "
                     f"but {resource_type.__name__} was requested."
                 )
-            # Increment ref count for cached resource too
-            if actual_path not in self._reference_counts:
-                self._reference_counts[actual_path] = 0
-            self._reference_counts[actual_path] += 1
             return res
 
-        # 3. Find Loader (O(1) Lookup)
+        # 3. Load from disk
+        resource = self._load_from_disk(actual_path, resource_type)
+
+        self._cache[actual_path] = resource
+
+        # A load is a cache-get, not an acquire: the resource enters the cache
+        # unpinned (ref count 0). Callers that need it to survive
+        # unload_unused() must acquire() it explicitly.
+        self._reference_counts[actual_path] = 0
+
+        return resource
+
+    def _load_from_disk(self, actual_path: str, resource_type: type[T]) -> T:
+        """Run the registered loader for a path and type-check the result.
+
+        Shared by load() (cache miss) and reload(). Does not touch the cache
+        or the reference counts.
+
+        Args:
+            actual_path: The resolved filesystem path.
+            resource_type: The expected class.
+
+        Returns:
+            The freshly loaded resource.
+
+        Raises:
+            ValueError: If no loader is registered for the file extension.
+            TypeError: If the loader returns the wrong type.
+        """
         extension = os.path.splitext(actual_path)[1].lower()
         loader = self._extension_map.get(extension)
 
         if not loader:
             raise ValueError(f"No loader registered for extension: {extension}")
 
-        # 4. Load with metadata if supported
         logger.debug("Loading resource: %s", actual_path)
 
         # Check for meta-aware loader and load metadata
+        meta = None
         if isinstance(loader, IMetaAwareLoader):
             meta = self._meta_loader.load_meta(actual_path)
             if meta:
@@ -169,15 +231,52 @@ class ResourceManager:
                 f"expected {resource_type.__name__}."
             )
 
+        # Record the resolved import settings on the resource so systems that
+        # need them post-load can read resource.import_meta.
+        resource.import_meta = meta
+
+        return resource
+
+    def reload(self, path_or_name: str) -> Resource:
+        """Re-read a cached resource from disk and swap it in place.
+
+        Runs the registered loader again (re-reading the `.meta` sidecar too,
+        if the loader is meta-aware) and replaces the cached instance. The
+        reference count is preserved, so anything that acquired the resource
+        keeps its hold.
+
+        Note:
+            Callers that already hold a reference to the *previous* instance
+            keep that stale object -- ``reload()`` swaps the cache entry, it
+            does not mutate the old instance. Re-``load()`` after a reload to
+            pick up the new one. This is what a hot-reload watcher does.
+
+        Args:
+            path_or_name: The full path or indexed filename of the asset.
+
+        Returns:
+            The freshly loaded resource now in the cache.
+
+        Raises:
+            KeyError: If the resource is not currently cached.
+            ValueError: If no loader is registered for the file extension.
+            TypeError: If the file now loads as a different type than the
+                cached instance.
+        """
+        actual_path = self._path_index.get(path_or_name, path_or_name)
+
+        if actual_path not in self._cache:
+            raise KeyError(
+                f"Cannot reload a resource that is not loaded: {path_or_name}"
+            )
+
+        old_type = type(self._cache[actual_path])
+        # Drop any cached .meta so import settings changed on disk take effect.
+        self._meta_loader.invalidate(actual_path)
+        resource = self._load_from_disk(actual_path, old_type)
+
         self._cache[actual_path] = resource
-
-        # Initialize reference count for new resource
-        if actual_path not in self._reference_counts:
-            self._reference_counts[actual_path] = 0
-
-        # Auto-increment ref count on load
-        self._reference_counts[actual_path] += 1
-
+        logger.debug("Reloaded resource: %s", actual_path)
         return resource
 
     def acquire(self, path_or_name: str) -> None:
@@ -312,12 +411,14 @@ class ResourceManager:
 
         return len(to_unload)
 
-    def get_cache_stats(self) -> dict:
+    def get_cache_stats(self) -> dict[str, Any]:
         """
         Get statistics about the current resource cache state.
 
         Returns:
-            dict: Statistics including resource count, total refs, and resource details.
+            A dict with ``resource_count`` (int), ``total_references`` (int)
+            and ``resources`` (a ``{path: {"type": str, "ref_count": int}}``
+            mapping).
         """
         total_refs = sum(self._reference_counts.values())
         resources_info = {
@@ -417,6 +518,11 @@ class ResourceManager:
                     metadata_path,
                     f"Region '{name}' has invalid data: {e}",
                 ) from e
+
+        # The Atlas holds the texture for its whole lifetime; pin it so
+        # unload_unused() cannot pull it out from under the atlas. Drop it
+        # with unload(atlas_path, force=True) when the atlas is finished.
+        self.acquire(atlas_path)
 
         # Create and return the atlas
         atlas = Atlas(texture=texture, regions=regions)

--- a/pyguara/resources/meta.py
+++ b/pyguara/resources/meta.py
@@ -175,6 +175,9 @@ class MetaLoader:
     def __init__(self) -> None:
         """Initialize the meta loader."""
         self._cache: dict[str, AssetMeta] = {}
+        # mtime of the `.meta` file each cache entry was parsed from, so a
+        # file changed on disk (hot reload) is re-read instead of served stale.
+        self._cache_mtime: dict[str, float] = {}
 
     def get_meta_path(self, asset_path: str) -> Path:
         """Get the `.meta` file path for an asset.
@@ -213,12 +216,25 @@ class MetaLoader:
         Returns:
             The loaded AssetMeta, or None if no meta file exists.
         """
-        # Check cache first
-        if asset_path in self._cache:
-            return self._cache[asset_path]
-
         meta_path = self.get_meta_path(asset_path)
-        if not meta_path.exists():
+        try:
+            current_mtime: float | None = meta_path.stat().st_mtime
+        except OSError:
+            current_mtime = None
+
+        # Serve from cache only if the file is unchanged since it was parsed.
+        if (
+            asset_path in self._cache
+            and self._cache_mtime.get(asset_path) == current_mtime
+        ):
+            cached = self._cache[asset_path]
+            self._warn_on_type_mismatch(meta_path, cached, expected_type)
+            return cached
+
+        if current_mtime is None:
+            # No readable `.meta` file. Drop any stale cache entry.
+            self._cache.pop(asset_path, None)
+            self._cache_mtime.pop(asset_path, None)
             return None
 
         try:
@@ -250,15 +266,6 @@ class MetaLoader:
             logger.warning("Unknown meta type '%s' in '%s'", type_name, meta_path)
             return None
 
-        # Validate expected type if specified
-        if expected_type is not None and meta_class != expected_type:
-            logger.warning(
-                "Meta file '%s' has type '%s', expected '%s'",
-                meta_path,
-                type_name,
-                expected_type.get_type_name(),
-            )
-
         # Create meta object, ignoring unknown fields
         try:
             # Filter to only known fields
@@ -270,10 +277,43 @@ class MetaLoader:
             logger.warning("Invalid data in meta file '%s': %s", meta_path, e)
             return None
 
+        self._warn_on_type_mismatch(meta_path, meta, expected_type)
+
         # Cache and return
         self._cache[asset_path] = meta
+        self._cache_mtime[asset_path] = current_mtime
         logger.debug("Loaded meta for '%s': %s", asset_path, type_name)
         return meta
+
+    @staticmethod
+    def _warn_on_type_mismatch(
+        meta_path: Path, meta: AssetMeta, expected_type: type[AssetMeta] | None
+    ) -> None:
+        """Log a warning if a loaded meta is not the caller's expected type.
+
+        Runs on every load_meta() call, including cache hits, so the warning
+        is not silently swallowed once an entry is cached.
+        """
+        if expected_type is not None and not isinstance(meta, expected_type):
+            logger.warning(
+                "Meta file '%s' has type '%s', expected '%s'",
+                meta_path,
+                type(meta).get_type_name(),
+                expected_type.get_type_name(),
+            )
+
+    def invalidate(self, asset_path: str) -> None:
+        """Drop the cached metadata for one asset.
+
+        The next load_meta() for this path re-reads the `.meta` file. Called
+        by ResourceManager.reload() so import settings changed on disk take
+        effect.
+
+        Args:
+            asset_path: Path to the asset file (not the `.meta` file).
+        """
+        self._cache.pop(asset_path, None)
+        self._cache_mtime.pop(asset_path, None)
 
     def get_or_default(self, asset_path: str, meta_type: type[M]) -> M:
         """Get metadata for an asset, returning defaults if no meta file.
@@ -309,8 +349,13 @@ class MetaLoader:
             with open(meta_path, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)
 
-            # Update cache
+            # Update cache, pinning it to the file we just wrote so a
+            # subsequent load_meta() does not treat it as stale.
             self._cache[asset_path] = meta
+            try:
+                self._cache_mtime[asset_path] = meta_path.stat().st_mtime
+            except OSError:
+                self._cache_mtime.pop(asset_path, None)
             logger.debug("Saved meta for '%s'", asset_path)
             return True
 
@@ -321,6 +366,7 @@ class MetaLoader:
     def clear_cache(self) -> None:
         """Clear the metadata cache."""
         self._cache.clear()
+        self._cache_mtime.clear()
 
 
 # Global meta loader instance

--- a/pyguara/resources/types.py
+++ b/pyguara/resources/types.py
@@ -10,6 +10,8 @@ the core engine depends on these abstract classes, while specific backends
 from abc import ABC, abstractmethod
 from typing import Any
 
+from pyguara.resources.meta import AssetMeta
+
 
 class Resource(ABC):
     """
@@ -17,17 +19,31 @@ class Resource(ABC):
 
     Attributes:
         path (str): The original file path or unique identifier of the resource.
+        import_meta (AssetMeta | None): The `.meta` sidecar settings a
+            meta-aware loader resolved for this resource, or None. Systems that
+            need import settings after load (e.g. the audio system reading
+            ``volume_db``) read them here instead of round-tripping through the
+            ResourceManager.
     """
 
     def __init__(self, path: str):
         """Initialize the resource with a file path."""
         self._path = path
-        self._ref_count = 0
+        self._import_meta: AssetMeta | None = None
 
     @property
     def path(self) -> str:
         """Get the file path associated with this resource."""
         return self._path
+
+    @property
+    def import_meta(self) -> AssetMeta | None:
+        """Get the `.meta` import settings resolved for this resource."""
+        return self._import_meta
+
+    @import_meta.setter
+    def import_meta(self, meta: AssetMeta | None) -> None:
+        self._import_meta = meta
 
     @property
     @abstractmethod

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -184,6 +184,26 @@ def test_play_sfx_centred_volume_is_set_on_the_channel_not_the_sound(
     assert audio_clip.native_handle.get_volume() == pytest.approx(1.0)
 
 
+def test_play_sfx_applies_audiometa_volume_db_as_per_asset_gain(
+    audio_system: PygameAudioSystem,
+) -> None:
+    """A clip whose import_meta is an AudioMeta(volume_db=...) is played at
+    the corresponding linear gain, multiplied into the channel volume."""
+    from pyguara.resources.meta import AudioMeta
+
+    clip = _make_clip("quiet.wav")
+    clip.import_meta = AudioMeta(volume_db=-6.0)  # ~0.501x
+
+    channel_id = audio_system.play_sfx(clip, volume=1.0)
+    assert channel_id is not None
+
+    assert pygame.mixer.Channel(channel_id).get_volume() == pytest.approx(
+        0.501, abs=0.02
+    )
+    # The shared Sound is still untouched (D2 from the audio audit).
+    assert clip.native_handle.get_volume() == pytest.approx(1.0)
+
+
 def test_channel_stereo_split_is_pure_and_symmetric() -> None:
     """The pan -> (left, right) maths, tested directly (the applied split is
     not observable through ``Channel.get_volume()``)."""

--- a/tests/test_graphics_spritesheet.py
+++ b/tests/test_graphics_spritesheet.py
@@ -125,3 +125,48 @@ def test_spritesheet_slice_regions(sample_image, texture_factory):
     assert frames[0].native_handle.get_at((10, 10)) == (255, 0, 0, 255)
     # Second region is White
     assert frames[1].native_handle.get_at((10, 10)) == (255, 255, 255, 255)
+
+
+def test_spritesheet_slice_grid_margin_and_spacing(texture_factory):
+    """Margin and inter-frame spacing are skipped, not sliced as pixels."""
+    # 2x2 grid of 32px frames, 4px margin, 2px spacing:
+    # 4 + 32 + 2 + 32 + 4 = 74 per axis.
+    img = Image.new("RGBA", (74, 74))
+    for y in range(74):
+        for x in range(74):
+            img.putpixel((x, y), (0, 0, 0, 255))
+    # Paint the top-left frame body red (starts at margin=4).
+    for y in range(4, 36):
+        for x in range(4, 36):
+            img.putpixel((x, y), (255, 0, 0, 255))
+    # Paint the second column's top frame body green (starts at 4+32+2 = 38).
+    for y in range(4, 36):
+        for x in range(38, 70):
+            img.putpixel((x, y), (0, 255, 0, 255))
+
+    sheet = SpriteSheet.from_image(img, texture_factory, "padded")
+    frames = sheet.slice_grid(32, 32, margin=4, spacing=2)
+
+    assert len(frames) == 4
+    assert frames[0].native_handle.get_at((0, 0)) == (255, 0, 0, 255)
+    assert frames[1].native_handle.get_at((0, 0)) == (0, 255, 0, 255)
+
+
+def test_spritesheet_slice_from_meta(texture_factory):
+    """slice_from_meta pulls grid geometry off a SpritesheetMeta."""
+    from pyguara.resources.meta import SpritesheetMeta
+
+    img = Image.new("RGBA", (74, 74), (10, 10, 10, 255))
+    sheet = SpriteSheet.from_image(img, texture_factory, "meta_sheet")
+    meta = SpritesheetMeta(frame_width=32, frame_height=32, margin=4, spacing=2)
+
+    frames = sheet.slice_from_meta(meta)
+    assert len(frames) == 4
+    assert frames[0].native_handle.get_width() == 32
+
+
+def test_spritesheet_slice_grid_rejects_nonpositive_dims(sample_image, texture_factory):
+    """A zero frame size raises instead of ZeroDivisionError."""
+    sheet = SpriteSheet.from_image(sample_image, texture_factory, "bad")
+    with pytest.raises(ValueError):
+        sheet.slice_grid(0, 32)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -4,6 +4,8 @@ Tests MetaLoader, TextureMeta, AudioMeta, SpritesheetMeta and related functional
 """
 
 import json
+import os
+import time
 from pathlib import Path
 
 import pytest
@@ -345,6 +347,60 @@ class TestMetaLoaderLoadMeta:
         result2 = loader.load_meta(str(asset_path))
         assert result1 is result2
         assert str(asset_path) in loader._cache
+
+    def test_load_meta_reparses_when_file_changes_on_disk(self, tmp_path: Path) -> None:
+        loader = MetaLoader()
+        asset_path = tmp_path / "test.png"
+        meta_path = tmp_path / "test.png.meta"
+        meta_path.write_text(json.dumps({"type": "texture", "filter": "linear"}))
+
+        first = loader.load_meta(str(asset_path))
+        assert isinstance(first, TextureMeta) and first.filter == "linear"
+
+        # Rewrite with a distinct mtime.
+        meta_path.write_text(json.dumps({"type": "texture", "filter": "nearest"}))
+        os.utime(meta_path, (time.time() + 2, time.time() + 2))
+
+        second = loader.load_meta(str(asset_path))
+        assert isinstance(second, TextureMeta) and second.filter == "nearest"
+
+    def test_load_meta_drops_cache_when_file_deleted(self, tmp_path: Path) -> None:
+        loader = MetaLoader()
+        asset_path = tmp_path / "test.png"
+        meta_path = tmp_path / "test.png.meta"
+        meta_path.write_text(json.dumps({"type": "texture"}))
+
+        assert loader.load_meta(str(asset_path)) is not None
+        meta_path.unlink()
+        assert loader.load_meta(str(asset_path)) is None
+        assert str(asset_path) not in loader._cache
+
+    def test_invalidate_forces_reparse(self, tmp_path: Path) -> None:
+        loader = MetaLoader()
+        asset_path = tmp_path / "test.png"
+        meta_path = tmp_path / "test.png.meta"
+        meta_path.write_text(json.dumps({"type": "texture", "filter": "linear"}))
+        loader.load_meta(str(asset_path))
+
+        # Same mtime (fast rewrite) would otherwise be served from cache.
+        meta_path.write_text(json.dumps({"type": "texture", "filter": "nearest"}))
+        os.utime(meta_path, (1_000_000, 1_000_000))
+        loader.invalidate(str(asset_path))
+
+        result = loader.load_meta(str(asset_path))
+        assert isinstance(result, TextureMeta) and result.filter == "nearest"
+
+    def test_load_meta_warns_on_type_mismatch_even_from_cache(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        loader = MetaLoader()
+        asset_path = tmp_path / "test.png"
+        (tmp_path / "test.png.meta").write_text(json.dumps({"type": "texture"}))
+
+        loader.load_meta(str(asset_path))  # primes the cache, no expected_type
+        with caplog.at_level("WARNING"):
+            loader.load_meta(str(asset_path), expected_type=AudioMeta)
+        assert any("expected 'audio'" in r.message for r in caplog.records)
 
     def test_load_meta_invalid_json(self, tmp_path: Path) -> None:
         loader = MetaLoader()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,57 +1,94 @@
-from unittest.mock import MagicMock, patch
+"""Tests for pyguara.resources.manager.ResourceManager.
+
+Lifecycle model under test (see ResourceManager docstring):
+    - load() is a cache-get; the resource enters the cache unpinned (count 0).
+    - acquire()/release() are the explicit pin API and must be balanced.
+    - unload_unused() evicts everything at count 0.
+    - reload() re-reads a cached resource and swaps it in place.
+"""
+
+import json
+from pathlib import Path
 
 import pytest
 
-from pyguara.resources.loader import IResourceLoader
+from pyguara.resources.data import DataResource
+from pyguara.resources.loaders.data_loader import JsonLoader
 from pyguara.resources.manager import ResourceManager
+from pyguara.resources.meta import AssetMeta, TextureMeta
 from pyguara.resources.types import Resource
 
 
 class MockRes(Resource):
+    """Minimal concrete Resource for cache/lifecycle tests."""
+
     @property
     def native_handle(self) -> str:
         return "mock"
 
 
-class MockLoader(IResourceLoader):
+class MockLoader:
+    """A loader that fabricates a MockRes without touching the disk."""
+
+    def __init__(self) -> None:
+        self.load_calls = 0
+
     @property
     def supported_extensions(self) -> list[str]:
         return [".mock"]
 
     def load(self, path: str) -> MockRes:
+        self.load_calls += 1
         return MockRes(path)
 
 
-def test_resource_caching() -> None:
+class MetaMockLoader(MockLoader):
+    """MockLoader that also implements the meta-aware protocol."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen_meta: AssetMeta | None = None
+
+    def load_with_meta(self, path: str, meta: AssetMeta | None) -> MockRes:
+        self.seen_meta = meta
+        self.load_calls += 1
+        return MockRes(path)
+
+
+def _mgr(*loaders: object) -> ResourceManager:
     manager = ResourceManager()
+    for loader in loaders or (MockLoader(),):
+        manager.register_loader(loader)  # type: ignore[arg-type]
+    return manager
+
+
+# --------------------------------------------------------------------------
+# Loading, caching, type safety
+# --------------------------------------------------------------------------
+
+
+def test_load_caches_by_path() -> None:
     loader = MockLoader()
-    manager.register_loader(loader)
+    manager = _mgr(loader)
 
-    # Mock index
-    manager._path_index["test"] = "assets/test.mock"
+    res1 = manager.load("file.mock", MockRes)
+    res2 = manager.load("file.mock", MockRes)
 
-    # 1. Load (Cache Miss)
-    res1 = manager.load("test", MockRes)
-    assert res1.path == "assets/test.mock"
-
-    # 2. Load (Cache Hit)
-    res2 = manager.load("test", MockRes)
-    assert res1 is res2  # Same instance
+    assert res1 is res2
+    assert loader.load_calls == 1  # second call served from cache
 
 
-def test_loader_selection() -> None:
-    manager = ResourceManager()
-    loader = MockLoader()
-    manager.register_loader(loader)
+def test_load_resolves_indexed_name(tmp_path: Path) -> None:
+    (tmp_path / "hero.mock").write_text("x")
+    manager = _mgr()
+    manager.index_directory(str(tmp_path))
 
-    # Should select MockLoader for .mock extension
-    res = manager.load("file.mock", MockRes)
-    assert isinstance(res, MockRes)
+    res = manager.load("hero", MockRes)
+    assert res.path == str(tmp_path / "hero.mock")
 
 
-def test_wrong_type_error() -> None:
-    manager = ResourceManager()
-    manager.register_loader(MockLoader())
+def test_load_wrong_type_raises_on_miss() -> None:
+    manager = _mgr()
 
     class OtherRes(Resource):
         @property
@@ -62,166 +99,284 @@ def test_wrong_type_error() -> None:
         manager.load("file.mock", OtherRes)
 
 
-def test_indexing() -> None:
+def test_load_wrong_type_raises_on_cache_hit() -> None:
+    manager = _mgr()
+    manager.load("file.mock", MockRes)
+
+    class OtherRes(Resource):
+        @property
+        def native_handle(self) -> None:
+            return None
+
+    with pytest.raises(TypeError, match="cached as MockRes"):
+        manager.load("file.mock", OtherRes)
+
+
+def test_load_unknown_extension_raises() -> None:
+    manager = _mgr()
+    with pytest.raises(ValueError, match="No loader registered"):
+        manager.load("file.unknown", MockRes)
+
+
+def test_register_loader_warns_on_extension_clash(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     manager = ResourceManager()
     manager.register_loader(MockLoader())
+    with caplog.at_level("WARNING"):
+        manager.register_loader(MockLoader())
+    assert any("Overwriting loader" in r.message for r in caplog.records)
 
-    with patch("pathlib.Path.rglob") as mock_glob:
-        mock_file = MagicMock()
-        mock_file.is_file.return_value = True
-        mock_file.suffix = ".mock"
-        mock_file.stem = "hero"
-        mock_file.name = "hero.mock"
-        # Configure __str__ to return the path
-        type(mock_file).__str__ = lambda self: "assets/hero.mock"  # type: ignore[method-assign]
 
-        mock_glob.return_value = [mock_file]
+# --------------------------------------------------------------------------
+# index_directory
+# --------------------------------------------------------------------------
 
-        with patch("pathlib.Path.exists", return_value=True):
-            manager.index_directory("assets")
+
+def test_index_directory_recursive(tmp_path: Path) -> None:
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "hero.mock").write_text("x")
+    (tmp_path / "sword.mock").write_text("x")
+    manager = _mgr()
+
+    manager.index_directory(str(tmp_path))
+
+    assert manager.load("hero", MockRes).path.endswith("a/hero.mock")
+    assert manager.load("sword.mock", MockRes).path.endswith("sword.mock")
+
+
+def test_index_directory_non_recursive_skips_subdirs(tmp_path: Path) -> None:
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "deep.mock").write_text("x")
+    manager = _mgr()
+
+    manager.index_directory(str(tmp_path), recursive=False)
+
+    with pytest.raises(ValueError):
+        manager.load("deep", MockRes)  # never indexed -> no extension match...
+
+
+def test_index_directory_ambiguous_stem_is_dropped_with_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    (tmp_path / "enemies").mkdir()
+    (tmp_path / "npcs").mkdir()
+    (tmp_path / "enemies" / "goblin.mock").write_text("enemy")
+    (tmp_path / "npcs" / "goblin.mock").write_text("npc")
+    manager = _mgr()
+
+    with caplog.at_level("WARNING"):
+        manager.index_directory(str(tmp_path))
+
+    assert any("Ambiguous asset name 'goblin'" in r.message for r in caplog.records)
+    # The bare stem is refused...
+    assert "goblin" not in manager._path_index
+    # ...but each unambiguous full name still resolves to its own file.
+    g1 = manager.load(str(tmp_path / "enemies" / "goblin.mock"), MockRes)
+    assert Path(g1.path).read_text() == "enemy"
+
+
+def test_index_directory_same_file_twice_is_not_ambiguous(tmp_path: Path) -> None:
+    (tmp_path / "hero.mock").write_text("x")
+    manager = _mgr()
+
+    manager.index_directory(str(tmp_path))
+    manager.index_directory(str(tmp_path))  # re-scan must not self-collide
 
     assert "hero" in manager._path_index
-    assert manager._path_index["hero"] == "assets/hero.mock"
 
 
-def test_reference_counting_basic() -> None:
-    """Test that load increments ref count and release decrements it."""
+# --------------------------------------------------------------------------
+# Reference counting: load does NOT pin
+# --------------------------------------------------------------------------
+
+
+def test_load_leaves_resource_unpinned() -> None:
+    manager = _mgr()
+    manager.load("a.mock", MockRes)
+    manager.load("a.mock", MockRes)  # repeated load must not accumulate
+
+    stats = manager.get_cache_stats()
+    assert stats["resources"]["a.mock"]["ref_count"] == 0
+
+
+def test_acquire_and_release_balance() -> None:
+    manager = _mgr()
+    manager.load("a.mock", MockRes)
+
+    manager.acquire("a.mock")
+    manager.acquire("a.mock")
+    assert manager.get_cache_stats()["resources"]["a.mock"]["ref_count"] == 2
+
+    manager.release("a.mock")
+    assert "a.mock" in manager.get_cache_stats()["resources"]
+
+    manager.release("a.mock")  # back to 0 -> evicted
+    assert "a.mock" not in manager.get_cache_stats()["resources"]
+
+
+def test_release_without_acquire_raises() -> None:
+    manager = _mgr()
+    manager.load("a.mock", MockRes)
+    with pytest.raises(ValueError, match="already zero"):
+        manager.release("a.mock")
+
+
+def test_acquire_unloaded_raises() -> None:
+    manager = _mgr()
+    with pytest.raises(KeyError, match="Cannot acquire"):
+        manager.acquire("ghost.mock")
+
+
+def test_release_unloaded_raises() -> None:
+    manager = _mgr()
+    with pytest.raises(KeyError, match="Cannot release"):
+        manager.release("ghost.mock")
+
+
+# --------------------------------------------------------------------------
+# unload / unload_unused
+# --------------------------------------------------------------------------
+
+
+def test_unload_unused_sweeps_everything_not_acquired() -> None:
+    manager = _mgr()
+    manager.load("a.mock", MockRes)
+    manager.load("b.mock", MockRes)
+    manager.load("c.mock", MockRes)
+    manager.acquire("b.mock")  # pin one
+
+    freed = manager.unload_unused()
+
+    assert freed == 2
+    remaining = manager.get_cache_stats()["resources"]
+    assert set(remaining) == {"b.mock"}
+
+
+def test_unload_force_evicts_pinned_resource() -> None:
+    manager = _mgr()
+    manager.load("a.mock", MockRes)
+    manager.acquire("a.mock")
+
+    manager.unload("a.mock", force=True)
+
+    assert "a.mock" not in manager.get_cache_stats()["resources"]
+
+
+def test_unload_without_force_decrements_a_pinned_resource() -> None:
+    manager = _mgr()
+    manager.load("a.mock", MockRes)
+    manager.acquire("a.mock")
+    manager.acquire("a.mock")
+
+    manager.unload("a.mock")  # 2 -> 1, still cached
+    assert manager.get_cache_stats()["resources"]["a.mock"]["ref_count"] == 1
+
+    manager.unload("a.mock")  # 1 -> 0 -> evicted
+    assert "a.mock" not in manager.get_cache_stats()["resources"]
+
+
+def test_unload_missing_resource_is_a_noop() -> None:
+    manager = _mgr()
+    manager.unload("ghost.mock")  # must not raise
+
+
+# --------------------------------------------------------------------------
+# reload
+# --------------------------------------------------------------------------
+
+
+def test_reload_swaps_the_cached_instance_and_keeps_refcount(tmp_path: Path) -> None:
+    path = tmp_path / "data.json"
+    path.write_text(json.dumps({"hp": 10}))
     manager = ResourceManager()
-    manager.register_loader(MockLoader())
+    manager.register_loader(JsonLoader())
 
-    # Load resource - should set ref count to 1
-    res1 = manager.load("test.mock", MockRes)
-    assert "test.mock" in manager._reference_counts
-    assert manager._reference_counts["test.mock"] == 1
+    first = manager.load(str(path), DataResource)
+    manager.acquire(str(path))
+    assert first.native_handle == {"hp": 10}
 
-    # Load again - should increment to 2
-    res2 = manager.load("test.mock", MockRes)
-    assert res1 is res2  # Same instance
-    assert manager._reference_counts["test.mock"] == 2
+    path.write_text(json.dumps({"hp": 99}))
+    second = manager.reload(str(path))
 
-    # Release once - ref count should be 1
-    manager.release("test.mock")
-    assert manager._reference_counts["test.mock"] == 1
-    assert "test.mock" in manager._cache  # Still cached
-
-    # Release again - ref count reaches 0, auto-unload
-    manager.release("test.mock")
-    assert "test.mock" not in manager._cache
-    assert "test.mock" not in manager._reference_counts
+    assert second is not first
+    assert second.native_handle == {"hp": 99}
+    assert manager.load(str(path), DataResource) is second  # cache updated
+    assert manager.get_cache_stats()["resources"][str(path)]["ref_count"] == 1
 
 
-def test_acquire_release() -> None:
-    """Test explicit acquire and release methods."""
-    manager = ResourceManager()
-    manager.register_loader(MockLoader())
-
-    # Load resource (ref count = 1)
-    manager.load("test.mock", MockRes)
-    assert manager._reference_counts["test.mock"] == 1
-
-    # Acquire additional reference (ref count = 2)
-    manager.acquire("test.mock")
-    assert manager._reference_counts["test.mock"] == 2
-
-    # Release once (ref count = 1)
-    manager.release("test.mock")
-    assert "test.mock" in manager._cache
-
-    # Release again (ref count = 0, auto-unload)
-    manager.release("test.mock")
-    assert "test.mock" not in manager._cache
+def test_reload_uncached_raises() -> None:
+    manager = _mgr()
+    with pytest.raises(KeyError, match="not loaded"):
+        manager.reload("never.mock")
 
 
-def test_acquire_unloaded_resource_error() -> None:
-    """Test that acquire raises error for unloaded resource."""
-    manager = ResourceManager()
-    manager.register_loader(MockLoader())
+def test_reload_picks_up_changed_meta(tmp_path: Path) -> None:
+    img = tmp_path / "hero.mock"
+    img.write_text("x")
+    meta = tmp_path / "hero.mock.meta"
+    meta.write_text(json.dumps({"type": "texture", "filter": "linear"}))
+    loader = MetaMockLoader()
+    manager = _mgr(loader)
 
-    with pytest.raises(KeyError, match="Cannot acquire reference to unloaded resource"):
-        manager.acquire("nonexistent.mock")
+    manager.load(str(img), MockRes)
+    assert isinstance(loader.seen_meta, TextureMeta)
+    assert loader.seen_meta.filter == "linear"
 
+    meta.write_text(json.dumps({"type": "texture", "filter": "nearest"}))
+    manager.reload(str(img))
 
-def test_release_unloaded_resource_error() -> None:
-    """Test that release raises error for unloaded resource."""
-    manager = ResourceManager()
-    manager.register_loader(MockLoader())
-
-    with pytest.raises(KeyError, match="Cannot release reference to unloaded resource"):
-        manager.release("nonexistent.mock")
-
-
-def test_release_zero_refcount_error() -> None:
-    """Test that release raises error when ref count is already zero."""
-    manager = ResourceManager()
-    manager.register_loader(MockLoader())
-
-    # Load and then release to zero
-    manager.load("test.mock", MockRes)
-    manager.release("test.mock")
-
-    # Try to release again - should error
-    with pytest.raises(KeyError):
-        manager.release("test.mock")
+    assert isinstance(loader.seen_meta, TextureMeta)
+    assert loader.seen_meta.filter == "nearest"
 
 
-def test_unload_unused() -> None:
-    """Test batch unloading of zero-ref resources."""
-    manager = ResourceManager()
-    manager.register_loader(MockLoader())
-
-    # Load 3 resources
-    manager.load("res1.mock", MockRes)
-    manager.load("res2.mock", MockRes)
-    manager.load("res3.mock", MockRes)
-
-    # Release res1 and res2 to zero
-    manager.release("res1.mock")
-    manager.release("res2.mock")
-
-    # res3 still has ref count 1, acquire another ref for res1
-    manager._reference_counts["res1.mock"] = 0  # Manually set to simulate zero refs
-    manager._cache["res1.mock"] = MockRes("res1.mock")  # Re-add to cache
-
-    # Batch unload
-    count = manager.unload_unused()
-
-    # Should have unloaded res1 (0 refs) but not res3 (1 ref)
-    assert count >= 1
-    assert "res3.mock" in manager._cache
-    assert manager._reference_counts["res3.mock"] == 1
+# --------------------------------------------------------------------------
+# Meta-aware loading through the manager
+# --------------------------------------------------------------------------
 
 
-def test_force_unload() -> None:
-    """Test force unload bypasses reference counting."""
-    manager = ResourceManager()
-    manager.register_loader(MockLoader())
+def test_meta_aware_loader_receives_and_attaches_meta(tmp_path: Path) -> None:
+    img = tmp_path / "hero.mock"
+    img.write_text("x")
+    (tmp_path / "hero.mock.meta").write_text(
+        json.dumps({"type": "texture", "filter": "linear"})
+    )
+    loader = MetaMockLoader()
+    manager = _mgr(loader)
 
-    # Load resource (ref count = 1)
-    manager.load("test.mock", MockRes)
-    assert manager._reference_counts["test.mock"] == 1
+    res = manager.load(str(img), MockRes)
 
-    # Force unload should work even with active references
-    manager.unload("test.mock", force=True)
-    assert "test.mock" not in manager._cache
-    assert "test.mock" not in manager._reference_counts
+    assert isinstance(loader.seen_meta, TextureMeta)
+    assert isinstance(res.import_meta, TextureMeta)
+    assert res.import_meta.filter == "linear"
 
 
-def test_cache_stats() -> None:
-    """Test get_cache_stats returns correct information."""
-    manager = ResourceManager()
-    manager.register_loader(MockLoader())
+def test_meta_aware_loader_without_sidecar_gets_none(tmp_path: Path) -> None:
+    img = tmp_path / "hero.mock"
+    img.write_text("x")
+    loader = MetaMockLoader()
+    manager = _mgr(loader)
 
-    # Load 2 resources
-    manager.load("res1.mock", MockRes)
-    manager.load("res2.mock", MockRes)
+    res = manager.load(str(img), MockRes)
 
-    # Acquire additional ref for res1
-    manager.acquire("res1.mock")
+    assert loader.seen_meta is None
+    assert res.import_meta is None
+
+
+# --------------------------------------------------------------------------
+# get_cache_stats
+# --------------------------------------------------------------------------
+
+
+def test_cache_stats_shape() -> None:
+    manager = _mgr()
+    manager.load("a.mock", MockRes)
+    manager.load("b.mock", MockRes)
+    manager.acquire("a.mock")
 
     stats = manager.get_cache_stats()
 
     assert stats["resource_count"] == 2
-    assert stats["total_references"] == 3  # res1=2, res2=1
-    assert "res1.mock" in stats["resources"]
-    assert stats["resources"]["res1.mock"]["ref_count"] == 2
-    assert stats["resources"]["res2.mock"]["ref_count"] == 1
+    assert stats["total_references"] == 1
+    assert stats["resources"]["a.mock"] == {"type": "MockRes", "ref_count": 1}
+    assert stats["resources"]["b.mock"]["ref_count"] == 0


### PR DESCRIPTION
Subsystem audit — `pyguara/resources` (Tier 3). Tracker: `REFACTOR_STATE.md`.
Independent branch off `main`; not stacked.

Two upfront decisions were put to the repo owner (each shapes the whole PR):
**F1** → "fix the model + add `reload()`"; **F4** → "wire the `.meta`
pipeline up in this slice".

## Phase A — code (every defect reproduced with a probe first)

- **F1 — reference counting was internally inconsistent and wired to
  nothing.** `load()` auto-incremented on every call including cache hits;
  `release()` auto-unloaded at 0. So `unload_unused()` ("cleanup between
  scenes") could never evict a resource in use, and a released one was
  already gone — dead code. No engine caller of
  acquire/release/unload/unload_unused; `AudioManager` `load()`s per play so
  the count climbed forever. `Resource._ref_count` was a *third*, dead
  counter. New model: `load()` is a pure cache-get → the resource enters
  **unpinned** (0); `acquire()`/`release()` are the explicit balanced pin
  API; `unload_unused()` now meaningfully sweeps everything unpinned.
- **F2 — `index_directory()` silently resolved a stem collision to whichever
  file the walk hit last** (`chars/hero.png` vs `fx/hero.png` →
  `load("hero")` returns the wrong file, no warning). Now the ambiguous bare
  stem is dropped with a warning naming both paths; unambiguous full-name
  keys always win.
- **F3 — `MetaLoader` cached parsed meta by path with no invalidation**
  (stale forever after a disk change — wrong under hot reload) and the
  path-only key swallowed the `expected_type` mismatch warning after the
  first call. Now mtime-pinned + re-read on change + deleted-file drop +
  `MetaLoader.invalidate()`, and the type check runs on every call.
- **F5 — `DataResource` docstring claimed "hot-reloaded by the
  ResourceManager"; no reload API existed.** Added `ResourceManager.reload()`
  — re-run loader, re-read `.meta`, type-check against the cached instance,
  swap in place, keep the reference count.
- **F4 — the `.meta` import pipeline was ~70% scaffolding.** `AudioMeta` and
  `SpritesheetMeta` had no consumer; `GLTextureLoader` hardcoded `LINEAR`
  and ignored `TextureMeta.filter`. Wired end to end: `Resource.import_meta`
  carries the resolved sidecar (attached by the manager); `GLTextureLoader`
  honours `filter` (**its default flips LINEAR→NEAREST to match the pygame
  path — an intentional backend alignment**, the two silently disagreed);
  the pygame audio backend applies `AudioMeta.volume_db` as a per-asset
  **channel** gain per play (never the shared `Sound`); `SpriteSheet`
  gained `margin`/`spacing` (previously meaningless everywhere) +
  `slice_from_meta()`, and rejects a zero frame size.
- Minor: `get_cache_stats() -> dict[str, Any]`; Portuguese comments
  translated; `load_atlas()` `acquire()`s its texture; curated `__all__` +
  `loaders/__init__.py` (CC-8), no cycle exposed.

## Phase B — tests (+21)

- `test_resources.py` **rewritten**: it asserted on `_reference_counts` /
  `_cache` / `_path_index` privates, mocked `Path.rglob` (so F2 was
  unreachable), and *hand-poked* an impossible zero-refcount state into
  `test_unload_unused`. Now: real `tmp_path` files, assertions via
  `get_cache_stats()`, and coverage for the new lifecycle, `reload()`, the
  F2 collision, and meta-aware load through the manager.
- `test_meta.py` (+5): every test used a fresh `MetaLoader()` (uniform
  setup), so F3 had no test that could see it. Added stale-cache-on-change,
  deleted-file, `invalidate()`, cache-hit type-mismatch warning.
- `test_graphics_spritesheet.py` (+3), `test_audio.py` (+1): margin/spacing,
  `slice_from_meta`, zero-dim rejection; the `volume_db` gain path on the
  real dummy-driver mixer. `GLTextureLoader`'s filter branch has no headless
  GL context in CI (issue #19 shape).

## Phase C — docs

`docs/systems/resources.md` (15 lines) covered `load()` / caching /
indexing and nothing else — no ref-counting API, no `.meta` system, no
`reload()` / `load_atlas()` / `get_cache_stats()` — and carried a stale
duplicated "Audio System" section and a "Persistence" section. Rewritten to
the real API with an honest per-`.meta`-type table of what each setting
currently affects.

## Verification

`pytest` 1735 pass (1714 → +21) · `ruff check .` clean · `ruff format
--check` clean · `mypy pyguara` clean (225 files) · `mkdocs build --strict`
exit 0 · `test_docs_api.py` (52) pass. Both non-docs commits verified
standalone in a detached worktree.

**PR is final — nothing else coming for this subsystem.** Follow-ups noted
in the tracker (audio should `acquire()` its clips under the new model; the
still-unconsumed `.meta` fields; no cache lock) are separate concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5