### PR TITLE
persistence audit: one atomic blob per save; fix silently-swallowed write failures

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -63,9 +63,60 @@ how the subject is *constructed*, not just what is asserted.
 
 ## Active Subsystem
 
-**None — `pyguara/resources` closed 2026-09-08 (branch
-`refactor/resources-audit`).** Next in the queue is `pyguara/persistence`
-(save/load, migration). Open `REFACTOR_STATE.md` "How to resume" and take it.
+**None — `pyguara/persistence` closed 2026-09-08 (branch
+`refactor/persistence-audit`).** Next in the queue is `pyguara/ai`
+(FSM, steering, pathfinding, navmesh, behaviour trees). Open
+`REFACTOR_STATE.md` "How to resume" and take it.
+
+`pyguara/persistence` in one slice, ~970 lines (`manager`, `storage`,
+`serializer`, `migration`, `types`). The migration half was actually sound
+— the chain-integrity guards (`to_version > from_version`, `to_version <=
+current_version` on register, "no gap" in `get_migration_path`, no
+downgrade) compose correctly and the `while version < current_version` loop
+provably terminates; probes for an overshoot / infinite loop all came back
+negative. The save/load half carried the recurring shapes. **`save_data()`
+discarded `storage.save()`'s return value** — `FileStorageBackend.save`
+returns `False` on `OSError` rather than raising, so a full disk still
+logged "Successfully saved" and returned `True` ("guard that returns a
+wrong answer"). **`FileStorageBackend` sanitised keys by deleting bad
+characters**, so `"slot 1"` / `"slot/1"` / `"slot.1"` all collapsed onto
+`slot1` and silently overwrote each other; an all-punctuation key wrote
+literal `.dat`/`.meta` — the resources F2 stem-collision shape exactly.
+Now non-round-tripping keys raise `ValueError`. **Data and meta were two
+independent `os.replace` calls** while the load path's comment claimed
+"atomic save ensures both or neither" — a crash between them left new data +
+stale-checksum meta, and `load_data` then returned `None` for a save whose
+bytes were intact. User asked which fix was more systemic; chose the
+envelope: metadata is framed into **one blob** (`{"…"}\n<payload>`),
+`StorageBackend` drops its `metadata` param and becomes a plain key→blob
+store, `FileStorageBackend` writes one `{key}.save` file (+ dir fsync +
+temp-file sweep). **`compress=` was a documented no-op** — implemented
+(gzip, recorded in the header). **`SerializationFormat.MSGPACK` was a
+public enum member with no implementation** though `msgpack` is a declared
+dep — implemented via the existing `prepare_for_json` / `game_object_hook`
+path and exposed through a new `fmt=` arg on `save_data`. `SaveMetadata`
+was built then hand-copied field by field and never reconstructed on load;
+now carries `format`/`compressed`, used via `asdict`, engine version from
+`importlib.metadata` (was hard-coded `"1.0.0"`), UTC timestamp. Migration
+gained `from_version >= 1` / `current_version >= 1` construction guards and
+`MigrationRegistry` is `eq=False`. Recurring shapes: "declared and wired to
+nothing" (`compress`, `MSGPACK`, the `metadata` half of `SaveMetadata`),
+"guard that returns a wrong answer" (the swallowed `save()` failure, the
+key mangling), "identity vs value" (`MigrationRegistry`), and uniform test
+setup — every storage test used an already-safe key (`save1`, `slot_a`,
+`autosave`) so the collapse was unreachable; every migration test used
+positive versions from 1 so the guards had no test. Tests +35 (1735 →
+1770). See the iteration log entry below.
+
+**Left open.** `save_data` still always writes JSON metadata + records the
+payload `fmt`; there is no per-call *metadata* format choice (fine — the
+header is meant to stay greppable). `BINARY` (pickle) load is unauthenticated
+— documented as trusted-input-only, not fixed (a signature scheme is its own
+slice). No `PersistenceManager` facade for `delete`/`list`/`exists` — callers
+still reach into `.storage` (only `SceneSerializer` does, via save/load).
+Mypy's `python_version` is `3.10` while `requires-python` is `3.12`, so
+`datetime.UTC` (ruff UP017's fix) fails typecheck — one `# noqa: UP017` and a
+possible CC (mypy target vs `requires-python`).
 
 `pyguara/resources` in one slice, ~1,100 lines (`manager`, `meta`,
 `loader`, `types`, `data`, `data_loader`, `exceptions`; hot reload itself
@@ -243,7 +294,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 - [x] `pyguara/audio` — audio manager, spatial audio *(done)*
 - [x] `pyguara/animation` — tween, easing, FSM *(done)*
 - [x] `pyguara/resources` — loaders, meta, hot reload *(done)*
-- [ ] `pyguara/persistence` — save/load, migration
+- [x] `pyguara/persistence` — save/load, migration *(done)*
 - [ ] `pyguara/ai` — FSM, steering, pathfinding, navmesh, behaviour trees
 
 ### Tier 4 — Tooling & authoring
@@ -262,6 +313,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/persistence` | 2026-09-08 | One slice (`manager`, `storage`, `serializer`, `migration`, `types`; ~970 lines). The **migration half was sound** — the chain-integrity guards compose and the path loop provably terminates; overshoot/infinite-loop probes came back negative. The save/load half held the recurring shapes. **`save_data()` discarded `storage.save()`'s return** — `FileStorageBackend.save` returns `False` on `OSError`, so a full disk logged "Successfully saved" and returned `True`; now checked. **`FileStorageBackend` sanitised keys by deleting bad chars** — `"slot 1"`/`"slot/1"`/`"slot.1"` all collapsed onto `slot1` and silently overwrote each other (the resources F2 stem-collision shape); non-round-tripping keys now raise `ValueError`. **Data + meta were two independent `os.replace` calls** while the load path claimed "atomic save ensures both or neither" — a crash between them made an intact save unreadable (stale checksum → `None`). User chose the systemic fix: metadata is framed into **one blob** (`{header json}\n<payload>`), `StorageBackend` drops its `metadata` param (plain key→blob store), `FileStorageBackend` writes one `{key}.save` file + dir fsync + temp-sweep. **`compress=` was a documented no-op** → gzip, recorded in the header. **`SerializationFormat.MSGPACK` was a public enum member with no impl** though `msgpack` is a declared dep → implemented via the existing `prepare_for_json`/`game_object_hook` path, exposed through a new `fmt=` arg. `SaveMetadata` was hand-copied field by field and never read back on load → now carries `format`/`compressed`, used via `asdict`, engine version from `importlib.metadata` (was `"1.0.0"`), UTC timestamp. Migration gained `from_version >= 1` / `current_version >= 1` guards; `MigrationRegistry` is `eq=False`. Recurring shapes: "declared and wired to nothing" (`compress`, `MSGPACK`, `SaveMetadata`'s metadata half), "guard that returns a wrong answer" (swallowed `save()` failure, key mangling), "identity vs value" (`MigrationRegistry`), uniform test setup (every storage test used an already-safe key; every migration test used versions from 1). BREAKING: on-disk save format changed (`.dat`+`.meta` → `.save`); pre-alpha, no migration. Tests +35 (1735 → 1770). Left open: `BINARY`/pickle load is unauthenticated (documented trusted-input-only); no `PersistenceManager` facade for `delete`/`list`; mypy `python_version` 3.10 vs `requires-python` 3.12 forces a `# noqa: UP017` (possible CC). |
 | `pyguara/resources` | 2026-09-08 | One slice (`manager`, `meta`, `loader`, `types`, `data`, `data_loader`; hot reload lives downstream in `pyguara/dev`). No headline crash — better shape than recent subsystems — but the recurring shapes held. **Reference counting was internally inconsistent and wired to nothing**: `load()` auto-incremented on every call incl. cache hits, `release()` auto-unloaded at 0, so `unload_unused()` could never evict anything in use and a released resource was already gone — dead. No engine caller of acquire/release/unload/unload_unused; `AudioManager` `load()`s per play → count climbs forever. `Resource._ref_count` was a *third* dead counter. Reworked (user: "fix the model + add reload()"): `load()` is a pure cache-get → unpinned (0); `acquire()`/`release()` pin; `unload_unused()` now sweeps. `index_directory()` **silently resolved a stem collision to the last file walked** — now the ambiguous bare stem is dropped with a warning, full-name keys always win. `MetaLoader` **cached parsed meta by path with no invalidation** (stale after a disk change — wrong under hot reload) and the path-only key **swallowed the `expected_type` mismatch warning** after the first call — now mtime-pinned + re-read + `invalidate()`, check runs every call. `DataResource` docstring claimed "hot-reloaded by the ResourceManager" with **no reload API** — added `ResourceManager.reload()` (re-run loader, re-read `.meta`, swap in place, keep count). The **`.meta` import pipeline was ~70% scaffolding** (`AudioMeta`/`SpritesheetMeta` had no consumer, GL loader hardcoded `LINEAR`) — wired end to end (user: "wire it up in this slice"): `Resource.import_meta` carries the resolved sidecar; `GLTextureLoader` honours `filter` (default flips to `NEAREST`, matching the pygame path); audio backend applies `AudioMeta.volume_db` as a per-asset channel gain; `SpriteSheet` gained `margin`/`spacing` (previously meaningless) + `slice_from_meta`. Recurring shapes: "declared and wired to nothing" (the whole ref-count half; `AudioMeta`; `_ref_count`) and uniform test setup (`test_resources.py` asserted on `_reference_counts`/`_cache`/`_path_index` privates and hand-poked an impossible state into `test_unload_unused`; every `test_meta.py` test used a fresh `MetaLoader()`). Tests +21. Left open: `AudioMeta.loop_*`/`normalize`/`load_mode`, `TextureMeta.mipmaps`/`wrap_*` still unconsumed (need streaming/DSP/GL-state — authoring-layer gap, sibling of #37); audio should `acquire()` its clips under the new model (small `pyguara/audio` follow-up, no behaviour change today); no lock on the cache dicts (no concurrent caller, parked CC). |
 | `pyguara/animation` | 2026-09-08 | One slice, both halves (`pyguara/animation` tween+easing, plus the sprite-animation FSM in `pyguara/graphics` only surveyed during the graphics audit). **`Tween` accepted only `float` scalars / `tuple`s**: `Tween(0, 100, 1.0)`, a `list`, mixed int/float, or a `Color` constructed fine then crashed on first `update()` with a bare `AssertionError` (`_interpolate` used `assert isinstance(x, float)` as validation, stripped under `-O`). `Tween` was a value-equality `@dataclass`, so `TweenManager.remove(b)` removed an equal-but-different `a` — now `@dataclass(eq=False)`. `Animator.update()` advanced ≤1 frame per call (`if`, not `while`) so a lag spike dropped frames and drifted behind forever while `_current_time` grew unbounded — now O(1) catch-up. `AnimationStateMachine` re-fired `on_complete` + the transition check every frame a non-looping clip sat finished (callback storm for any terminal state) — fixed with a `_completion_handled` latch reset on transition. `AnimationClip` gained `__post_init__` validation (`frame_rate<=0` → `ZeroDivisionError`, `frames=[]` → `IndexError`). `TransitionCondition.IMMEDIATE` was declared but `_check_transitions()` had no branch — now honoured (fires on entry). `Scene.update_animations()` removed: its docstring told games to call it from `scene.update()`, but `AnimationSystem` has been auto-registered on the scene's `SystemManager` since wayfinder ticket 24, so following the docs double-updated every animation; it had no real callers. Recurring shapes: "assert as runtime validation", "identity vs value" (the gamepad-index shape), "one advance per frame" (the audio/application shape), the `on_complete` retrigger storm (audio F5), "no `__post_init__`" (audio F6 / physics config), "declared and wired to nothing" (`IMMEDIATE`), and uniform test setup — every tween test used float `0.0→100.0`, every FSM test stepped `dt == 1/frame_rate` exactly and stopped updating on the completion frame. Left open: a single huge `dt` still resolves only one loop boundary per `Tween.update()` (catches up over later frames, documented); `Color` tweening unsupported (documented); `_allow_methods = True` on both FSM components stays CC-6. |
 | `pyguara/audio` | 2026-09-08 | One slice. **SFX playback was dead end to end**: the pygame backend called `Channel.get_id()` (pygame-ce has `Channel.id`), so every real `play_sfx`/`play_sfx_at_position` raised, was swallowed by `except (AttributeError, Exception)`, and returned `None` while the sound played on untracked — hidden because all 107 audio tests `patch("pygame.mixer")` wholesale. Loudness/pan were set on the ResourceManager-shared `Sound` not the channel, so concurrent plays of one clip corrupted each other and recycled channels kept the last sound's hard pan. `AudioSourceSystem` never detected a finished one-shot — `is_playing` lied forever, a source could not be replayed, and stale channel ids kept receiving spatial mix updates meant for whatever reused the channel; fixed with a new `IAudioSystem.is_channel_active()` reconciled each frame, plus an `_auto_played` latch (auto_play is "on awake", not loop — the fix exposed a retrigger storm). `SpatialAudioConfig` gained `__post_init__` validation (0 → `ZeroDivisionError` in `calculate_pan`; inverted range → attenuation cliff). Added `IAudioSystem.shutdown()` (idempotent `pygame.mixer.quit()`), wired into `Application.shutdown()`. Recurring shapes: "mock away the unit under test" (the whole `test_audio.py`) and "declared and wired to nothing" (`AudioManager._active_channels`, removed). Left open: bus/master volume changes don't re-mix already-playing non-spatial SFX (mixer limitation, documented). |
@@ -464,6 +516,164 @@ convert to explicit `is None` checks as each subsystem is audited.
 ---
 
 ## Iteration Log
+
+### `pyguara/persistence` — CLOSED 2026-09-08 (branch `refactor/persistence-audit`)
+
+One slice, ~970 lines: `persistence/{manager,storage,serializer,migration,
+types}.py`. Every defect reproduced with a probe against the real code
+first. `pyguara/scene/serializer.py` is a *consumer* (goes through
+`save_data`/`load_data`) and was audited under `pyguara/scene`; only its
+test's in-memory backend was touched here, for the protocol change.
+
+**Verification:** 1770 tests pass (up from 1735; +35 across
+`test_persistence.py` — rewritten — `test_migration.py`, and
+`tests/integration/test_persistence_backend.py` — rewritten). `ruff check .`
+clean; `ruff format --check` clean; `mypy pyguara` clean across 225 files;
+`mkdocs build --strict` exit 0; `test_docs_api.py` (54) passes. Both commits
+verified standalone in a detached worktree (`git worktree add --detach`,
+`uv sync --extra dev`): code commit 1768 / 1768, docs commit 1770 / 1770.
+
+One upfront decision put to the user: F3's fix depth. Options were a
+contained single-file fix in the backend, a manager-layer envelope, or
+leave-and-document; the user asked which was more systemic and took the
+**envelope** — the `metadata` argument on `StorageBackend` is what forced
+every backend to keep two things consistent, and it is purely a
+`PersistenceManager` concern. `compress` and `MSGPACK` the user chose to
+implement rather than delete.
+
+**F1 — `save_data()` ignored `storage.save()`'s return value.** The
+`StorageBackend` protocol returns `bool`; `FileStorageBackend.save` returns
+`False` on `OSError` rather than raising. `save_data` called
+`self.storage.save(...)` and discarded the result, logged "Successfully
+saved" and returned `True`. Probe: a backend whose `save` returns `False`
+→ `save_data` returned `True`. "Guard that returns a wrong answer." Now the
+result is checked; `save_data` returns `False` and logs the rejection.
+
+**F2 — `FileStorageBackend._get_paths` collapsed distinct keys.** The key
+was sanitised by *deleting* every character that was not alphanumeric,
+`_` or `-`. Probe: `save("slot 1", …)`, `save("slot/1", …)`, `save("slot.1",
+…)` all wrote `slot1.dat`; the last write won and the first two were gone.
+An all-punctuation key → empty stem → literal `.dat`/`.meta` files, and
+every punctuation-only key aliased together. Exactly the resources F2
+shape ("silently resolved a stem collision to whichever file the walk hit
+last"). Now `FileStorageBackend` raises `ValueError` for any key that is
+empty or contains a character outside `[A-Za-z0-9_-]` — a save key is
+developer-controlled, so reject it loudly (the `config` precedent) rather
+than pick a wrong file.
+
+**F3 — the data file and the meta file were replaced by two independent
+`os.replace` calls.** `storage.save()` wrote `{key}.dat` atomically, then
+`{key}.meta` atomically. `load()`'s comment: "Check both files exist
+(atomic save ensures both or neither)" — false; two replaces are not
+jointly atomic. A crash between them leaves new data + a stale-checksum
+meta, and `load_data(verify_integrity=True)` then returns `None` for a save
+whose bytes are perfectly intact. Probe: desync the two files → `load_data`
+→ `None`. Fixed by the envelope: `PersistenceManager._frame` writes a
+one-line compact-JSON metadata header, a `\n`, then the payload bytes;
+`_unframe` splits on the first `\n`. `StorageBackend` becomes
+`save(key, blob) -> bool` / `load(key) -> bytes | None` (no `metadata`
+param). `FileStorageBackend` writes one `{key}.save` file with the existing
+temp-then-`os.replace`, plus a directory `fsync` after the rename and an
+orphaned-`.tmp_*` sweep on init. **Breaking on-disk format change** —
+pre-alpha, no existing saves, no migration path provided.
+
+**F4 — `compress` was a documented no-op.** `save_data(…, compress=True)`
+did nothing; the docstring said "Not implemented in this snippet". Probe:
+`compress=True` and `compress=False` produced identical file sizes. Now
+`gzip.compress` runs on the payload when set, `compressed: true` goes in
+the header, and `load_data` reverses it transparently. The checksum covers
+the payload as written (post-compression).
+
+**F5 — `SerializationFormat.MSGPACK` had no implementation.**
+`serializer.serialize(…, MSGPACK)` raised `ValueError: Unsupported
+serialization format`, though `msgpack>=1.1.2` is a declared dependency and
+a PyInstaller hidden-import, and the package docstring advertises
+"MessagePack". Implemented: `msgpack.packb(prepare_for_json(data),
+use_bin_type=True)` and `msgpack.unpackb(data, object_hook=game_object_hook,
+raw=False, strict_map_key=False)` — the same engine-value-type path JSON
+uses. Exposed through a new `fmt: SerializationFormat` argument on
+`save_data` (it previously hard-coded JSON, so the format was unreachable
+from the facade). `msgpack.*` added to the mypy `ignore_missing_imports`
+overrides.
+
+**Minor.** `SaveMetadata` was constructed then hand-copied field by field
+into a dict (`# (In a real scenario, use asdict)`) and never reconstructed
+on load; now it carries `format`/`compressed`, is serialised with
+`asdict()`, takes the engine version from `importlib.metadata.version`
+(was hard-coded `"1.0.0"` while pyproject is `0.4.0`), and uses a
+timezone-aware UTC timestamp. `FileStorageBackend.__init__` now
+`os.makedirs(..., exist_ok=True)` (was check-then-create, a TOCTOU race).
+`delete()` returns whether a file was actually removed and guards
+`os.remove`.
+
+**Migration — audited, largely sound.** Probes for a version overshoot, an
+infinite `get_migration_path` loop, and a mid-chain gap all came back
+negative: `register()`'s `to_version <= current_version` guard plus the
+"version not in `_migrations` → raise" plus `to_version > from_version`
+(strictly increasing loop variable) compose to a terminating, gap-free
+walk, and downgrades are already rejected. Added only construction-time
+guards (`Migration.from_version >= 1`, `MigrationManager.current_version
+>= 1` — the "no `__post_init__` validation" recurring theme) and
+`@dataclass(eq=False)` on `MigrationRegistry` (two registries with
+equivalent migrations compared `==` — the `Tween` identity-vs-value shape
+from the animation audit; low stakes here, fixed for consistency). The
+in-place mutate-and-return contract of migration functions is *documented*
+(the `@migration` docstring example does `data.pop`) and left as is; a test
+now pins it.
+
+**Phase B — verdict on the 27 existing tests (+35; `test_persistence.py`
+and `test_persistence_backend.py` rewritten, `test_migration.py` extended).**
+
+*`test_migration.py` (24, +7) — the strong file.* Real assertions on real
+return values through the public surface: `Migration` validation, register
+/ path / single- and multi-step `migrate` / decorator / registry. Good
+coverage of the ordering guards. **Uniform version setup** was the blind
+spot — every `Migration` used small positive ints from 1, so the F-guards
+(version 0 / negative) had no test, and `MigrationRegistry` equality was
+never probed. Added: the `>= 1` rejections, the identity-equality
+guarantee, and a test pinning the mutate-and-return chain threading one
+dict.
+
+*`test_persistence.py` (3 → ~12) — thin, rewritten.* Only `Serializer`
+JSON round-trips for `Vector2`/`Color`/one dataclass. No msgpack, no
+BINARY, no `PersistenceManager`, no compression, no integrity, no envelope.
+Rewrote as a `Serializer` unit file: JSON + MSGPACK (parametrised over
+`Vector2`/`Color`/`Rect`/nested) + BINARY round-trips, msgpack-is-smaller,
+default-format selection.
+
+*`tests/integration/test_persistence_backend.py` (4 → ~20) — rewritten.*
+Decent shape (real `tmp_path`, real files) but pinned to the old two-file
+`.dat`/`.meta` protocol and the 3-arg `save`, and every key was already
+filesystem-safe (`save1`, `slot_a`, `autosave`) so F2 was unreachable.
+Rewrote for the blob protocol: save/load/overwrite, the key-rejection
+parametrisation (space, slash, dot, `..`, NUL, `:` , `\`), `list_keys` /
+`delete` semantics, `makedirs` idempotence, the temp-file sweep; then
+`PersistenceManager` end to end — envelope layout, integrity failure →
+`None` (and `verify_integrity=False` surfacing the tampered value), the F1
+backend-failure → `False`, gzip round-trip + size, msgpack via `fmt=`, and
+migrate-on-load.
+
+**Phase C.** `pyguara/persistence` had **no docs page at all** (the
+resources iteration's Phase C note anticipated this: "gets its own page").
+Wrote `docs/systems/persistence.md` in the resources-page voice:
+`save_data`/`load_data` (keys, `fmt`, `compress`, `save_version`), the
+single-blob on-disk format + its MD5 checksum, the `StorageBackend`
+protocol and `FileStorageBackend`'s key rule, and the migration pipeline
+(registration, contiguous chain, load-time application, no downgrade,
+`MigrationError`). Added to the mkdocs nav; `test_docs_api.py` picks up the
+new backticked references (52 → 54) and they resolve. Notes the
+`BINARY`/pickle "trusted files only" caveat.
+
+**Left open.** `save_data` records the payload `fmt` but the *metadata*
+header is always JSON — deliberate, it stays greppable. `BINARY`/pickle
+load is unauthenticated (an MD5 the attacker can recompute is no defence);
+documented as trusted-input-only, a signing scheme is its own slice. No
+`PersistenceManager` facade for `delete`/`list`/`exists` — callers reach
+into `.storage` (only `SceneSerializer` does). `ResourceManager`-style: no
+lock on anything, but persistence has no concurrent caller. Mypy's
+`python_version = "3.10"` vs `requires-python` 3.12 makes ruff's UP017
+(`datetime.UTC`) and mypy disagree — one `# noqa: UP017`; worth a CC if it
+recurs.
 
 ### `pyguara/resources` — CLOSED 2026-09-08 (branch `refactor/resources-audit`)
 

--- a/docs/systems/persistence.md
+++ b/docs/systems/persistence.md
@@ -1,0 +1,124 @@
+# Persistence
+
+`pyguara.persistence` is the save/load layer: it turns an object graph into
+a durable file on disk and back, verifies it has not been corrupted, and
+migrates old save files forward as your schema changes.
+
+```python
+from pyguara.persistence import PersistenceManager
+
+pm = container.get(PersistenceManager)
+
+pm.save_data("slot_1", {"level": 3, "hp": 100})
+state = pm.load_data("slot_1")            # -> {"level": 3, "hp": 100} or None
+```
+
+The bootstrap wires a `PersistenceManager` backed by a `FileStorageBackend`
+rooted at `./saves` and a `MigrationManager` at `current_version=1`.
+
+## `save_data` / `load_data`
+
+| | |
+| --- | --- |
+| `save_data(key, data, save_version=1, compress=False, fmt=JSON)` | Serialize, checksum, and write one blob. Returns `True` only if the bytes reached storage. |
+| `load_data(key, verify_integrity=True)` | Read, verify, deserialize, migrate. Returns the object, or `None` if the key is absent, the blob is corrupt, or a migration failed. |
+
+`data` may be any JSON-friendly graph; `Vector2`, `Color` and `Rect` are
+recognised and round-trip as themselves. A `dict` is the only top-level
+shape that migrations apply to.
+
+- **`fmt`** — `SerializationFormat.JSON` (default, human-readable),
+  `MSGPACK` (compact binary, same value-type support as JSON), or `BINARY`
+  (pickle — handles arbitrary objects but **only load a `BINARY` file you
+  trust**; deserializing a pickle runs code).
+- **`compress`** — gzip the payload before writing. Transparent on load
+  (the header records it).
+- **`save_version`** — the schema version stamped into the file, read back
+  by the migration step.
+
+`load_data` never raises for a bad file: a missing key, a truncated blob, a
+failed checksum, or a failed migration all log and return `None`.
+
+## On-disk format
+
+Each key is stored as **one file** — `saves/<key>.save` for the file
+backend — laid out as a single-line JSON metadata header, a newline, then
+the payload bytes:
+
+```
+{"version":"0.4.0","timestamp":"2026-09-08T17:02:37+00:00","data_type":"dict","checksum":"87f0…","save_version":1,"format":"json","compressed":false}
+{
+  "level": 3,
+  "hp": 100
+}
+```
+
+Metadata and payload share one file so there is no window in which they can
+disagree — the write either lands whole or not at all. The `checksum` is an
+MD5 of the payload bytes exactly as written (after compression, if any);
+`load_data(verify_integrity=False)` skips the comparison.
+
+## Storage backends
+
+`PersistenceManager` talks to a `StorageBackend` — a plain key → blob
+store:
+
+```python
+class StorageBackend(Protocol):
+    def save(self, key: str, blob: bytes) -> bool: ...
+    def load(self, key: str) -> bytes | None: ...
+    def delete(self, key: str) -> bool: ...
+    def list_keys(self) -> list[str]: ...
+```
+
+`FileStorageBackend(base_path="saves")` is the built-in implementation. It
+writes atomically (temp file, `fsync`, `os.replace`, then an `fsync` of the
+directory) and sweeps orphaned `.tmp_*` files left by a crashed write on
+startup.
+
+**Keys must be filesystem-safe as given** — letters, digits, `_` and `-`.
+A key containing a space, a dot, or a path separator is rejected with
+`ValueError` rather than silently rewritten: `"slot 1"` and `"slot/1"` would
+otherwise both collapse onto `slot1` and overwrite each other.
+
+## Migrations
+
+When a loaded save's `save_version` is older than the
+`MigrationManager`'s `current_version`, `load_data` walks the registered
+migrations in order and applies each one before returning.
+
+```python
+from pyguara.persistence import register_migration
+
+@register_migration(from_version=1, to_version=2, description="hp -> health")
+def _v1_to_v2(data: dict) -> dict:
+    data["health"] = data.pop("hp")
+    return data
+```
+
+A migration function takes the data `dict`, mutates and returns it. The
+`MigrationManager` threads one dict through the whole chain
+(`1 → 2 → 3 → …`), so a migration sees the output of the previous step.
+
+- Register via `@register_migration` (collected in the global registry,
+  which the bootstrap drains into the manager) or
+  `MigrationManager.register(Migration(...))` directly.
+- `to_version` must be greater than `from_version`, both `>= 1`, and no two
+  migrations may share a `from_version`.
+- The chain must be **contiguous** from the save's version to
+  `current_version` — a gap raises `ValueError` (caught by `load_data`,
+  logged, returns `None`).
+- **No downgrades.** Loading a save whose version is *newer* than
+  `current_version` fails rather than guessing.
+- A migration that raises is wrapped in `MigrationError` with the failing
+  step; the partly-migrated data is discarded.
+
+`MigrationManager.needs_migration(v)` and `has_migration_path(v)` let you
+check ahead of a load.
+
+## Scenes
+
+`SceneSerializer` (`pyguara.scene`) is the higher-level entry point for
+saving a whole scene's entities and components; it serializes each entity to
+a dict and hands the result to `PersistenceManager.save_data`. See the
+Scenes page for that layer.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,5 +39,6 @@ nav:
       - Audio: systems/audio.md
       - Editor Tools: systems/editor.md
       - Input: systems/input.md
+      - Persistence: systems/persistence.md
       - Resources: systems/resources.md
       - Scripting: systems/scripting.md

--- a/pyguara/persistence/manager.py
+++ b/pyguara/persistence/manager.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import gzip
 import hashlib
-from datetime import datetime
-from typing import TYPE_CHECKING, Any, TypeVar
+import json
+from dataclasses import asdict
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
+from typing import TYPE_CHECKING, Any
 
 from pyguara.log import get_logger
 from pyguara.persistence.serializer import Serializer
@@ -14,18 +18,28 @@ if TYPE_CHECKING:
     from pyguara.persistence.migration import MigrationManager
 
 logger = get_logger(__name__)
-T = TypeVar("T")
+
+_HEADER_SEP = b"\n"
+
+try:
+    _ENGINE_VERSION = version("pyguara")
+except PackageNotFoundError:  # pragma: no cover - only when run uninstalled
+    _ENGINE_VERSION = "0.0.0"
 
 
 class PersistenceManager:
-    """
-    Coordinator for the Data Persistence subsystem.
+    """Coordinator for the data persistence subsystem.
 
-    This manager orchestrates serialization, integrity checking, and storage.
-    It acts as the Facade for the rest of the engine to save/load data.
+    Orchestrates serialization, integrity checking and storage, acting as
+    the facade the rest of the engine uses to save and load data.
+
+    A save is written as a single blob: a one-line JSON metadata header,
+    a newline, then the serialized (and optionally compressed) payload.
+    The storage backend only has to make that one blob durable, so there is
+    no window in which metadata and payload can disagree.
 
     Attributes:
-        storage: The backend storage implementation (e.g., FileSystem, SQLite).
+        storage: The backend blob store.
         serializer: The serialization handler.
         migration_manager: Optional manager for schema migrations.
     """
@@ -38,103 +52,102 @@ class PersistenceManager:
         """Initialize the persistence manager.
 
         Args:
-            storage_backend: The concrete implementation of where data is stored.
-            migration_manager: Optional manager for handling schema migrations.
+            storage_backend: The concrete blob store to persist to.
+            migration_manager: Optional manager for handling schema
+                migrations on load.
         """
         self.storage = storage_backend
         self.serializer = Serializer(default_format=SerializationFormat.JSON)
         self.migration_manager = migration_manager
 
     def save_data(
-        self, key: str, data: Any, save_version: int = 1, compress: bool = False
+        self,
+        key: str,
+        data: Any,
+        save_version: int = 1,
+        compress: bool = False,
+        fmt: SerializationFormat = SerializationFormat.JSON,
     ) -> bool:
         """Save an object to storage.
 
-        Calculates checksums and attaches metadata automatically.
+        Serializes the object, records integrity and schema metadata, and
+        writes the result as one atomic blob.
 
         Args:
-            key: Unique identifier for this save data (e.g., "player_save_1").
+            key: Unique identifier for this save data (e.g. "player_save_1").
             data: The object to save.
-            save_version: The schema version of the data (for migrations).
-            compress: Whether to apply compression (Not implemented in this snippet).
+            save_version: The schema version of the data, for migrations.
+            compress: If True, gzip the serialized payload before writing.
+            fmt: Serialization format. JSON (the default) stays
+                human-readable; MSGPACK is more compact; BINARY (pickle)
+                handles arbitrary objects but must only be loaded from
+                trusted files.
 
         Returns:
-            True if successful, False otherwise.
+            True if the blob was written, False if serialization or the
+            storage write failed.
         """
         try:
-            # 1. Serialize
-            # We use JSON by default for debuggability, but this could be config driven
-            fmt = SerializationFormat.JSON
-            raw_bytes = self.serializer.serialize(data, format_type=fmt)
+            payload = self.serializer.serialize(data, format_type=fmt)
+            if compress:
+                payload = gzip.compress(payload)
 
-            # 2. Integrity
-            checksum = hashlib.md5(raw_bytes).hexdigest()
-
-            # 3. Metadata
             metadata = SaveMetadata(
-                version="1.0.0",  # Engine version
-                timestamp=datetime.now(),
+                version=_ENGINE_VERSION,
+                timestamp=datetime.now(timezone.utc),  # noqa: UP017 (mypy py3.10)
                 data_type=type(data).__name__,
-                checksum=checksum,
+                checksum=hashlib.md5(payload).hexdigest(),  # noqa: S324
                 save_version=save_version,
+                format=fmt.value,
+                compressed=compress,
             )
-
-            # Convert metadata to dict for storage
-            # (In a real scenario, use asdict)
-            meta_dict = {
-                "version": metadata.version,
-                "timestamp": metadata.timestamp.isoformat(),
-                "data_type": metadata.data_type,
-                "checksum": metadata.checksum,
-                "save_version": metadata.save_version,
-                "format": fmt.value,
-            }
-
-            # 4. Storage
-            self.storage.save(key, raw_bytes, meta_dict)
-            logger.info(f"Successfully saved data '{key}'")
-            return True
-
+            blob = self._frame(metadata, payload)
         except Exception as e:
-            logger.error(f"Failed to save data '{key}': {e}", exc_info=True)
+            logger.error(f"Failed to serialize data '{key}': {e}", exc_info=True)
             return False
+
+        if not self.storage.save(key, blob):
+            logger.error(f"Storage backend rejected write for '{key}'")
+            return False
+
+        logger.info(f"Successfully saved data '{key}'")
+        return True
 
     def load_data(self, key: str, verify_integrity: bool = True) -> Any | None:
         """Load an object from storage.
 
         Args:
             key: Unique identifier for the save data.
-            verify_integrity: If True, validates MD5 checksum before returning.
+            verify_integrity: If True, validate the payload's MD5 checksum
+                before deserializing.
 
         Returns:
-            The deserialized object, or None if failed/corrupted.
+            The deserialized object, or None if the key is absent, the blob
+            is corrupt, or a migration failed.
         """
         try:
-            # 1. Retrieve
-            result = self.storage.load(key)
-            if not result:
+            blob = self.storage.load(key)
+            if blob is None:
                 logger.warning(f"No data found for key '{key}'")
                 return None
 
-            raw_bytes, meta_dict = result
+            meta_dict, payload = self._unframe(blob)
 
-            # 2. Verify Integrity
             if verify_integrity:
-                stored_checksum = meta_dict.get("checksum")
-                calculated_checksum = hashlib.md5(raw_bytes).hexdigest()
-                if stored_checksum != calculated_checksum:
+                stored = meta_dict.get("checksum")
+                calculated = hashlib.md5(payload).hexdigest()  # noqa: S324
+                if stored != calculated:
                     logger.error(
                         f"Integrity check failed for '{key}'. File may be corrupted."
                     )
                     return None
 
-            # 3. Deserialize
-            fmt_str = meta_dict.get("format", "json")
-            fmt = SerializationFormat(fmt_str)
+            if meta_dict.get("compressed"):
+                payload = gzip.decompress(payload)
 
-            data = self.serializer.deserialize(raw_bytes, format_type=fmt)
+            fmt = SerializationFormat(meta_dict.get("format", "json"))
+            data = self.serializer.deserialize(payload, format_type=fmt)
 
-            # 4. Apply Migrations if needed
             if self.migration_manager and isinstance(data, dict):
                 save_version = meta_dict.get("save_version", 1)
                 if self.migration_manager.needs_migration(save_version):
@@ -149,3 +162,37 @@ class PersistenceManager:
         except Exception as e:
             logger.error(f"Failed to load data '{key}': {e}", exc_info=True)
             return None
+
+    @staticmethod
+    def _frame(metadata: SaveMetadata, payload: bytes) -> bytes:
+        """Combine metadata and payload into one blob.
+
+        Args:
+            metadata: The save metadata.
+            payload: The serialized (and optionally compressed) payload.
+
+        Returns:
+            ``<header json><newline><payload bytes>``.
+        """
+        meta_dict = asdict(metadata)
+        meta_dict["timestamp"] = metadata.timestamp.isoformat()
+        header = json.dumps(meta_dict, separators=(",", ":")).encode("utf-8")
+        return header + _HEADER_SEP + payload
+
+    @staticmethod
+    def _unframe(blob: bytes) -> tuple[dict[str, Any], bytes]:
+        """Split a blob back into its metadata dict and payload bytes.
+
+        Args:
+            blob: A blob produced by :meth:`_frame`.
+
+        Returns:
+            ``(metadata_dict, payload_bytes)``.
+
+        Raises:
+            ValueError: If the blob has no header separator.
+        """
+        header, sep, payload = blob.partition(_HEADER_SEP)
+        if not sep:
+            raise ValueError("Save blob is missing its metadata header")
+        return json.loads(header.decode("utf-8")), payload

--- a/pyguara/persistence/migration.py
+++ b/pyguara/persistence/migration.py
@@ -33,6 +33,10 @@ class Migration:
 
     def __post_init__(self) -> None:
         """Validate migration version ordering."""
+        if self.from_version < 1:
+            raise ValueError(
+                f"Migration from_version must be >= 1, got {self.from_version}"
+            )
         if self.to_version <= self.from_version:
             raise ValueError(
                 f"Migration to_version ({self.to_version}) must be greater than "
@@ -69,8 +73,13 @@ class MigrationManager:
         """Initialize the migration manager.
 
         Args:
-            current_version: The current schema version.
+            current_version: The current schema version. Must be >= 1.
+
+        Raises:
+            ValueError: If ``current_version`` is less than 1.
         """
+        if current_version < 1:
+            raise ValueError(f"current_version must be >= 1, got {current_version}")
         self.current_version = current_version
         self._migrations: dict[int, Migration] = {}  # from_version -> Migration
 
@@ -241,11 +250,14 @@ def migration(
     return decorator
 
 
-@dataclass
+@dataclass(eq=False)
 class MigrationRegistry:
     """Global registry for auto-discovered migrations.
 
     Use this to collect migrations defined across multiple modules.
+
+    Identity-compared: two registries are equal only if they are the same
+    object, never merely because they hold equivalent migrations.
     """
 
     _migrations: list[Migration] = field(default_factory=list)

--- a/pyguara/persistence/serializer.py
+++ b/pyguara/persistence/serializer.py
@@ -5,6 +5,8 @@ import json
 import pickle
 from typing import Any
 
+import msgpack
+
 from pyguara.common.types import Color, Rect, Vector2
 from pyguara.persistence.types import SerializationFormat
 
@@ -116,6 +118,11 @@ class Serializer:
             clean_data = prepare_for_json(data)
             return json.dumps(clean_data, indent=2).encode("utf-8")
 
+        elif fmt == SerializationFormat.MSGPACK:
+            # prepare_for_json reduces engine value types to tagged dicts,
+            # which msgpack packs natively; game_object_hook rebuilds them.
+            return bytes(msgpack.packb(prepare_for_json(data), use_bin_type=True))
+
         elif fmt == SerializationFormat.BINARY:
             return pickle.dumps(data)
 
@@ -140,6 +147,11 @@ class Serializer:
 
         if fmt == SerializationFormat.JSON:
             return json.loads(data.decode("utf-8"), object_hook=game_object_hook)
+
+        elif fmt == SerializationFormat.MSGPACK:
+            return msgpack.unpackb(
+                data, object_hook=game_object_hook, raw=False, strict_map_key=False
+            )
 
         elif fmt == SerializationFormat.BINARY:
             return pickle.loads(data)

--- a/pyguara/persistence/storage.py
+++ b/pyguara/persistence/storage.py
@@ -1,20 +1,22 @@
 """Concrete storage backend implementations."""
 
-import json
+import contextlib
 import os
 import tempfile
-from typing import Any
 
 from pyguara.log import get_logger
 
 logger = get_logger(__name__)
+
+_TEMP_PREFIX = ".tmp_"
 
 
 def _atomic_write_bytes(path: str, data: bytes) -> None:
     """Atomically write bytes to a file using write-to-temp-then-rename.
 
     This ensures that the target file is never left in a partial state.
-    If a crash occurs during the write, only the temp file is affected.
+    If a crash occurs during the write, only the temp file is affected;
+    the previous contents of ``path`` remain intact until the rename.
 
     Args:
         path: The target file path.
@@ -26,7 +28,7 @@ def _atomic_write_bytes(path: str, data: bytes) -> None:
     dir_path = os.path.dirname(path) or "."
 
     # Create temp file in the same directory to ensure same filesystem
-    fd, temp_path = tempfile.mkstemp(dir=dir_path, prefix=".tmp_")
+    fd, temp_path = tempfile.mkstemp(dir=dir_path, prefix=_TEMP_PREFIX)
     try:
         os.write(fd, data)
         os.fsync(fd)  # Ensure data is flushed to disk
@@ -43,159 +45,156 @@ def _atomic_write_bytes(path: str, data: bytes) -> None:
             os.remove(temp_path)
         raise
 
-
-def _atomic_write_text(path: str, text: str, encoding: str = "utf-8") -> None:
-    """Atomically write text to a file using write-to-temp-then-rename.
-
-    Args:
-        path: The target file path.
-        text: The text to write.
-        encoding: The text encoding to use.
-
-    Raises:
-        OSError: If the write or rename fails.
-    """
-    _atomic_write_bytes(path, text.encode(encoding))
+    # Flush the rename itself so the swap survives a crash, not just the
+    # bytes inside the file.
+    try:
+        dir_fd = os.open(dir_path, os.O_DIRECTORY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        # Directory fsync is a durability nicety; platforms without
+        # O_DIRECTORY (or where it is not permitted) still get the rename.
+        pass
 
 
 class FileStorageBackend:
-    """
-    Storage backend that saves data to the local filesystem.
+    """Storage backend that saves each key as one file on the local disk.
 
-    Each 'key' maps to a file in the base directory.
-    Format:
-        {key}.dat -> Raw Data
-        {key}.meta -> Metadata (JSON)
+    Each key maps to a single ``{key}.save`` file under ``base_path``,
+    written with an atomic temp-file-then-rename so a crash mid-write never
+    corrupts the previous value.
 
-    Uses atomic writes to prevent data corruption on crash.
+    Keys must be filesystem-safe as given: alphanumerics, ``_`` and ``-``.
+    A key that would need rewriting to be safe is rejected with
+    ``ValueError`` rather than silently mangled -- two keys that sanitise to
+    the same name would otherwise overwrite each other.
     """
+
+    SUFFIX = ".save"
 
     def __init__(self, base_path: str = "saves") -> None:
-        """
-        Initialize the file storage.
+        """Initialize the file storage.
 
         Args:
-            base_path: Directory where files will be stored.
+            base_path: Directory where files will be stored. Created if
+                absent.
         """
         self.base_path = base_path
-        if not os.path.exists(self.base_path):
-            os.makedirs(self.base_path)
+        os.makedirs(self.base_path, exist_ok=True)
+        self._sweep_temp_files()
 
-    def _get_paths(self, key: str) -> tuple[str, str]:
-        """Return (data_path, meta_path) for a given key."""
-        # Sanitize key to avoid path traversal
-        safe_key = "".join(c for c in key if c.isalnum() or c in ("_", "-"))
-        return (
-            os.path.join(self.base_path, f"{safe_key}.dat"),
-            os.path.join(self.base_path, f"{safe_key}.meta"),
-        )
+    def _sweep_temp_files(self) -> None:
+        """Remove orphaned temp files left by a crashed write."""
+        try:
+            entries = os.listdir(self.base_path)
+        except OSError:
+            return
+        for name in entries:
+            if name.startswith(_TEMP_PREFIX):
+                with contextlib.suppress(OSError):
+                    os.remove(os.path.join(self.base_path, name))
 
-    def save(self, key: str, data: bytes, metadata: dict[str, Any]) -> bool:
-        """Save data and metadata to disk atomically.
+    def _path_for(self, key: str) -> str:
+        """Return the file path for a key, validating the key first.
 
-        Uses atomic writes to prevent data corruption. Both files are
-        written to temporary files first, then atomically renamed.
-        If a crash occurs during save, the previous version remains intact.
+        Args:
+            key: The storage key.
+
+        Returns:
+            Absolute-or-relative path to the key's ``.save`` file.
+
+        Raises:
+            ValueError: If the key is empty or contains characters that are
+                not alphanumeric, ``_`` or ``-``.
+        """
+        if not key:
+            raise ValueError("Storage key must be a non-empty string")
+        if any(not (c.isalnum() or c in ("_", "-")) for c in key):
+            raise ValueError(
+                f"Invalid storage key {key!r}: only letters, digits, '_' and "
+                f"'-' are allowed (no spaces, dots or path separators)"
+            )
+        return os.path.join(self.base_path, f"{key}{self.SUFFIX}")
+
+    def save(self, key: str, blob: bytes) -> bool:
+        """Write a blob to disk atomically.
 
         Args:
             key: Unique identifier for the data.
-            data: The raw binary data to store.
-            metadata: Dictionary of metadata associated with the data.
+            blob: The bytes to store.
 
         Returns:
-            True if the save was successful, False otherwise.
+            True if the write succeeded, False on an OS-level failure.
+
+        Raises:
+            ValueError: If the key is not filesystem-safe.
         """
-        data_path, meta_path = self._get_paths(key)
-
+        path = self._path_for(key)
         try:
-            # Write data file atomically first
-            _atomic_write_bytes(data_path, data)
-
-            # Write metadata file atomically
-            meta_json = json.dumps(metadata, indent=4)
-            _atomic_write_text(meta_path, meta_json)
-
-            logger.debug("Saved '%s' (%d bytes)", key, len(data))
+            _atomic_write_bytes(path, blob)
+            logger.debug("Saved '%s' (%d bytes)", key, len(blob))
             return True
         except OSError as e:
             logger.error("Save failed for '%s': %s", key, e, exc_info=True)
             return False
 
-    def load(self, key: str) -> tuple[bytes, dict[str, Any]] | None:
-        """Load data and metadata from disk.
+    def load(self, key: str) -> bytes | None:
+        """Read the blob stored under a key.
 
         Args:
             key: Unique identifier for the data.
 
         Returns:
-            A tuple (data, metadata) if found and valid, None otherwise.
-            Returns None if either file is missing (possibly corrupted save).
+            The stored bytes, or None if the file is absent or unreadable.
+
+        Raises:
+            ValueError: If the key is not filesystem-safe.
         """
-        data_path, meta_path = self._get_paths(key)
-
-        # Check both files exist (atomic save ensures both or neither)
-        if not os.path.exists(data_path):
-            if os.path.exists(meta_path):
-                logger.warning(
-                    "Corrupted save '%s': metadata exists but data missing", key
-                )
+        path = self._path_for(key)
+        if not os.path.exists(path):
             return None
-
-        if not os.path.exists(meta_path):
-            logger.warning("Corrupted save '%s': data exists but metadata missing", key)
-            return None
-
         try:
-            with open(data_path, "rb") as f:
-                data = f.read()
-
-            with open(meta_path, encoding="utf-8") as f:
-                meta = json.load(f)
-
-            logger.debug("Loaded '%s' (%d bytes)", key, len(data))
-            return data, meta
+            with open(path, "rb") as f:
+                blob = f.read()
+            logger.debug("Loaded '%s' (%d bytes)", key, len(blob))
+            return blob
         except OSError as e:
             logger.error("Load failed for '%s': %s", key, e, exc_info=True)
             return None
-        except json.JSONDecodeError as e:
-            logger.error("Metadata corrupted for '%s': %s", key, e, exc_info=True)
-            return None
 
     def delete(self, key: str) -> bool:
-        """Delete data and metadata files for a key.
+        """Delete the file for a key.
 
         Args:
             key: Unique identifier for the data to delete.
 
         Returns:
-            True if at least the data file was deleted, False if not found.
+            True if a file was removed, False if it was already absent.
+
+        Raises:
+            ValueError: If the key is not filesystem-safe.
         """
-        data_path, meta_path = self._get_paths(key)
-
-        success = False
-        if os.path.exists(data_path):
-            os.remove(data_path)
-            success = True
-
-        if os.path.exists(meta_path):
-            os.remove(meta_path)
-
-        if success:
-            logger.debug("Deleted '%s'", key)
-
-        return success
+        path = self._path_for(key)
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            return False
+        except OSError as e:
+            logger.error("Delete failed for '%s': %s", key, e, exc_info=True)
+            return False
+        logger.debug("Deleted '%s'", key)
+        return True
 
     def list_keys(self) -> list[str]:
-        """List all available keys in storage.
+        """List all keys currently present in storage.
 
         Returns:
-            List of key names (based on .meta files present).
+            Key names (files ending in ``.save``, suffix stripped).
         """
-        keys = []
-        if not os.path.exists(self.base_path):
+        try:
+            entries = os.listdir(self.base_path)
+        except OSError:
             return []
-
-        for filename in os.listdir(self.base_path):
-            if filename.endswith(".meta"):
-                keys.append(filename[:-5])
-        return keys
+        return [n[: -len(self.SUFFIX)] for n in entries if n.endswith(self.SUFFIX)]

--- a/pyguara/persistence/types.py
+++ b/pyguara/persistence/types.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 
 class SerializationFormat(Enum):
@@ -16,15 +16,22 @@ class SerializationFormat(Enum):
 
 @dataclass
 class SaveMetadata:
-    """
-    Metadata associated with a stored object.
+    """Metadata recorded alongside a stored object.
+
+    Serialised into the header of every save blob and re-read on load; the
+    load path uses ``format``/``compressed`` to reverse the encoding and
+    ``checksum`` to verify integrity.
 
     Attributes:
-        version: The version string of the engine/game when saved.
-        timestamp: When the data was saved.
+        version: The engine version string when the data was saved.
+        timestamp: When the data was saved (timezone-aware, UTC).
         data_type: The class name of the stored object.
-        checksum: MD5 hash for integrity verification.
-        save_version: Integer version for migration tracking.
+        checksum: MD5 hash of the stored payload bytes, for integrity
+            verification. Covers the payload exactly as written to disk
+            (after compression, if any).
+        save_version: Integer schema version, for migration tracking.
+        format: The ``SerializationFormat`` value the payload is encoded in.
+        compressed: Whether the payload bytes are gzip-compressed.
     """
 
     version: str
@@ -32,47 +39,53 @@ class SaveMetadata:
     data_type: str
     checksum: str | None = None
     save_version: int = 1
+    format: str = "json"
+    compressed: bool = False
 
 
 @runtime_checkable
 class StorageBackend(Protocol):
-    """Interface for physical data storage mechanisms."""
+    """Interface for physical data storage mechanisms.
 
-    def save(self, key: str, data: bytes, metadata: dict[str, Any]) -> bool:
-        """Save raw bytes and metadata to the storage medium.
+    A backend is a plain key -> blob store. Framing of metadata into the
+    blob is the ``PersistenceManager``'s job, so a backend only has to make
+    a single value durable per key rather than keep two files consistent.
+    """
+
+    def save(self, key: str, blob: bytes) -> bool:
+        """Persist a blob under a key, replacing any existing value.
 
         Args:
             key: Unique identifier for the data.
-            data: The raw binary data to store.
-            metadata: Dictionary of metadata associated with the data.
+            blob: The bytes to store.
 
         Returns:
-            True if the save was successful, False otherwise.
+            True if the write succeeded, False otherwise.
         """
         ...
 
-    def load(self, key: str) -> tuple[bytes, dict[str, Any]] | None:
-        """Load raw bytes and metadata from the storage medium.
+    def load(self, key: str) -> bytes | None:
+        """Return the blob stored under a key.
 
         Args:
             key: Unique identifier for the data.
 
         Returns:
-            A tuple (data, metadata) if found, None otherwise.
+            The stored bytes, or None if the key is absent or unreadable.
         """
         ...
 
     def delete(self, key: str) -> bool:
-        """Delete data from the storage medium.
+        """Delete the value stored under a key.
 
         Args:
             key: Unique identifier for the data.
 
         Returns:
-            True if deleted, False if not found or failed.
+            True if a value was removed, False if the key was absent.
         """
         ...
 
     def list_keys(self) -> list[str]:
-        """List all available keys in storage."""
+        """List all keys currently present in storage."""
         ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,6 +283,10 @@ module = "PyInstaller.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = "msgpack.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = "pyguara.game.*"
 ignore_missing_imports = true
 

--- a/tests/integration/test_persistence_backend.py
+++ b/tests/integration/test_persistence_backend.py
@@ -1,89 +1,187 @@
-"""Integration tests for Persistence System backend."""
+"""Integration tests for the persistence subsystem.
 
+Covers ``FileStorageBackend`` as a blob store and ``PersistenceManager``
+end to end against real files under ``tmp_path``.
+"""
+
+import gzip
 import json
-import tempfile
-from collections.abc import Generator
-from pathlib import Path
 
 import pytest
 
 from pyguara.persistence.manager import PersistenceManager
+from pyguara.persistence.migration import Migration, MigrationManager
 from pyguara.persistence.storage import FileStorageBackend
+from pyguara.persistence.types import SerializationFormat
 
 
+# --------------------------------------------------------------------------- #
+# FileStorageBackend                                                           #
+# --------------------------------------------------------------------------- #
+class TestFileStorageBackend:
+    def test_save_load_roundtrip(self, tmp_path):
+        backend = FileStorageBackend(base_path=str(tmp_path))
+        backend.save("save1", b"hello world")
+
+        assert (tmp_path / "save1.save").exists()
+        assert backend.load("save1") == b"hello world"
+
+    def test_load_missing_key_returns_none(self, tmp_path):
+        backend = FileStorageBackend(base_path=str(tmp_path))
+        assert backend.load("ghost") is None
+
+    def test_save_overwrites_in_place(self, tmp_path):
+        backend = FileStorageBackend(base_path=str(tmp_path))
+        backend.save("s", b"first")
+        backend.save("s", b"second")
+        assert backend.load("s") == b"second"
+        assert list(tmp_path.glob("*.save")) == [tmp_path / "s.save"]
+
+    @pytest.mark.parametrize(
+        "bad_key",
+        ["", "slot 1", "slot/1", "slot.1", "../etc/passwd", "a\x00b", "a:b", "a\\b"],
+    )
+    def test_unsafe_keys_are_rejected_not_mangled(self, tmp_path, bad_key):
+        """Keys that would need sanitising raise instead of silently
+        collapsing onto each other (two keys -> one file -> lost save)."""
+        backend = FileStorageBackend(base_path=str(tmp_path))
+        with pytest.raises(ValueError):
+            backend.save(bad_key, b"x")
+        with pytest.raises(ValueError):
+            backend.load(bad_key)
+
+    def test_safe_keys_with_dash_and_underscore_allowed(self, tmp_path):
+        backend = FileStorageBackend(base_path=str(tmp_path))
+        assert backend.save("slot_1-autosave", b"ok")
+        assert backend.load("slot_1-autosave") == b"ok"
+
+    def test_list_keys(self, tmp_path):
+        backend = FileStorageBackend(base_path=str(tmp_path))
+        backend.save("slot_a", b"")
+        backend.save("slot_b", b"")
+        (tmp_path / "not-a-save.txt").write_text("ignore me")
+        assert sorted(backend.list_keys()) == ["slot_a", "slot_b"]
+
+    def test_delete_reports_whether_a_file_was_removed(self, tmp_path):
+        backend = FileStorageBackend(base_path=str(tmp_path))
+        backend.save("gone", b"x")
+        assert backend.delete("gone") is True
+        assert backend.delete("gone") is False
+        assert backend.load("gone") is None
+
+    def test_creates_base_path_and_tolerates_existing(self, tmp_path):
+        target = tmp_path / "deep" / "saves"
+        FileStorageBackend(base_path=str(target))
+        # Second construction over an existing directory must not raise.
+        FileStorageBackend(base_path=str(target))
+        assert target.is_dir()
+
+    def test_sweeps_orphaned_temp_files_on_init(self, tmp_path):
+        (tmp_path / ".tmp_crashed").write_bytes(b"partial")
+        (tmp_path / "real.save").write_bytes(b"keep")
+        backend = FileStorageBackend(base_path=str(tmp_path))
+        assert not (tmp_path / ".tmp_crashed").exists()
+        assert backend.load("real") == b"keep"
+
+
+# --------------------------------------------------------------------------- #
+# PersistenceManager end to end                                                #
+# --------------------------------------------------------------------------- #
 @pytest.fixture
-def temp_storage_path() -> Generator[Path, None, None]:
-    """Create a temporary directory for saves."""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        yield Path(tmp_dir)
+def manager(tmp_path):
+    return PersistenceManager(FileStorageBackend(base_path=str(tmp_path)))
 
 
-def test_file_storage_save_load(temp_storage_path: Path) -> None:
-    """FileStorageBackend should save and load data."""
-    backend = FileStorageBackend(base_path=str(temp_storage_path))
+class TestPersistenceManager:
+    def test_save_load_roundtrip(self, manager):
+        data = {"score": 500, "name": "Player"}
+        assert manager.save_data("autosave", data) is True
+        assert manager.load_data("autosave") == data
 
-    data = {"player_xp": 100, "level": 2}
-    data_bytes = json.dumps(data).encode("utf-8")
-    meta = {"version": 1}
+    def test_blob_is_a_single_file_with_a_json_header_line(self, manager, tmp_path):
+        manager.save_data("game", {"level": 3})
+        raw = (tmp_path / "game.save").read_bytes()
+        header, sep, payload = raw.partition(b"\n")
+        assert sep == b"\n"
+        meta = json.loads(header)
+        assert meta["format"] == "json"
+        assert meta["data_type"] == "dict"
+        assert meta["version"]  # a real engine version, not hard-coded "1.0.0"
+        assert meta["timestamp"].endswith("+00:00")  # timezone-aware UTC
+        assert json.loads(payload) == {"level": 3}
 
-    # Save
-    backend.save("save1", data_bytes, meta)
+    def test_load_missing_returns_none(self, manager):
+        assert manager.load_data("nope") is None
 
-    # Check file exists
-    assert (temp_storage_path / "save1.dat").exists()
-    assert (temp_storage_path / "save1.meta").exists()
+    def test_integrity_failure_returns_none(self, manager, tmp_path):
+        manager.save_data("game", {"hp": 10})
+        path = tmp_path / "game.save"
+        header, _, payload = path.read_bytes().partition(b"\n")
+        # Flip a value byte: still valid JSON, but no longer matches checksum.
+        path.write_bytes(header + b"\n" + payload.replace(b"10", b"99"))
+        assert manager.load_data("game") is None
+        # ...but skipping the check surfaces the (now different) data
+        assert manager.load_data("game", verify_integrity=False) == {"hp": 99}
 
-    # Load
-    loaded = backend.load("save1")
-    assert loaded is not None
-    loaded_data, loaded_meta = loaded
-    assert loaded_data == data_bytes
-    assert loaded_meta == meta
+    def test_save_data_returns_false_when_backend_fails(self, tmp_path):
+        class FailingBackend:
+            def save(self, key, blob):
+                return False
 
+            def load(self, key):
+                return None
 
-def test_file_storage_missing_file(temp_storage_path: Path) -> None:
-    """FileStorageBackend should handle missing files."""
-    backend = FileStorageBackend(base_path=str(temp_storage_path))
+            def delete(self, key):
+                return False
 
-    # Load nonexistent
-    assert backend.load("ghost") is None
+            def list_keys(self):
+                return []
 
-    # Delete nonexistent (should return False)
-    assert not backend.delete("ghost")
+        manager = PersistenceManager(FailingBackend())
+        assert manager.save_data("k", {"a": 1}) is False
 
+    def test_compression_roundtrip_and_shrinks_payload(self, manager, tmp_path):
+        data = {"blob": "x" * 5000}
+        manager.save_data("plain", data, compress=False)
+        manager.save_data("gz", data, compress=True)
 
-def test_file_storage_list_slots(temp_storage_path: Path) -> None:
-    """FileStorageBackend should list available save slots."""
-    backend = FileStorageBackend(base_path=str(temp_storage_path))
+        plain = (tmp_path / "plain.save").stat().st_size
+        gz = (tmp_path / "gz.save").stat().st_size
+        assert gz < plain // 5
 
-    backend.save("slot_a", b"", {})
-    backend.save("slot_b", b"", {})
+        _, _, payload = (tmp_path / "gz.save").read_bytes().partition(b"\n")
+        assert gzip.decompress(payload)  # payload really is gzip
+        assert manager.load_data("gz") == data
 
-    slots = backend.list_keys()
-    assert len(slots) == 2
-    assert "slot_a" in slots
-    assert "slot_b" in slots
+    def test_msgpack_format_roundtrip(self, manager, tmp_path):
+        data = {"a": 1, "nested": {"b": [1, 2, 3]}}
+        manager.save_data("mk", data, fmt=SerializationFormat.MSGPACK)
+        meta = json.loads((tmp_path / "mk.save").read_bytes().partition(b"\n")[0])
+        assert meta["format"] == "msgpack"
+        assert manager.load_data("mk") == data
 
+    def test_migration_applied_on_load(self, tmp_path):
+        writer = PersistenceManager(FileStorageBackend(base_path=str(tmp_path)))
+        writer.save_data("hero", {"hp": 100, "name": "P"}, save_version=1)
 
-def test_persistence_manager_integration(temp_storage_path: Path) -> None:
-    """PersistenceManager should coordinate with backend."""
-    storage = FileStorageBackend(base_path=str(temp_storage_path))
-    manager = PersistenceManager(storage)
+        mm = MigrationManager(current_version=2)
+        mm.register(
+            Migration(
+                1,
+                2,
+                lambda d: {
+                    **{k: v for k, v in d.items() if k != "hp"},
+                    "health": d["hp"],
+                },
+            )
+        )
+        reader = PersistenceManager(
+            FileStorageBackend(base_path=str(tmp_path)), migration_manager=mm
+        )
+        loaded = reader.load_data("hero")
+        assert loaded == {"name": "P", "health": 100}
 
-    game_data = {"score": 500}
-
-    # Save
-    manager.save_data("autosave", game_data)
-
-    # Verify metadata added
-    raw = storage.load("autosave")
-    assert raw is not None
-    data_bytes, meta = raw
-
-    # PersistenceManager serializes to JSON bytes by default
-    assert json.loads(data_bytes.decode("utf-8")) == game_data
-    assert "timestamp" in meta
-
-    # Load
-    loaded_data = manager.load_data("autosave")
-    assert loaded_data == game_data
+    def test_delete_through_backend(self, manager):
+        manager.save_data("temp", {"x": 1})
+        assert manager.storage.delete("temp") is True
+        assert manager.load_data("temp") is None

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -43,6 +43,13 @@ class TestMigration:
         with pytest.raises(ValueError, match="must be greater than"):
             Migration(from_version=3, to_version=2, migrate_fn=migrate_fn)
 
+    def test_migration_rejects_non_positive_from_version(self):
+        """A schema version below 1 is not a real version."""
+        with pytest.raises(ValueError, match="from_version must be >= 1"):
+            Migration(from_version=0, to_version=1, migrate_fn=lambda d: d)
+        with pytest.raises(ValueError, match="from_version must be >= 1"):
+            Migration(from_version=-3, to_version=-1, migrate_fn=lambda d: d)
+
     def test_migration_apply(self):
         """Test applying a migration."""
 
@@ -193,6 +200,25 @@ class TestMigrationManager:
         result = manager.migrate(original, from_version=2)
         assert result is original
 
+    def test_manager_rejects_non_positive_current_version(self):
+        """current_version below 1 is meaningless and would make
+        needs_migration() answer nonsense for any real save."""
+        with pytest.raises(ValueError, match="current_version must be >= 1"):
+            MigrationManager(current_version=0)
+        with pytest.raises(ValueError, match="current_version must be >= 1"):
+            MigrationManager(current_version=-1)
+
+    def test_migrate_runs_functions_in_declared_order_on_the_same_dict(self):
+        """Migration functions conventionally mutate-and-return; the chain
+        threads one dict through every step (documented contract)."""
+        manager = MigrationManager(current_version=3)
+        manager.register(Migration(1, 2, lambda d: (d.update(a=1) or d)))
+        manager.register(Migration(2, 3, lambda d: (d.update(b=d["a"] + 1) or d)))
+        original = {"seed": 0}
+        result = manager.migrate(original, from_version=1)
+        assert result == {"seed": 0, "a": 1, "b": 2}
+        assert result is original  # threaded in place, not copied
+
     def test_migrate_future_version(self):
         """Test that future versions raise error."""
         manager = MigrationManager(current_version=2)
@@ -300,3 +326,15 @@ class TestMigrationRegistry:
         registry.register_all(manager)
 
         assert not manager.has_migration_path(1)
+
+    def test_registries_compare_by_identity(self):
+        """Two registries holding equivalent migrations are still distinct
+        objects -- equality must not collapse them."""
+        fn = lambda d: d  # noqa: E731
+        a = MigrationRegistry()
+        b = MigrationRegistry()
+        assert a == a
+        assert a != b
+        a.add(Migration(1, 2, fn))
+        b.add(Migration(1, 2, fn))
+        assert a != b

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,57 +1,118 @@
+"""Unit tests for the persistence Serializer."""
+
 import dataclasses
 
-from pyguara.common.types import Color, Vector2
+import pytest
+
+from pyguara.common.types import Color, Rect, Vector2
 from pyguara.persistence.serializer import SerializationFormat, Serializer
 
 
 @dataclasses.dataclass
-class TestComponent:
+class _Component:
     name: str
     position: Vector2
     color: Color
 
 
-def test_json_vector2():
+# --------------------------------------------------------------------------- #
+# JSON                                                                         #
+# --------------------------------------------------------------------------- #
+def test_json_vector2_roundtrip():
     s = Serializer()
-    v = Vector2(10.5, 20.0)
-
-    # Serialize
-    data = s.serialize(v, SerializationFormat.JSON)
+    data = s.serialize(Vector2(10.5, 20.0), SerializationFormat.JSON)
     json_str = data.decode("utf-8")
     assert '"x": 10.5' in json_str
     assert '"__type__": "Vector2"' in json_str
 
-    # Deserialize
     obj = s.deserialize(data, SerializationFormat.JSON)
     assert isinstance(obj, Vector2)
-    assert obj.x == 10.5
-    assert obj.y == 20.0
+    assert (obj.x, obj.y) == (10.5, 20.0)
 
 
-def test_json_color():
+def test_json_color_roundtrip():
     s = Serializer()
-    c = Color(255, 100, 50, 128)
-
-    data = s.serialize(c, SerializationFormat.JSON)
-    obj = s.deserialize(data, SerializationFormat.JSON)
-
+    obj = s.deserialize(
+        s.serialize(Color(255, 100, 50, 128), SerializationFormat.JSON),
+        SerializationFormat.JSON,
+    )
     assert isinstance(obj, Color)
-    assert obj.r == 255
-    assert obj.a == 128
+    assert (obj.r, obj.a) == (255, 128)
 
 
-def test_json_dataclass_roundtrip():
-    """
-    Note: Dataclass roundtrip currently returns a DICT for the dataclass itself,
-    but nested Vector/Colors should be objects.
-    Full dataclass reconstruction requires a schema-aware loader (Phase 2).
-    """
+def test_json_dataclass_returns_dict_with_rebuilt_value_types():
+    """A dataclass round-trips to a dict (no schema-aware loader here),
+    but nested Vector2 / Color are rebuilt as objects."""
     s = Serializer()
-    comp = TestComponent("Player", Vector2(1, 1), Color(0, 0, 0))
+    comp = _Component("Player", Vector2(1, 1), Color(0, 0, 0))
+    res = s.deserialize(
+        s.serialize(comp, SerializationFormat.JSON), SerializationFormat.JSON
+    )
+    assert res["name"] == "Player"
+    assert isinstance(res["position"], Vector2)
+    assert isinstance(res["color"], Color)
 
-    data = s.serialize(comp, SerializationFormat.JSON)
-    res_dict = s.deserialize(data, SerializationFormat.JSON)
 
-    assert res_dict["name"] == "Player"
-    assert isinstance(res_dict["position"], Vector2)
-    assert isinstance(res_dict["color"], Color)
+# --------------------------------------------------------------------------- #
+# MSGPACK                                                                      #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"a": 1, "b": [1, 2, 3], "c": {"d": True, "e": None}},
+        Vector2(3.5, -2.0),
+        Color(10, 20, 30, 40),
+        Rect(1, 2, 3, 4),
+        {"pos": Vector2(1, 2), "tint": Color(1, 2, 3), "tags": ["x", "y"]},
+    ],
+)
+def test_msgpack_roundtrip_including_engine_types(value):
+    s = Serializer()
+    raw = s.serialize(value, SerializationFormat.MSGPACK)
+    assert isinstance(raw, bytes)
+    back = s.deserialize(raw, SerializationFormat.MSGPACK)
+
+    if isinstance(value, Vector2):
+        assert isinstance(back, Vector2) and (back.x, back.y) == (value.x, value.y)
+    elif isinstance(value, Color):
+        assert isinstance(back, Color) and back == value
+    elif isinstance(value, Rect):
+        assert isinstance(back, Rect) and back == value
+    elif "pos" in value:
+        assert isinstance(back["pos"], Vector2)
+        assert isinstance(back["tint"], Color)
+    else:
+        assert back == value
+
+
+def test_msgpack_is_more_compact_than_json():
+    s = Serializer()
+    payload = {"pos": Vector2(1, 2), "n": list(range(50))}
+    assert len(s.serialize(payload, SerializationFormat.MSGPACK)) < len(
+        s.serialize(payload, SerializationFormat.JSON)
+    )
+
+
+# --------------------------------------------------------------------------- #
+# BINARY (pickle)                                                              #
+# --------------------------------------------------------------------------- #
+def test_binary_roundtrips_arbitrary_object():
+    s = Serializer()
+    obj = _Component("P", Vector2(5, 6), Color(1, 1, 1))
+    back = s.deserialize(
+        s.serialize(obj, SerializationFormat.BINARY), SerializationFormat.BINARY
+    )
+    assert isinstance(back, _Component)
+    assert back.name == "P"
+
+
+# --------------------------------------------------------------------------- #
+# Format handling                                                              #
+# --------------------------------------------------------------------------- #
+def test_default_format_is_used_when_unspecified():
+    s = Serializer(default_format=SerializationFormat.MSGPACK)
+    raw = s.serialize({"a": 1})
+    assert s.deserialize(raw) == {"a": 1}
+    # and it is not JSON
+    with pytest.raises(UnicodeDecodeError):
+        raw.decode("utf-8")

--- a/tests/test_scene_serializer.py
+++ b/tests/test_scene_serializer.py
@@ -16,15 +16,16 @@ from pyguara.scene.serializer import SceneSerializer
 
 
 class MockStorageBackend(StorageBackend):
-    """In-memory storage backend for testing."""
+    """In-memory blob store for testing."""
 
     def __init__(self) -> None:
-        self._storage: dict[str, tuple[bytes, dict[str, Any]]] = {}
+        self._storage: dict[str, bytes] = {}
 
-    def save(self, key: str, data: bytes, metadata: dict[str, Any]) -> None:
-        self._storage[key] = (data, metadata)
+    def save(self, key: str, blob: bytes) -> bool:
+        self._storage[key] = blob
+        return True
 
-    def load(self, key: str) -> tuple[bytes, dict[str, Any]] | None:
+    def load(self, key: str) -> bytes | None:
         return self._storage.get(key)
 
     def delete(self, key: str) -> bool:
@@ -33,8 +34,8 @@ class MockStorageBackend(StorageBackend):
             return True
         return False
 
-    def exists(self, key: str) -> bool:
-        return key in self._storage
+    def list_keys(self) -> list[str]:
+        return list(self._storage)
 
 
 class MockScene(Scene):


### PR DESCRIPTION
Subsystem audit of `pyguara/persistence` (`REFACTOR_STATE.md` pending queue).
One slice, ~970 lines: `manager`, `storage`, `serializer`, `migration`,
`types`. Every defect reproduced with a probe against the real code before
being touched.

**Independent branch, cut from `main`. Not stacked.**

### ⚠️ Breaking: on-disk save format changed

`FileStorageBackend` now stores one `{key}.save` file instead of a
`{key}.dat` / `{key}.meta` pair, and `StorageBackend` is
`save(key, blob) -> bool` / `load(key) -> bytes | None` (the `metadata`
argument is gone — framing metadata into the blob is the manager's job).
PyGuara is pre-alpha and ships no save files, so there is no migration path.

### Findings

| # | Fix |
|---|---|
| **F1** | `save_data()` discarded `storage.save()`'s return value. `FileStorageBackend.save` returns `False` on `OSError` rather than raising, so a full disk logged "Successfully saved" and returned `True`. Now checked. |
| **F2** | `FileStorageBackend` sanitised keys by *deleting* disallowed characters, so `"slot 1"`, `"slot/1"` and `"slot.1"` all collapsed onto `slot1` and silently overwrote each other; an all-punctuation key wrote literal `.dat`/`.meta`. Non-round-tripping keys now raise `ValueError`. (Same shape as the resources audit's silent stem collision.) |
| **F3** | `save()` wrote the data file and the meta file as two independent `os.replace` calls, while the load path claimed "atomic save ensures both or neither". A crash between the two renames left new data + a stale-checksum meta, and `load_data` then returned `None` for a save whose bytes were intact. Metadata is now framed into a single blob (`{one-line JSON header}\n{payload}`) — one `os.replace`, nothing to desync. Plus a directory `fsync` after the rename and an orphaned-temp-file sweep on init. |
| **F4** | `save_data(..., compress=True)` was a documented no-op. Implemented with gzip; recorded in the header; transparent on load. |
| **F5** | `SerializationFormat.MSGPACK` was a public enum member with no implementation, though `msgpack` is already a dependency and a PyInstaller hidden-import. Implemented via the existing `prepare_for_json` / `game_object_hook` path; exposed through a new `fmt=` argument on `save_data`. |
| minor | `SaveMetadata` carries `format`/`compressed` and is used via `asdict()` instead of being hand-copied; engine version from `importlib.metadata` (was hard-coded `"1.0.0"`); UTC timestamp. `os.makedirs(exist_ok=True)`. `delete()` reports whether a file was removed. Migration gains `from_version >= 1` / `current_version >= 1` construction guards; `MigrationRegistry` is `eq=False`. |

The **migration half was audited and found sound** — the chain-integrity
guards compose correctly and the path loop provably terminates; probes for
an overshoot / infinite loop / mid-chain gap all came back negative. Only
construction-time guards and the registry equality were changed there.

### Tests

`test_persistence.py` and `tests/integration/test_persistence_backend.py`
rewritten for the blob protocol with key-rejection, integrity, compression,
msgpack and migrate-on-load coverage; `test_migration.py` gains the
version-guard and identity-equality cases; the scene serializer's in-memory
backend updated to the new protocol. **Suite 1735 → 1770.**

### Docs

`pyguara/persistence` had no documentation page. Added
`docs/systems/persistence.md` (save/load API, the single-blob format and its
checksum, the `StorageBackend` protocol and key rules, the migration
pipeline) and wired it into the mkdocs nav. Notes the `BINARY`/pickle
"trusted files only" caveat.

### Verification

`pytest` (1770) · `ruff check .` · `ruff format --check` · `mypy pyguara`
(225 files) · `mkdocs build --strict` — all clean. Both non-docs commits
verified standalone in a detached worktree.

### Commits

1. `refactor(persistence)!:` — code + tests (F1–F5 + minor). Breaking format change.
2. `docs(persistence):` — the systems page + nav.
3. `docs:` — `REFACTOR_STATE.md` iteration log.

Merge with a merge commit (commits are split `refactor:` / `docs:` deliberately). PR is final — nothing else coming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5