### PR TITLE
refactor(ai): floor grid coords, thread dt into behavior trees, wire all steering behaviors

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -79,10 +79,87 @@ how the subject is *constructed*, not just what is asserted.
 
 ## Active Subsystem
 
-**None — `pyguara/persistence` closed 2026-09-08 (branch
-`refactor/persistence-audit`).** Next in the queue is `pyguara/ai`
-(FSM, steering, pathfinding, navmesh, behaviour trees). Open
-`REFACTOR_STATE.md` "How to resume" and take it.
+**None — `pyguara/ai` closed 2026-09-08 (branch `refactor/ai-audit`).**
+Next in the queue is Tier 4: `pyguara/ui` (layout engine, widgets, theming).
+Open `REFACTOR_STATE.md` "How to resume" and take it.
+
+`pyguara/ai` in one slice, ~2,100 lines (`fsm`, `blackboard`, `components`,
+`ai_system`, `steering`, `steering_system`, `behavior_tree`, `navmesh`,
+`pathfinding/{core,astar,grid}`). No single dead-end like audio's SFX, but
+the recurring shapes held. **`world_to_grid_coords()` used `int()`** (rounds
+toward zero) not `floor`, so any grid with a non-zero `offset` — or any
+negative local coordinate — resolved to the wrong cell, and the whole
+quadrant left of / above the origin collapsed onto row/column 0 (probe:
+world `(-10,-10)` → grid `(0,0)`, whose centre is `(16,16)` — a sign flip).
+"Guard/formula that returns a wrong answer." Now `math.floor`. **`AISystem`
+passed the raw `Entity` as the behavior-tree context**, so `WaitNode` (and
+any node reading `context.dt`) fell back to a hardcoded `1/60` and drifted
+with the real frame rate — `WaitNode(1.0)` took ~2.1 s at 30 fps, ~3.5 s at
+144 fps; the engine's own game (`protocolo_bandeira`) had to hand-roll its
+own AI system with a `dt`-carrying context to work around it. Fixed by a
+small `AIContext` (entity + dt + blackboard), user's choice, passed to
+`tree.tick()`. **`SteeringSystem` only dispatched `seek/arrive/flee/wander`**
+— `SteeringBehavior.pursuit()` / `.evade()`, the only two that lead a
+*moving* target (the roguelike "chase the player" case), were fully
+implemented but unreachable through the ECS system, and an unknown
+`behavior` string produced zero force with no warning. "Declared and wired
+to nothing" + silent guard. Per the user's choice, `behavior` is now a
+`SteeringBehaviorType` enum (`SEEK/ARRIVE/FLEE/WANDER/PURSUIT/EVADE`),
+coerced-and-validated in `__post_init__` (unknown → `ValueError` at
+construction), all six wired, `SteeringAgent` gained `target_velocity` for
+pursuit/evade. **`behavior="arrive"` overshot the target and orbited it
+forever** — the dt-scaled steering force is only a weak proportional brake;
+the system now enforces the arrive speed ramp directly and snaps to rest.
+**Generic `AStarPathfinder` crashed on a priority tie** (`TypeError: '<' not
+supported`) whenever graph nodes were not order-comparable — `Node` is bound
+only to `Hashable`, ties are the common case; latent for the shipped
+`GridGraph` (tuple nodes). Added the standard monotonic tie-break counter
+(also to `NavMeshPathfinder`'s copy). **`NavMesh.remove_polygon()` left the
+dangling id in every other polygon's `neighbors` list** — now pruned. FSM
+`set_initial_state()` / an unknown transition target were silent no-ops —
+now logged, and a second `set_initial_state()` calls the previous state's
+`on_exit()`. `NavMeshPathfinder`'s docstring claimed funnel smoothing it
+does not do — corrected. Recurring shapes: "guard/formula that returns a
+wrong answer" (`int` vs `floor`, silent steering/FSM no-ops), "declared and
+wired to nothing" (`pursuit`/`evade`, `AISystem` never threading `dt`),
+"one advance per frame / hardcoded dt" (`WaitNode`), and uniform test setup
+— `TestCoordinateConversion` used only positive coords + positive offsets
+(hid the floor bug), `test_wait_completes` baked the `0.016` fallback into
+its comment, and there was **no test at all** for `AISystem` or
+`SteeringSystem` despite both being auto-registered on every scene. Tests
++29 (1770 → 1799). See the iteration log entry below.
+
+**Capability gaps (Phase D)** — the subsystem is defect-free but thin: BT
+composites have memory with no *reactive* variant (a guard `ConditionNode`
+at the front of a `SequenceNode` stops being re-checked once the sequence
+advances past it) and `ParallelNode` re-ticks already-completed children;
+FSM has no transition table / event-driven transitions (only
+`update()`-returns-a-name); no declarative blackboard BT nodes (every leaf
+is a hand-written closure); `NavMesh` needs a full shared edge (no
+partial-edge portals / T-junctions), returns polygon-*centre* waypoints (no
+funnel string-pulling), and generates nothing (you hand it convex
+polygons). `SteeringSystem` integrates `transform.position` directly,
+bypassing physics/`CharacterMover` — agents don't collide or separate.
+`_wander_targets` is only evicted on scene exit, not per destroyed entity.
+Disposition: the BT/FSM authoring gaps → propose one **new issue** (sibling
+of #37/#40/#43); navmesh funnel/portals/generation → **parked** pending a
+real consumer (flow-field pathfinding is already #28's); steering-vs-physics
+→ **parked** for the top-down `CharacterMover` slice; `_wander_targets`
+eviction → left-open note. See the iteration log.
+
+**Left open.** `WaitNode` still has a `getattr(context, "dt", 1/60)`
+fallback for trees ticked with a bare object (now a named constant, not a
+magic literal). The arrive fix is a system-side velocity clamp, not a
+redesign of the force/integration model shared by all behaviors —
+`_ARRIVE_STOP_DISTANCE = 1.0` world units. `NavMeshPolygon.contains_point`
+references `xinters` before assignment on a code path the outer guards make
+unreachable (fragile, not fixed).
+
+---
+
+`pyguara/persistence` in one slice, ~970 lines (`manager`, `storage`,
+`serializer`, `migration`, `types`). The migration half was actually sound
+— the chain-integrity guards (`to_version > from_version`, `to_version <=
 
 `pyguara/persistence` in one slice, ~970 lines (`manager`, `storage`,
 `serializer`, `migration`, `types`). The migration half was actually sound
@@ -322,7 +399,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 - [x] `pyguara/animation` — tween, easing, FSM *(done)*
 - [x] `pyguara/resources` — loaders, meta, hot reload *(done)*
 - [x] `pyguara/persistence` — save/load, migration *(done)*
-- [ ] `pyguara/ai` — FSM, steering, pathfinding, navmesh, behaviour trees
+- [x] `pyguara/ai` — FSM, steering, pathfinding, navmesh, behaviour trees *(done)*
 
 ### Tier 4 — Tooling & authoring
 - [ ] `pyguara/ui` — layout engine, widgets, theming
@@ -340,6 +417,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/ai` | 2026-09-08 | One slice (`fsm`, `blackboard`, `components`, `ai_system`, `steering`, `steering_system`, `behavior_tree`, `navmesh`, `pathfinding/*`; ~2,100 lines). **`world_to_grid_coords()` used `int()` not `floor`** — a non-zero grid `offset` or any negative local coord resolved to the wrong cell, and the quadrant left of/above the origin collapsed onto row/col 0 (world `(-10,-10)` → grid `(0,0)`, a sign flip). "Formula that returns a wrong answer" → `math.floor`. **`AISystem` passed the bare `Entity` as the BT context**, so `WaitNode` (any `context.dt` reader) fell back to a hardcoded `1/60` and drifted with frame rate — `WaitNode(1.0)` = ~2.1s @30fps, ~3.5s @144fps; the engine's own game hand-rolled its own AI system to dodge this. Fixed with a small `AIContext` (entity+dt+blackboard), passed to `tree.tick()`. **`SteeringSystem` only dispatched `seek/arrive/flee/wander`** — `pursuit`/`evade` (the only moving-target behaviors) were implemented but unreachable, and an unknown `behavior` string produced zero force silently. `behavior` is now a validated `SteeringBehaviorType` enum, all six wired, `SteeringAgent` gained `target_velocity`. **`behavior="arrive"` overshot and orbited the target forever** — system now enforces the arrive speed ramp on velocity and snaps to rest. **Generic `AStarPathfinder` crashed on a priority tie** with non-order-comparable nodes (`Node` is only `Hashable`; ties are common) — added the monotonic tie-break counter (also to `NavMeshPathfinder`). **`NavMesh.remove_polygon()` left dangling ids in other polygons' `neighbors`** — now pruned. FSM `set_initial_state()` / unknown transition targets were silent no-ops — now logged; a second `set_initial_state()` exits the prior state. `NavMeshPathfinder` docstring claimed a funnel algorithm it lacks — corrected. Recurring shapes: "guard/formula returns a wrong answer", "declared and wired to nothing" (`pursuit`/`evade`, `dt` never threaded), "hardcoded dt", uniform test setup (`TestCoordinateConversion` all-positive; **zero** tests for `AISystem`/`SteeringSystem`). Tests +29 (1770 → 1799). Phase D: BT/FSM authoring gaps (no reactive composites, no FSM transition table, no declarative blackboard nodes) → propose a new issue (sibling of #37/#40/#43); navmesh funnel/partial-portals/generation → parked (flow-field is #28's); steering-vs-physics → parked for the top-down `CharacterMover` slice. Left open: `WaitNode` keeps a named `getattr` dt fallback; the arrive fix is a velocity clamp (`_ARRIVE_STOP_DISTANCE = 1.0`), not a force-model redesign; `NavMeshPolygon.contains_point` has a fragile-but-unreachable `xinters`-before-assignment. |
 | `pyguara/persistence` | 2026-09-08 | One slice (`manager`, `storage`, `serializer`, `migration`, `types`; ~970 lines). The **migration half was sound** — the chain-integrity guards compose and the path loop provably terminates; overshoot/infinite-loop probes came back negative. The save/load half held the recurring shapes. **`save_data()` discarded `storage.save()`'s return** — `FileStorageBackend.save` returns `False` on `OSError`, so a full disk logged "Successfully saved" and returned `True`; now checked. **`FileStorageBackend` sanitised keys by deleting bad chars** — `"slot 1"`/`"slot/1"`/`"slot.1"` all collapsed onto `slot1` and silently overwrote each other (the resources F2 stem-collision shape); non-round-tripping keys now raise `ValueError`. **Data + meta were two independent `os.replace` calls** while the load path claimed "atomic save ensures both or neither" — a crash between them made an intact save unreadable (stale checksum → `None`). User chose the systemic fix: metadata is framed into **one blob** (`{header json}\n<payload>`), `StorageBackend` drops its `metadata` param (plain key→blob store), `FileStorageBackend` writes one `{key}.save` file + dir fsync + temp-sweep. **`compress=` was a documented no-op** → gzip, recorded in the header. **`SerializationFormat.MSGPACK` was a public enum member with no impl** though `msgpack` is a declared dep → implemented via the existing `prepare_for_json`/`game_object_hook` path, exposed through a new `fmt=` arg. `SaveMetadata` was hand-copied field by field and never read back on load → now carries `format`/`compressed`, used via `asdict`, engine version from `importlib.metadata` (was `"1.0.0"`), UTC timestamp. Migration gained `from_version >= 1` / `current_version >= 1` guards; `MigrationRegistry` is `eq=False`. Recurring shapes: "declared and wired to nothing" (`compress`, `MSGPACK`, `SaveMetadata`'s metadata half), "guard that returns a wrong answer" (swallowed `save()` failure, key mangling), "identity vs value" (`MigrationRegistry`), uniform test setup (every storage test used an already-safe key; every migration test used versions from 1). BREAKING: on-disk save format changed (`.dat`+`.meta` → `.save`); pre-alpha, no migration. Tests +35 (1735 → 1770). Phase D capability gaps: no backup/retention, no save-menu API (`list_saves`, cheap metadata read, `delete`/`exists` facade), CWD-relative save dir — grouped into #43 ("persistence production layer", sibling of #37); envelope `format_version` parked; run/meta split is #28's. Left open: `BINARY`/pickle load unauthenticated (trusted-input-only); mypy `python_version` 3.10 vs `requires-python` 3.12 forces a `# noqa: UP017` (possible CC). |
 | `pyguara/resources` | 2026-09-08 | One slice (`manager`, `meta`, `loader`, `types`, `data`, `data_loader`; hot reload lives downstream in `pyguara/dev`). No headline crash — better shape than recent subsystems — but the recurring shapes held. **Reference counting was internally inconsistent and wired to nothing**: `load()` auto-incremented on every call incl. cache hits, `release()` auto-unloaded at 0, so `unload_unused()` could never evict anything in use and a released resource was already gone — dead. No engine caller of acquire/release/unload/unload_unused; `AudioManager` `load()`s per play → count climbs forever. `Resource._ref_count` was a *third* dead counter. Reworked (user: "fix the model + add reload()"): `load()` is a pure cache-get → unpinned (0); `acquire()`/`release()` pin; `unload_unused()` now sweeps. `index_directory()` **silently resolved a stem collision to the last file walked** — now the ambiguous bare stem is dropped with a warning, full-name keys always win. `MetaLoader` **cached parsed meta by path with no invalidation** (stale after a disk change — wrong under hot reload) and the path-only key **swallowed the `expected_type` mismatch warning** after the first call — now mtime-pinned + re-read + `invalidate()`, check runs every call. `DataResource` docstring claimed "hot-reloaded by the ResourceManager" with **no reload API** — added `ResourceManager.reload()` (re-run loader, re-read `.meta`, swap in place, keep count). The **`.meta` import pipeline was ~70% scaffolding** (`AudioMeta`/`SpritesheetMeta` had no consumer, GL loader hardcoded `LINEAR`) — wired end to end (user: "wire it up in this slice"): `Resource.import_meta` carries the resolved sidecar; `GLTextureLoader` honours `filter` (default flips to `NEAREST`, matching the pygame path); audio backend applies `AudioMeta.volume_db` as a per-asset channel gain; `SpriteSheet` gained `margin`/`spacing` (previously meaningless) + `slice_from_meta`. Recurring shapes: "declared and wired to nothing" (the whole ref-count half; `AudioMeta`; `_ref_count`) and uniform test setup (`test_resources.py` asserted on `_reference_counts`/`_cache`/`_path_index` privates and hand-poked an impossible state into `test_unload_unused`; every `test_meta.py` test used a fresh `MetaLoader()`). Tests +21. Left open: `AudioMeta.loop_*`/`normalize`/`load_mode`, `TextureMeta.mipmaps`/`wrap_*` still unconsumed (need streaming/DSP/GL-state — authoring-layer gap, sibling of #37); audio should `acquire()` its clips under the new model (small `pyguara/audio` follow-up, no behaviour change today); no lock on the cache dicts (no concurrent caller, parked CC). |
 | `pyguara/animation` | 2026-09-08 | One slice, both halves (`pyguara/animation` tween+easing, plus the sprite-animation FSM in `pyguara/graphics` only surveyed during the graphics audit). **`Tween` accepted only `float` scalars / `tuple`s**: `Tween(0, 100, 1.0)`, a `list`, mixed int/float, or a `Color` constructed fine then crashed on first `update()` with a bare `AssertionError` (`_interpolate` used `assert isinstance(x, float)` as validation, stripped under `-O`). `Tween` was a value-equality `@dataclass`, so `TweenManager.remove(b)` removed an equal-but-different `a` — now `@dataclass(eq=False)`. `Animator.update()` advanced ≤1 frame per call (`if`, not `while`) so a lag spike dropped frames and drifted behind forever while `_current_time` grew unbounded — now O(1) catch-up. `AnimationStateMachine` re-fired `on_complete` + the transition check every frame a non-looping clip sat finished (callback storm for any terminal state) — fixed with a `_completion_handled` latch reset on transition. `AnimationClip` gained `__post_init__` validation (`frame_rate<=0` → `ZeroDivisionError`, `frames=[]` → `IndexError`). `TransitionCondition.IMMEDIATE` was declared but `_check_transitions()` had no branch — now honoured (fires on entry). `Scene.update_animations()` removed: its docstring told games to call it from `scene.update()`, but `AnimationSystem` has been auto-registered on the scene's `SystemManager` since wayfinder ticket 24, so following the docs double-updated every animation; it had no real callers. Recurring shapes: "assert as runtime validation", "identity vs value" (the gamepad-index shape), "one advance per frame" (the audio/application shape), the `on_complete` retrigger storm (audio F5), "no `__post_init__`" (audio F6 / physics config), "declared and wired to nothing" (`IMMEDIATE`), and uniform test setup — every tween test used float `0.0→100.0`, every FSM test stepped `dt == 1/frame_rate` exactly and stopped updating on the completion frame. Left open: a single huge `dt` still resolves only one loop boundary per `Tween.update()` (catches up over later frames, documented); `Color` tweening unsupported (documented); `_allow_methods = True` on both FSM components stays CC-6. |
@@ -545,6 +623,156 @@ convert to explicit `is None` checks as each subsystem is audited.
 ---
 
 ## Iteration Log
+
+### `pyguara/ai` — CLOSED 2026-09-08 (branch `refactor/ai-audit`)
+
+One slice, ~2,100 lines: `ai/{fsm,blackboard,components,ai_system,steering,
+steering_system,behavior_tree,navmesh}.py` and `ai/pathfinding/{core,astar,
+grid}.py`. Every defect reproduced with a probe against the real code
+first. `games/protocolo_bandeira` is a *consumer* (its `EnemyAISystem`
+hand-rolls an `AIContext`-shaped object) and confirmed F2 from the outside;
+it was not modified.
+
+**Verification:** 1799 tests pass (up from 1770; +29 across a rewritten
+`test_ai.py`, a new `test_steering.py`, and additions to
+`test_behavior_tree.py` / `test_navmesh.py` / `test_pathfinding.py`).
+`ruff check .` clean; `ruff format --check` clean; `mypy pyguara` clean
+across 226 files; `mkdocs build --strict` exit 0; `test_docs_api.py` (54)
+passes.
+
+Two upfront decisions put to the user. **F2 fix depth:** a contained
+`WaitNode`-only patch, a lightweight proxy, or a real context object — the
+user took the **`AIContext`** (entity + dt + blackboard), so `AISystem` now
+constructs one per frame and hands it to `tree.tick()`; this changes what
+leaf callables receive under `AISystem` (bare `Entity` → `AIContext`), a
+breaking change that pre-alpha and the fact that `AISystem` was unusable for
+timed nodes make acceptable. **F3 scope:** validate-only, wire pursuit/evade,
+or a full enum — the user took the **full enum**: `SteeringBehaviorType`
+(`str, Enum`) with `__post_init__` coercion+validation, all six behaviors
+wired, `SteeringAgent.target_velocity` added for the moving-target pair.
+
+**F1 — `world_to_grid_coords()` truncated toward zero.** `int((p.x -
+offset.x) / cell_size)` rounds toward zero, not down. Probe: `cell_size=32`,
+world `-1` → grid `0` (should be `-1`), `-33` → `-1` (should be `-2`); with
+`offset=(100,100)`, world `(90,90)` → `(0,0)` (should be `(-1,-1)`). Any
+centred or camera-relative grid, and the entire quadrant left of / above the
+origin, was mis-resolved — a sign flip near the axes. Now `math.floor`.
+`TestCoordinateConversion` had used only positive coords and positive
+offsets — uniform setup, third instance of the pattern this audit keeps
+hitting.
+
+**F2 — `AISystem` never threaded `dt` into the tree.** `AISystem.update(dt)`
+called `ai.behavior_tree.tick(entity)`. `WaitNode.tick` does
+`getattr(context, "dt", <fallback>)`; an `Entity` has no `dt`, so every
+`WaitNode` (and any custom timing node) advanced by a hardcoded `1/60` per
+*tick*, not per real second. Probe: `WaitNode(1.0)` driven by `AISystem`
+completed after ~2.08 s at 30 fps and ~3.47 s at 144 fps. `protocolo_bandeira`
+already worked around this by building its own context object carrying `dt`.
+Fix: new `pyguara/ai/context.py::AIContext` (`entity`, `dt`, `blackboard`);
+`AISystem` builds one per component per frame. `WaitNode`'s literal `0.016`
+became a named `_WAIT_FALLBACK_DT` for the bare-object case. "Declared and
+wired to nothing" / "hardcoded dt".
+
+**F3 — `pursuit`/`evade` were implemented but unreachable; unknown behavior
+was silent.** `SteeringSystem._calculate_steering` branched only on
+`seek/arrive/flee/wander` (lower-cased string compare).
+`SteeringBehavior.pursuit()` / `.evade()` — the only behaviors that lead a
+moving target — had no branch, and `behavior="chase"` (a typo) or
+`"pursuit"` produced `Vector2(0,0)` every frame with no diagnostic. Probe:
+`behavior="pursuit"` with a target set → agent never moved. Fix per the
+user's choice: `SteeringBehaviorType(str, Enum)` with the six members;
+`SteeringAgent.__post_init__` does `self.behavior =
+SteeringBehaviorType(self.behavior)` (raises `ValueError` on an unknown
+name); `_calculate_steering` dispatches on the enum with all six wired;
+`SteeringAgent.target_velocity: Vector2` added, refreshed by the caller
+alongside `target`, consumed by pursuit/evade.
+
+**F7 — `arrive` overshot and orbited the target forever.** Probe: target at
+x=300, `max_speed=200`, `slowing_radius=100` — the agent reached x≈357 then
+swung 306 → 285 → 288 → … indefinitely, never settling.
+`SteeringBehavior.arrive`'s `if distance < 0.1: return -current_velocity`
+returns a *velocity* as a *force* and only fires within 0.1 px (never hit);
+the real brake is `desired - current_velocity` scaled by `dt/mass`, a weak
+proportional term the `max_force` cap plus Euler integration make unstable.
+Fix: `SteeringSystem.update` now enforces the arrive ramp on the resulting
+velocity — cap speed to `max_speed * distance / slowing_radius` inside the
+radius, snap to rest within `_ARRIVE_STOP_DISTANCE = 1.0`. A system-side
+clamp, not a redesign of the force model all behaviors share.
+
+**F4 — generic `AStarPathfinder` crashed on a priority tie.** `frontier`
+held `(priority, node)`; on equal priorities heapq compares the second
+element, and `core.Node` is bound only to `Hashable`. Probe: a 4-node
+diamond graph with a zero heuristic (so both mid nodes get priority 1.0) and
+nodes that are hashable but define no `__lt__` → `TypeError: '<' not
+supported between instances of 'Cell' and 'Cell'`. Latent for the shipped
+`GridGraph` (tuple nodes are orderable) but ties are the normal case. Fix:
+`itertools.count()` tie-breaker — `(priority, next(counter), node)` — so the
+node is never compared. Applied the same to `NavMeshPathfinder.
+_find_polygon_path` (int nodes today, same latent shape).
+
+**F5 — `NavMesh.remove_polygon()` left dangling neighbor ids.** It deleted
+the polygon and its edges but not the id from other polygons' `neighbors`
+lists. Probe: three rects in a row, `build_connections()`, `remove_polygon(2)`
+→ `get_neighbors(1)` still `[0, 2]`. `NavMeshPathfinder` defends
+(`get_polygon → None → continue`) but `get_neighbors` is public — a debug
+overlay or a third-party pathfinder hits the `None`. Fix: prune every
+remaining `neighbors` list in `remove_polygon`.
+
+**F6 — FSM silent failures.** `set_initial_state("Typo")` left the machine
+permanently `None` with no diagnostic; a state whose `update()` returns an
+unregistered name was silently ignored. Probes confirmed both. Fix: both
+paths `logger.warning(...)` (matching how `di`/`systems`/`input` handle
+unknown keys post-audit); `set_initial_state` also now calls the previous
+state's `on_exit()` if called a second time.
+
+**Phase B verdict.** The BT and pathfinding/navmesh suites are substantial
+(797 / 589 / 670 lines) and load-bearing — node-status truth tables,
+corner-cut prevention, A* around obstacles. But `test_ai.py` was 54 lines
+(only `Blackboard` + one FSM transition, asserting on `fsm._current_state`),
+there was **no `test_steering.py` at all** despite `SteeringSystem` being
+auto-registered on every scene, and no test exercised `AISystem`. Uniform
+setup hid F1 (`TestCoordinateConversion`: positive coords + positive offsets
+only) and `test_wait_completes` had `# 0.016 * 4 = 0.064 > 0.05` baked into
+its comment — a test pinning the bug. Added: negative/offset
+`world_to_grid_coords` cases; an A* test over a non-orderable-node graph;
+`remove_polygon` neighbor-pruning; `WaitNode`-honours-real-`dt`; a rewritten
+`test_ai.py` (FSM warnings, `AISystem`/`AIContext` integration incl. the
+frame-rate-independence regression); a new `test_steering.py` (all six
+behaviors reachable, arrive settles and does not re-oscillate, enum
+validation, wander-state persistence + cleanup, Navigator path-follow).
+
+**Phase D — capability gaps.** Defect-free but thin for a shipped game:
+
+- *BT/FSM authoring* (**propose new issue**, sibling of #37/#40/#43):
+  `SequenceNode`/`SelectorNode` have memory and there is no *reactive*
+  variant, so a guard `ConditionNode` at the front of a sequence is not
+  re-checked once the sequence advances past it — the "attack while visible,
+  else patrol" pattern silently keeps attacking; `ParallelNode` re-ticks
+  already-completed children (no latching, re-fires one-shots); FSM
+  transitions are only `update()`-returns-a-name (no `add_transition(from,
+  to, predicate)` table, no event-driven transitions); every BT leaf is a
+  hand-written closure (no `BlackboardCondition` / `SetBlackboard` /
+  cooldown / random-selector nodes).
+- *Navmesh* (**parked** — needs a real consumer; flow-field pathfinding is
+  already #28's): polygons must share a *full* edge (no partial-edge portals
+  / T-junctions), `NavMeshPathfinder` returns polygon-*centre* waypoints (no
+  funnel string-pulling — paths zig-zag), and nothing *generates* a mesh
+  (you supply convex polygons by hand).
+- *Steering vs. physics* (**parked** for the top-down `CharacterMover`
+  slice): `SteeringSystem` writes `transform.position` directly, so agents
+  don't collide with solids, don't separate from each other, and
+  double-integrate if they also carry a body.
+- *`_wander_targets` eviction* (**left-open note**): cleared only on scene
+  exit, not per destroyed entity — a scene that spawns/despawns many
+  wanderers leaks entries keyed by dead entity ids. The scene already has
+  `subscribe_entity_removed`; wiring it in is small.
+
+**Left open.** `WaitNode` keeps a `getattr(context, "dt",
+_WAIT_FALLBACK_DT)` for trees ticked with a bare object. The arrive fix is a
+velocity clamp, not a rework of the `dt`-scaled force/integration model.
+`NavMeshPolygon.contains_point` references `xinters` before assignment on a
+branch the outer `y > min / y <= max` guards make unreachable for a
+horizontal edge — fragile, not touched.
 
 ### `pyguara/persistence` — CLOSED 2026-09-08 (branch `refactor/persistence-audit`)
 

--- a/docs/ai/intelligence.md
+++ b/docs/ai/intelligence.md
@@ -21,39 +21,63 @@ PyGuara features a professional-grade Behavior Tree (BT) implementation, perfect
 ### Usage Example
 
 ```python
+from pyguara.ai import AIComponent
 from pyguara.ai.behavior_tree import BehaviorTree, SequenceNode, ActionNode, NodeStatus
 
 def move_to_player(context):
-    # Logic...
+    # context.entity, context.dt, context.blackboard are available
     return NodeStatus.SUCCESS
 
 def attack_player(context):
-    # Logic...
     return NodeStatus.SUCCESS
 
-# Define structure
+# Define structure -- leaves are wrapped in ActionNode/ConditionNode
 root = SequenceNode([
     ActionNode(move_to_player),
-    ActionNode(attack_player)
+    ActionNode(attack_player),
 ])
 
-# Create component
-ai_component = AIComponent()
-ai_component.behavior_tree = BehaviorTree(root)
+# Attach to an entity; AISystem ticks the tree once per frame
+ai_component = AIComponent(behavior_tree=BehaviorTree(root))
 ```
+
+### The tick context
+
+`AISystem` passes each tree an **`AIContext`** (`pyguara.ai.AIContext`) with
+`entity`, `dt`, and `blackboard` fields. Timing nodes such as `WaitNode` read
+`context.dt`; ticking a tree with a bare object that has no `dt` falls back to a
+fixed step and drifts with the real frame rate.
 
 ## 🔄 Finite State Machines (FSM)
 
 For simpler logic, use the FSM system.
 
 *   **State**: Abstract base class with `on_enter`, `update`, `on_exit`.
-*   **StateMachine**: Manages current state and transitions.
+*   **StateMachine**: Manages current state and transitions. `add_state(name,
+    state)` registers a state; `set_initial_state(name)` and a state's
+    `update()` return value drive transitions by name. An unknown name is
+    logged as a warning and ignored -- the machine is not left in a half-
+    transitioned state.
 
 ## 🧭 Pathfinding & Steering
 
-*   **AStarPathfinder**: Grid and Graph based pathfinding.
-*   **Steering**: Common behaviors like `Seek`, `Flee`, and `Arrive` for natural movement.
-*   **Navmesh**: Tools for generating and navigating walkable surfaces.
+*   **AStarPathfinder**: A generic A* solver over any `Graph` (a `get_neighbors`
+    / `cost` protocol). Graph nodes only need to be hashable, not orderable.
+*   **GridGraph**: A concrete 4/8-directional grid with pluggable heuristics
+    (`ManhattanDistance`, `EuclideanDistance`, `DiagonalDistance`,
+    `OctileDistance`), `smooth_path`, and `world_to_grid_coords` /
+    `path_to_world_coords` (both floor toward negative infinity, so a non-zero
+    grid `offset` works).
+*   **Steering**: `SteeringSystem` runs an entity's `SteeringAgent` each frame.
+    `SteeringAgent.behavior` is a `SteeringBehaviorType`: `SEEK`, `ARRIVE`,
+    `FLEE`, `WANDER`, `PURSUIT`, `EVADE`. `PURSUIT` and `EVADE` intercept or
+    dodge a *moving* target -- set `SteeringAgent.target_velocity` alongside
+    `target`. An unknown behavior string is rejected when the component is
+    built.
+*   **Navmesh**: `NavMesh` holds convex polygons you supply and connects those
+    that share a full edge; `NavMeshPathfinder.find_path` runs A* over the
+    polygon graph and returns polygon-center waypoints. Funnel string-pulling
+    and partial-edge portals are not yet implemented.
 
 ## 📝 Blackboard
 

--- a/docs/guides/ONBOARDING.md
+++ b/docs/guides/ONBOARDING.md
@@ -221,41 +221,59 @@ Before diving into individual systems, it's crucial to understand the three core
 *   **Features:**
     *   **Finite State Machines (FSMs):** For simple, state-based AI.
     *   **Behavior Trees (BTs):** A professional-grade BT implementation for complex, hierarchical AI logic. Includes all standard node types (Sequence, Selector, Parallel, Decorators).
-    *   **Steering Behaviors:** For dynamic movement (seek, flee, arrive).
-    *   **Pathfinding:** A* pathfinding on a navigation mesh.
+    *   **Steering Behaviors:** For dynamic movement. `SteeringSystem` drives
+        an entity's `SteeringAgent` each frame; `behavior` is a
+        `SteeringBehaviorType` (`SEEK`, `ARRIVE`, `FLEE`, `WANDER`, `PURSUIT`,
+        `EVADE`). `PURSUIT`/`EVADE` lead a moving target, so keep
+        `SteeringAgent.target_velocity` up to date alongside `target`.
+    *   **Pathfinding:** A generic A* solver (`AStarPathfinder`) over any
+        `Graph`, a concrete `GridGraph` with heuristics and path smoothing, and
+        a polygon `NavMesh` (`NavMeshPathfinder` returns polygon-center
+        waypoints; funnel string-pulling is not yet implemented).
 *   **How to Use (Behavior Tree):**
     1.  Define simple functions that will act as your leaf nodes.
     2.  Compose these functions into a tree using `SequenceNode`, `SelectorNode`, etc.
     3.  Create a `BehaviorTree` instance with your root node.
     4.  Add an `AIComponent` to your entity and assign the tree to it.
 
+    Leaf callables receive the tick `context`. Under `AISystem` that is an
+    `AIContext` with `.entity`, `.dt`, and `.blackboard` -- pass `dt` on,
+    because `WaitNode` (and any timing node) reads `context.dt`.
+
     ```python
-    from pyguara.ai.behavior_tree import BehaviorTree, ActionNode, SequenceNode, SelectorNode, NodeStatus
+    from pyguara.ai import AIComponent
+    from pyguara.ai.behavior_tree import (
+        ActionNode, BehaviorTree, ConditionNode, NodeStatus, SelectorNode, SequenceNode,
+    )
 
     def find_player(context) -> NodeStatus:
         # ... logic to find player ...
         if found:
-            context.blackboard['player_pos'] = player_position
+            context.blackboard.set("player_pos", player_position)
             return NodeStatus.SUCCESS
         return NodeStatus.FAILURE
 
     def move_towards_player(context) -> NodeStatus:
-        # ... logic to move towards context.blackboard['player_pos'] ...
+        target = context.blackboard.get("player_pos")
+        # ... move using context.dt ...
         if close_enough:
             return NodeStatus.SUCCESS
-        return NodeStatus.RUNNING # Still moving
+        return NodeStatus.RUNNING  # Still moving
 
-    # In your scene
-    attack_sequence = SequenceNode([find_player, move_towards_player])
-    patrol_action = ActionNode(...)
-    root_node = SelectorNode([attack_sequence, patrol_action])
+    def patrol(context) -> NodeStatus:
+        return NodeStatus.RUNNING
 
-    tree = BehaviorTree(root=root_node)
-    ai_comp = AIComponent()
-    ai_comp.behavior_tree = tree # The AISystem will tick this
+    # In your scene: leaves must be wrapped in ActionNode/ConditionNode.
+    attack_sequence = SequenceNode([
+        ActionNode(find_player),
+        ActionNode(move_towards_player),
+    ])
+    root_node = SelectorNode([attack_sequence, ActionNode(patrol)])
+
+    ai_comp = AIComponent(behavior_tree=BehaviorTree(root=root_node))
 
     my_enemy = self.entity_manager.create_entity()
-    self.entity_manager.add_component(my_enemy, ai_comp)
+    my_enemy.add_component(ai_comp)  # AISystem ticks it each frame
     ```
 
 ---

--- a/pyguara/ai/__init__.py
+++ b/pyguara/ai/__init__.py
@@ -4,6 +4,7 @@ Provides behavior trees, finite state machines, steering behaviors,
 and other AI utilities.
 """
 
+from pyguara.ai.ai_system import AISystem
 from pyguara.ai.behavior_tree import (
     ActionNode,
     BehaviorNode,
@@ -22,7 +23,13 @@ from pyguara.ai.behavior_tree import (
     WaitNode,
 )
 from pyguara.ai.blackboard import Blackboard
-from pyguara.ai.components import AIComponent, Navigator, SteeringAgent
+from pyguara.ai.components import (
+    AIComponent,
+    Navigator,
+    SteeringAgent,
+    SteeringBehaviorType,
+)
+from pyguara.ai.context import AIContext
 from pyguara.ai.fsm import State, StateMachine
 from pyguara.ai.navmesh import (
     NavMesh,
@@ -67,7 +74,10 @@ __all__ = [
     "StateMachine",
     # Components
     "AIComponent",
+    "AIContext",
+    "AISystem",
     "SteeringAgent",
+    "SteeringBehaviorType",
     "Navigator",
     # Steering
     "SteeringBehavior",

--- a/pyguara/ai/ai_system.py
+++ b/pyguara/ai/ai_system.py
@@ -1,6 +1,7 @@
 """Systems for updating AI logic."""
 
 from pyguara.ai.components import AIComponent
+from pyguara.ai.context import AIContext
 from pyguara.ecs.manager import EntityManager
 
 
@@ -24,6 +25,9 @@ class AISystem:
             if ai.fsm:
                 ai.fsm.update(dt)
 
-            # Update Behavior Tree if present
+            # Update Behavior Tree if present. Pass an AIContext, not the bare
+            # entity: WaitNode and any timing node read context.dt, which an
+            # Entity has not got -- they would silently run on a fixed step.
             if ai.behavior_tree:
-                ai.behavior_tree.tick(entity)
+                context = AIContext(entity=entity, dt=dt, blackboard=ai.blackboard)
+                ai.behavior_tree.tick(context)

--- a/pyguara/ai/behavior_tree.py
+++ b/pyguara/ai/behavior_tree.py
@@ -19,6 +19,12 @@ class NodeStatus(Enum):
     RUNNING = auto()
 
 
+# Fallback frame delta for WaitNode when the tick context carries no `dt`.
+# AISystem passes an AIContext with a real dt; this only bites a tree ticked
+# with a bare object, and is deliberately visible rather than a bare literal.
+_WAIT_FALLBACK_DT = 1.0 / 60.0
+
+
 class BehaviorNode(ABC):
     """Base class for all behavior tree nodes."""
 
@@ -128,7 +134,7 @@ class WaitNode(BehaviorNode):
 
     def tick(self, context: Any) -> NodeStatus:
         """Update wait timer."""
-        dt = getattr(context, "dt", 0.016)  # Default to ~60 FPS
+        dt = getattr(context, "dt", _WAIT_FALLBACK_DT)
         self._elapsed += dt
 
         if self._elapsed >= self.duration:

--- a/pyguara/ai/components.py
+++ b/pyguara/ai/components.py
@@ -1,6 +1,7 @@
 """ECS components for AI."""
 
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 from pyguara.ai.blackboard import Blackboard
@@ -10,6 +11,23 @@ from pyguara.ecs.component import BaseComponent
 
 if TYPE_CHECKING:
     from pyguara.ai.behavior_tree import BehaviorTree
+
+
+class SteeringBehaviorType(str, Enum):
+    """Steering behavior a ``SteeringAgent`` runs each frame.
+
+    Subclasses ``str`` so an agent constructed with a plain string
+    (``SteeringAgent(behavior="seek")``) and serialized forms keep working;
+    ``SteeringAgent.__post_init__`` coerces the field to this enum and raises
+    ``ValueError`` on an unknown name rather than silently producing no force.
+    """
+
+    SEEK = "seek"
+    ARRIVE = "arrive"
+    FLEE = "flee"
+    WANDER = "wander"
+    PURSUIT = "pursuit"
+    EVADE = "evade"
 
 
 @dataclass
@@ -45,8 +63,12 @@ class SteeringAgent(BaseComponent):
         mass: Used to calculate acceleration (Force / Mass).
         velocity: Current velocity of the agent.
         target: Target position for steering (if None, uses Navigator path).
+        target_velocity: Velocity of the target, used by ``pursuit``/``evade``
+            to lead a moving target. The caller refreshes it each frame
+            alongside ``target``; ignored by the other behaviors.
         slowing_radius: Distance at which to start slowing for arrive behavior.
-        behavior: Active steering behavior type.
+        behavior: Active steering behavior. Accepts a ``SteeringBehaviorType``
+            or its string value; coerced in ``__post_init__``.
     """
 
     max_speed: float = 200.0
@@ -54,12 +76,16 @@ class SteeringAgent(BaseComponent):
     mass: float = 1.0
     velocity: Vector2 = field(default_factory=lambda: Vector2(0, 0))
     target: Vector2 | None = None
+    target_velocity: Vector2 = field(default_factory=lambda: Vector2(0, 0))
     slowing_radius: float = 100.0
-    behavior: str = "seek"  # "seek", "arrive", "flee", "wander"
+    behavior: SteeringBehaviorType = SteeringBehaviorType.SEEK
     enabled: bool = True
 
     def __post_init__(self) -> None:
-        """Call superclass init after initialization."""
+        """Coerce ``behavior`` to the enum, then call superclass init."""
+        # Raises ValueError on an unknown name -- fail at construction rather
+        # than run every frame producing a zero force with no diagnostic.
+        self.behavior = SteeringBehaviorType(self.behavior)
         super().__init__()
 
 

--- a/pyguara/ai/context.py
+++ b/pyguara/ai/context.py
@@ -1,0 +1,27 @@
+"""Context object handed to a behavior tree by :class:`AISystem`."""
+
+from dataclasses import dataclass
+
+from pyguara.ai.blackboard import Blackboard
+from pyguara.ecs.entity import Entity
+
+
+@dataclass
+class AIContext:
+    """What a behavior-tree node receives as its ``context`` under ``AISystem``.
+
+    ``AISystem`` ticks every ``AIComponent``'s tree once per frame with one of
+    these, so nodes can reach the entity, the shared blackboard, and -- unlike
+    passing the bare entity -- the frame delta. ``WaitNode`` and any custom
+    timing node read ``context.dt``; without it they silently fall back to a
+    fixed step and drift with the real frame rate.
+
+    Attributes:
+        entity: The entity whose AI is being updated.
+        dt: Seconds elapsed since the previous AI update.
+        blackboard: The component's shared blackboard.
+    """
+
+    entity: Entity
+    dt: float
+    blackboard: Blackboard

--- a/pyguara/ai/fsm.py
+++ b/pyguara/ai/fsm.py
@@ -4,6 +4,9 @@ from abc import ABC, abstractmethod
 
 from pyguara.ai.blackboard import Blackboard
 from pyguara.ecs.entity import Entity
+from pyguara.log import get_logger
+
+logger = get_logger(__name__)
 
 
 class State(ABC):
@@ -52,10 +55,21 @@ class StateMachine:
 
     def set_initial_state(self, name: str) -> None:
         """Set the starting state."""
-        if name in self._states:
-            self._current_state = self._states[name]
-            self._current_state_name = name
-            self._current_state.on_enter()
+        if name not in self._states:
+            logger.warning(
+                "set_initial_state(%r): no such state registered; "
+                "the machine stays inert. Known states: %s",
+                name,
+                sorted(self._states),
+            )
+            return
+
+        if self._current_state is not None:
+            self._current_state.on_exit()
+
+        self._current_state = self._states[name]
+        self._current_state_name = name
+        self._current_state.on_enter()
 
     def update(self, dt: float) -> None:
         """Update current state and handle transitions."""
@@ -71,6 +85,14 @@ class StateMachine:
     def _transition_to(self, name: str) -> None:
         """Execute transition logic."""
         if name not in self._states:
+            logger.warning(
+                "State %r asked to transition to %r, which is not registered; "
+                "staying in %r. Known states: %s",
+                self._current_state_name,
+                name,
+                self._current_state_name,
+                sorted(self._states),
+            )
             return
 
         if self._current_state:

--- a/pyguara/ai/navmesh.py
+++ b/pyguara/ai/navmesh.py
@@ -166,6 +166,11 @@ class NavMesh:
                 for e in self._edges
                 if e.poly1_id != polygon_id and e.poly2_id != polygon_id
             ]
+            # Drop the now-dangling id from every remaining neighbor list, so
+            # get_neighbors() never hands back an id get_polygon() can't resolve.
+            for polygon in self._polygons.values():
+                if polygon_id in polygon.neighbors:
+                    polygon.neighbors.remove(polygon_id)
 
     def get_polygon(self, polygon_id: int) -> NavMeshPolygon | None:
         """Get polygon by ID.
@@ -276,8 +281,9 @@ class NavMesh:
 class NavMeshPathfinder:
     """A* pathfinding on navigation meshes.
 
-    Finds paths through connected polygons and smooths them
-    using the funnel algorithm.
+    Finds a path through connected polygons (A* over the polygon adjacency
+    graph) and returns the polygon centers as waypoints. String-pulling via
+    the funnel algorithm is not yet implemented -- see ``_create_waypoint_path``.
     """
 
     def __init__(self, navmesh: NavMesh):
@@ -328,9 +334,13 @@ class NavMeshPathfinder:
             List of polygon IDs forming path, or None
         """
         import heapq
+        from itertools import count
 
-        # A* on polygon graph
-        open_set = [(0.0, start_id)]
+        # A* on polygon graph. The counter breaks priority ties without ever
+        # comparing polygon ids, keeping the pop order stable and independent
+        # of id values.
+        counter = count()
+        open_set: list[tuple[float, int, int]] = [(0.0, next(counter), start_id)]
         came_from: dict[int, int] = {}
         g_score: dict[int, float] = {start_id: 0.0}
 
@@ -341,7 +351,7 @@ class NavMeshPathfinder:
             return None
 
         while open_set:
-            _, current_id = heapq.heappop(open_set)
+            _, _, current_id = heapq.heappop(open_set)
 
             if current_id == goal_id:
                 # Reconstruct path
@@ -380,7 +390,7 @@ class NavMeshPathfinder:
                     h = (dx * dx + dy * dy) ** 0.5
 
                     f = tentative_g + h
-                    heapq.heappush(open_set, (f, neighbor_id))
+                    heapq.heappush(open_set, (f, next(counter), neighbor_id))
 
         return None
 

--- a/pyguara/ai/pathfinding/astar.py
+++ b/pyguara/ai/pathfinding/astar.py
@@ -1,6 +1,7 @@
 """Generic A* pathfinding algorithm implementation."""
 
 import heapq
+from itertools import count
 
 from pyguara.ai.pathfinding.core import Graph, Heuristic, Node
 
@@ -16,14 +17,20 @@ class AStarPathfinder:
 
         Optimized to reduce heap operations.
         """
-        frontier: list[tuple[float, Node]] = []
-        heapq.heappush(frontier, (0, start))
+        # The monotonic tie-breaker is load-bearing, not cosmetic: on a
+        # priority tie heapq compares the next tuple element, and Node is only
+        # bound to Hashable -- an arbitrary graph node need not be
+        # order-comparable, so (priority, node) tuples raise TypeError. The
+        # counter is always distinct, so the node is never compared.
+        counter = count()
+        frontier: list[tuple[float, int, Node]] = []
+        heapq.heappush(frontier, (0.0, next(counter), start))
 
         came_from: dict[Node, Node | None] = {start: None}
         cost_so_far: dict[Node, float] = {start: 0.0}
 
         while frontier:
-            _, current = heapq.heappop(frontier)
+            _, _, current = heapq.heappop(frontier)
 
             if current == goal:
                 break
@@ -34,7 +41,7 @@ class AStarPathfinder:
                 if next_node not in cost_so_far or new_cost < cost_so_far[next_node]:
                     cost_so_far[next_node] = new_cost
                     priority = new_cost + heuristic.estimate(next_node, goal)
-                    heapq.heappush(frontier, (priority, next_node))
+                    heapq.heappush(frontier, (priority, next(counter), next_node))
                     came_from[next_node] = current
 
         return self._reconstruct_path(came_from, start, goal)

--- a/pyguara/ai/pathfinding/grid.py
+++ b/pyguara/ai/pathfinding/grid.py
@@ -219,6 +219,10 @@ def world_to_grid_coords(
     Returns:
         Grid position (x, y).
     """
-    grid_x = int((position.x - offset.x) / cell_size)
-    grid_y = int((position.y - offset.y) / cell_size)
+    # floor, not int(): int() truncates toward zero, so a world point left of
+    # or above the grid origin (negative local coordinate -- common with a
+    # non-zero offset) would land one cell too high and, for -cell_size < d < 0,
+    # collapse onto cell 0 instead of -1.
+    grid_x = math.floor((position.x - offset.x) / cell_size)
+    grid_y = math.floor((position.y - offset.y) / cell_size)
     return (grid_x, grid_y)

--- a/pyguara/ai/steering_system.py
+++ b/pyguara/ai/steering_system.py
@@ -2,12 +2,15 @@
 
 from typing import cast
 
-from pyguara.ai.components import Navigator, SteeringAgent
+from pyguara.ai.components import Navigator, SteeringAgent, SteeringBehaviorType
 from pyguara.ai.steering import SteeringBehavior
 from pyguara.common.components import Transform
 from pyguara.common.types import Vector2
 from pyguara.ecs.entity import Entity
 from pyguara.ecs.manager import EntityManager
+
+# Distance (world units) within which an ARRIVE agent is snapped to rest.
+_ARRIVE_STOP_DISTANCE = 1.0
 
 
 class SteeringSystem:
@@ -47,7 +50,7 @@ class SteeringSystem:
 
             # Determine target position
             target = self._get_target(entity, agent)
-            if target is None and agent.behavior != "wander":
+            if target is None and agent.behavior != SteeringBehaviorType.WANDER:
                 continue
 
             # Calculate steering force based on behavior
@@ -71,6 +74,22 @@ class SteeringSystem:
                     Vector2, new_velocity.normalized() * agent.max_speed
                 )
             agent.velocity = new_velocity
+
+            # ARRIVE must actually stop. The dt-scaled force above is only a
+            # weak proportional brake, so on its own the agent overshoots the
+            # target and orbits it forever. Enforce the arrive speed ramp on
+            # the velocity directly: cap speed to max_speed * d / slowing_radius
+            # inside the radius, and snap to rest at the target.
+            if agent.behavior == SteeringBehaviorType.ARRIVE and target is not None:
+                distance = (target - transform.position).length
+                if distance <= _ARRIVE_STOP_DISTANCE:
+                    agent.velocity = Vector2(0, 0)
+                elif distance < agent.slowing_radius and agent.slowing_radius > 0:
+                    ramp_speed = agent.max_speed * (distance / agent.slowing_radius)
+                    if agent.velocity.length > ramp_speed:
+                        agent.velocity = cast(
+                            Vector2, agent.velocity.normalized() * ramp_speed
+                        )
 
             # Update position
             transform.position = transform.position + agent.velocity * dt
@@ -118,24 +137,9 @@ class SteeringSystem:
         Returns:
             Steering force vector.
         """
-        behavior = agent.behavior.lower()
+        behavior = agent.behavior
 
-        if behavior == "seek" and target is not None:
-            return SteeringBehavior.seek(
-                transform, target, agent.max_speed, agent.velocity
-            )
-
-        elif behavior == "arrive" and target is not None:
-            return SteeringBehavior.arrive(
-                transform, target, agent.max_speed, agent.velocity, agent.slowing_radius
-            )
-
-        elif behavior == "flee" and target is not None:
-            return SteeringBehavior.flee(
-                transform, target, agent.max_speed, agent.velocity
-            )
-
-        elif behavior == "wander":
+        if behavior == SteeringBehaviorType.WANDER:
             wander_target = self._wander_targets.get(entity_id)
             force, new_wander_target = SteeringBehavior.wander(
                 transform,
@@ -146,7 +150,43 @@ class SteeringSystem:
             self._wander_targets[entity_id] = new_wander_target
             return force
 
-        return Vector2(0, 0)
+        if target is None:
+            return Vector2(0, 0)
+
+        if behavior == SteeringBehaviorType.SEEK:
+            return SteeringBehavior.seek(
+                transform, target, agent.max_speed, agent.velocity
+            )
+
+        if behavior == SteeringBehaviorType.ARRIVE:
+            return SteeringBehavior.arrive(
+                transform, target, agent.max_speed, agent.velocity, agent.slowing_radius
+            )
+
+        if behavior == SteeringBehaviorType.FLEE:
+            return SteeringBehavior.flee(
+                transform, target, agent.max_speed, agent.velocity
+            )
+
+        if behavior == SteeringBehaviorType.PURSUIT:
+            return SteeringBehavior.pursuit(
+                transform,
+                target,
+                agent.target_velocity,
+                agent.max_speed,
+                agent.velocity,
+            )
+
+        # Only EVADE remains: WANDER returned above, and every other member is
+        # handled just above; SteeringAgent.__post_init__ rejects anything else
+        # at construction.
+        return SteeringBehavior.evade(
+            transform,
+            target,
+            agent.target_velocity,
+            agent.max_speed,
+            agent.velocity,
+        )
 
     def _update_navigator(
         self, entity: Entity, transform: Transform, target: Vector2

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,6 +1,20 @@
+"""Tests for the FSM, blackboard, and the ECS-facing AISystem/AIContext."""
+
+import logging
+
+from pyguara.ai import AIContext, AISystem
+from pyguara.ai.behavior_tree import (
+    ActionNode,
+    BehaviorTree,
+    NodeStatus,
+    SequenceNode,
+    WaitNode,
+)
 from pyguara.ai.blackboard import Blackboard
+from pyguara.ai.components import AIComponent
 from pyguara.ai.fsm import State, StateMachine
 from pyguara.ecs.entity import Entity
+from pyguara.ecs.manager import EntityManager
 
 
 # Mocks
@@ -10,16 +24,31 @@ class MockState(State):
         self.name = name
         self.entered = False
         self.exited = False
+        self.enter_count = 0
+        self.exit_count = 0
         self.next_state: str | None = None
 
     def on_enter(self):
         self.entered = True
+        self.enter_count += 1
 
     def on_exit(self):
         self.exited = True
+        self.exit_count += 1
 
     def update(self, dt):
         return self.next_state
+
+
+def _make_fsm() -> tuple[StateMachine, MockState, MockState]:
+    entity = Entity()
+    bb = Blackboard()
+    fsm = StateMachine(entity, bb)
+    idle = MockState(entity, bb, "idle")
+    walk = MockState(entity, bb, "walk")
+    fsm.add_state("idle", idle)
+    fsm.add_state("walk", walk)
+    return fsm, idle, walk
 
 
 def test_blackboard():
@@ -31,24 +60,122 @@ def test_blackboard():
 
 
 def test_fsm_transitions():
-    entity = Entity()
-    bb = Blackboard()
-    fsm = StateMachine(entity, bb)
-
-    s1 = MockState(entity, bb, "idle")
-    s2 = MockState(entity, bb, "walk")
-
-    fsm.add_state("idle", s1)
-    fsm.add_state("walk", s2)
+    fsm, s1, s2 = _make_fsm()
 
     fsm.set_initial_state("idle")
-    assert fsm._current_state == s1
+    assert fsm._current_state is s1
     assert s1.entered
 
     # Trigger transition
     s1.next_state = "walk"
     fsm.update(0.1)
 
-    assert fsm._current_state == s2
+    assert fsm._current_state is s2
     assert s1.exited
     assert s2.entered
+
+
+def test_set_initial_state_unknown_name_warns_and_stays_inert(caplog):
+    """An unknown initial state name is a mistake worth a warning, not silence."""
+    fsm, _idle, _walk = _make_fsm()
+
+    with caplog.at_level(logging.WARNING):
+        fsm.set_initial_state("Idle")  # wrong case
+
+    assert fsm._current_state is None
+    assert any("Idle" in r.message for r in caplog.records)
+    # And the inert machine no-ops rather than raising.
+    fsm.update(0.1)
+
+
+def test_set_initial_state_twice_exits_the_first_state():
+    """Re-seeding the machine must not leak the previous state's on_enter."""
+    fsm, idle, walk = _make_fsm()
+
+    fsm.set_initial_state("idle")
+    fsm.set_initial_state("walk")
+
+    assert idle.exit_count == 1
+    assert walk.enter_count == 1
+    assert fsm._current_state is walk
+
+
+def test_transition_to_unknown_target_warns_and_holds(caplog):
+    fsm, idle, _walk = _make_fsm()
+    fsm.set_initial_state("idle")
+    idle.next_state = "nowhere"
+
+    with caplog.at_level(logging.WARNING):
+        fsm.update(0.1)
+
+    assert fsm._current_state_name == "idle"
+    assert idle.exit_count == 0  # never left
+    assert any("nowhere" in r.message for r in caplog.records)
+
+
+class TestAISystemContext:
+    """AISystem must hand behavior trees a context that carries dt."""
+
+    def test_wait_node_completes_in_real_time_regardless_of_frame_rate(self):
+        """Regression: the tree got the bare Entity, so WaitNode ran on a
+        fixed ~1/60 step and a 1s wait took ~2s at 30fps, ~3.5s at 144fps."""
+        for fps in (30, 60, 144):
+            em = EntityManager()
+            entity = em.create_entity()
+            done = {"hit": False}
+
+            def _mark(_ctx, flag=done):
+                flag["hit"] = True
+                return NodeStatus.SUCCESS
+
+            tree = BehaviorTree(
+                root=SequenceNode([WaitNode(duration=1.0), ActionNode(_mark)])
+            )
+            entity.add_component(AIComponent(behavior_tree=tree))
+            system = AISystem(em)
+
+            frames = 0
+            while not done["hit"] and frames < fps * 3:
+                system.update(1.0 / fps)
+                frames += 1
+
+            elapsed = frames / fps
+            assert done["hit"], f"wait never completed at {fps}fps"
+            assert 0.9 <= elapsed <= 1.2, f"{fps}fps: waited {elapsed:.2f}s"
+
+    def test_context_exposes_entity_and_blackboard(self):
+        em = EntityManager()
+        entity = em.create_entity()
+        seen: dict[str, object] = {}
+
+        def _probe(ctx: AIContext):
+            seen["entity"] = ctx.entity
+            seen["dt"] = ctx.dt
+            seen["blackboard"] = ctx.blackboard
+            return NodeStatus.SUCCESS
+
+        ai = AIComponent(behavior_tree=BehaviorTree(root=ActionNode(_probe)))
+        entity.add_component(ai)
+
+        AISystem(em).update(0.033)
+
+        assert seen["entity"] is entity
+        assert seen["dt"] == 0.033
+        assert seen["blackboard"] is ai.blackboard
+
+    def test_disabled_component_is_skipped(self):
+        em = EntityManager()
+        entity = em.create_entity()
+        ticks = {"n": 0}
+
+        def _count(_ctx):
+            ticks["n"] += 1
+            return NodeStatus.SUCCESS
+
+        ai = AIComponent(behavior_tree=BehaviorTree(root=ActionNode(_count)))
+        ai.enabled = False
+        entity.add_component(ai)
+
+        AISystem(em).update(0.016)
+
+        assert ticks["n"] == 0

--- a/tests/test_behavior_tree.py
+++ b/tests/test_behavior_tree.py
@@ -184,6 +184,29 @@ class TestWaitNode:
         status = node.tick(context)
         assert status == NodeStatus.RUNNING
 
+    def test_wait_uses_context_dt_not_a_fixed_step(self):
+        """Elapsed time tracks the context's real dt, whatever its value.
+
+        Regression: WaitNode read a hardcoded ~1/60 fallback, so under a
+        context that carried a real (larger or smaller) dt the wait drifted.
+        """
+        node = WaitNode(duration=1.0)
+        ctx = MockContext()
+        ctx.dt = 0.25  # 4 ticks == 1.0s, regardless of frame rate
+
+        assert node.tick(ctx) == NodeStatus.RUNNING
+        assert node.tick(ctx) == NodeStatus.RUNNING
+        assert node.tick(ctx) == NodeStatus.RUNNING
+        assert node.tick(ctx) == NodeStatus.SUCCESS
+
+    def test_wait_completes_in_one_tick_for_a_large_dt(self):
+        """A single long frame satisfies the whole wait."""
+        node = WaitNode(duration=0.5)
+        ctx = MockContext()
+        ctx.dt = 2.0
+
+        assert node.tick(ctx) == NodeStatus.SUCCESS
+
 
 class TestSequenceNode:
     """Test SequenceNode functionality."""

--- a/tests/test_navmesh.py
+++ b/tests/test_navmesh.py
@@ -273,6 +273,27 @@ class TestNavMesh:
 
         assert navmesh.polygon_count == 0
 
+    def test_remove_polygon_prunes_dangling_neighbor_ids(self):
+        """A removed polygon's id must not linger in its ex-neighbors' lists.
+
+        ``get_neighbors`` is public; a stale id there is one nobody can
+        resolve back to a polygon.
+        """
+        navmesh = NavMesh()
+        for i, x in enumerate((0.0, 100.0, 200.0)):
+            navmesh.add_polygon(create_rectangle_polygon(i, x, 0.0, 100.0, 100.0))
+        navmesh.build_connections()
+        assert navmesh.get_neighbors(1) == [0, 2]
+
+        navmesh.remove_polygon(2)
+
+        assert navmesh.get_neighbors(1) == [0]
+        assert navmesh.get_neighbors(0) == [1]
+        # And every listed neighbor still resolves.
+        for poly_id in (0, 1):
+            for neighbor_id in navmesh.get_neighbors(poly_id):
+                assert navmesh.get_polygon(neighbor_id) is not None
+
     def test_get_polygon(self):
         """Should retrieve polygon by ID."""
         navmesh = NavMesh()

--- a/tests/test_pathfinding.py
+++ b/tests/test_pathfinding.py
@@ -366,6 +366,71 @@ class TestAStarPathfinder:
         assert len(path2) > original_length
 
 
+class TestAStarGenericGraph:
+    """A* over a graph whose nodes are not order-comparable.
+
+    ``Node`` is bound only to ``Hashable``; before the monotonic tie-breaker
+    a priority tie made heapq compare the node objects and raise
+    ``TypeError: '<' not supported``. Priority ties are the common case, not
+    the exotic one.
+    """
+
+    class _Cell:
+        """Hashable, equatable, deliberately NOT ordered."""
+
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def __hash__(self) -> int:
+            return hash(self.name)
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, type(self)) and other.name == self.name
+
+        def __repr__(self) -> str:
+            return f"_Cell({self.name})"
+
+    class _DiamondGraph:
+        """A -> B, A -> C, B -> D, C -> D; every edge costs 1."""
+
+        def __init__(self, a, b, c, d) -> None:
+            self._adj = {a: [b, c], b: [d], c: [d], d: []}
+
+        def get_neighbors(self, node):
+            return iter(self._adj[node])
+
+        def cost(self, from_node, to_node) -> float:
+            return 1.0
+
+    class _ZeroHeuristic:
+        """Uniform h == 0, so B and C are pushed with an identical priority."""
+
+        def estimate(self, current, goal) -> float:
+            return 0.0
+
+    def test_priority_tie_with_unordered_nodes(self):
+        """Equal priorities must not force a comparison of the nodes."""
+        a, b, c, d = (self._Cell(n) for n in "ABCD")
+        graph = self._DiamondGraph(a, b, c, d)
+
+        path = AStarPathfinder().find_path(graph, a, d, self._ZeroHeuristic())
+
+        assert path is not None
+        assert path[0] == a
+        assert path[-1] == d
+        assert len(path) == 3  # A -> (B or C) -> D
+
+    def test_unreachable_goal_returns_none(self):
+        """A disconnected goal still returns None, not a crash."""
+        a, b, c, d = (self._Cell(n) for n in "ABCD")
+        island = self._Cell("Z")
+        graph = self._DiamondGraph(a, b, c, d)
+
+        path = AStarPathfinder().find_path(graph, a, island, self._ZeroHeuristic())
+
+        assert path is None
+
+
 class TestPathSmoothing:
     """Test path smoothing functionality."""
 
@@ -465,6 +530,47 @@ class TestCoordinateConversion:
         grid_pos = world_to_grid_coords(world_pos, cell_size)
 
         assert grid_pos == (0, 0)
+
+    def test_world_to_grid_negative_coords_floor_not_truncate(self):
+        """A point left of / above the origin floors, it does not truncate.
+
+        ``int()`` rounds toward zero, so ``-10`` would land in cell 0 and
+        ``-40`` in cell -1 -- one cell too high, and a sign flip near the
+        axis. The cell containing ``-10`` (with cell_size 32) is ``-1``.
+        """
+        cell_size = 32.0
+
+        assert world_to_grid_coords(Vector2(-1.0, -1.0), cell_size) == (-1, -1)
+        assert world_to_grid_coords(Vector2(-10.0, -31.0), cell_size) == (-1, -1)
+        assert world_to_grid_coords(Vector2(-32.0, -32.0), cell_size) == (-1, -1)
+        assert world_to_grid_coords(Vector2(-33.0, -64.0), cell_size) == (-2, -2)
+
+    def test_world_to_grid_offset_puts_origin_inside_playfield(self):
+        """With an offset, local coords go negative -- and must still floor.
+
+        A centered grid (offset at the play area's middle) resolves points in
+        the top-left quadrant to negative cells; truncation collapsed that
+        whole quadrant onto row/column 0.
+        """
+        cell_size = 32.0
+        offset = Vector2(100.0, 100.0)
+
+        # 10px left of and above the offset origin -> cell (-1, -1).
+        assert world_to_grid_coords(Vector2(90.0, 90.0), cell_size, offset) == (-1, -1)
+        # On the origin -> (0, 0).
+        assert world_to_grid_coords(Vector2(100.0, 100.0), cell_size, offset) == (0, 0)
+        # 40px right/below -> (1, 1).
+        assert world_to_grid_coords(Vector2(140.0, 140.0), cell_size, offset) == (1, 1)
+
+    def test_round_trip_conversion_negative_cell(self):
+        """world -> grid -> world -> grid is stable in the negative quadrant."""
+        cell_size = 32.0
+        original = Vector2(-70.0, -145.0)
+
+        grid_pos = world_to_grid_coords(original, cell_size)
+        world_center = path_to_world_coords([grid_pos], cell_size)[0]
+
+        assert world_to_grid_coords(world_center, cell_size) == grid_pos
 
     def test_path_to_world_coords_basic(self):
         """Should convert grid path to world coords."""

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -1,0 +1,179 @@
+"""Tests for SteeringSystem and the SteeringBehaviorType enum.
+
+The subsystem audit had no steering-system test at all, and every
+SteeringAgent was built the same way (``behavior="wander"``), so the
+string-dispatch gaps went unseen.
+"""
+
+import pytest
+
+from pyguara.ai.components import Navigator, SteeringAgent, SteeringBehaviorType
+from pyguara.ai.steering_system import SteeringSystem
+from pyguara.common.components import Transform
+from pyguara.common.types import Vector2
+from pyguara.ecs.manager import EntityManager
+
+
+def _agent_entity(em: EntityManager, pos: Vector2, **agent_kwargs):
+    entity = em.create_entity()
+    entity.add_component(Transform(position=pos))
+    entity.add_component(SteeringAgent(**agent_kwargs))
+    return entity
+
+
+def _run(system: SteeringSystem, frames: int = 120, dt: float = 1.0 / 60.0) -> None:
+    for _ in range(frames):
+        system.update(dt)
+
+
+class TestSteeringBehaviorType:
+    """Construction-time coercion and validation."""
+
+    def test_string_is_coerced_to_enum(self):
+        agent = SteeringAgent(behavior="arrive")
+        assert agent.behavior is SteeringBehaviorType.ARRIVE
+
+    def test_enum_value_passes_through(self):
+        agent = SteeringAgent(behavior=SteeringBehaviorType.PURSUIT)
+        assert agent.behavior is SteeringBehaviorType.PURSUIT
+
+    def test_default_is_seek(self):
+        assert SteeringAgent().behavior is SteeringBehaviorType.SEEK
+
+    def test_unknown_behavior_rejected_at_construction(self):
+        with pytest.raises(ValueError, match="chase"):
+            SteeringAgent(behavior="chase")
+
+
+class TestReachableBehaviors:
+    """Every enum member must actually drive the agent through the system."""
+
+    def test_seek_moves_toward_target(self):
+        em = EntityManager()
+        e = _agent_entity(em, Vector2(0, 0), behavior="seek", target=Vector2(500, 0))
+        _run(SteeringSystem(em))
+        assert e.get_component(Transform).position.x > 50
+
+    def test_flee_moves_away_from_target(self):
+        em = EntityManager()
+        e = _agent_entity(em, Vector2(0, 0), behavior="flee", target=Vector2(30, 0))
+        _run(SteeringSystem(em))
+        assert e.get_component(Transform).position.x < -10
+
+    def test_wander_moves_without_a_target(self):
+        em = EntityManager()
+        e = _agent_entity(em, Vector2(0, 0), behavior="wander")
+        _run(SteeringSystem(em))
+        assert e.get_component(Transform).position.sqr_magnitude > 1.0
+
+    def test_pursuit_leads_a_moving_target(self):
+        em = EntityManager()
+        # Target ahead on X, moving fast in +Y: interception must gain Y.
+        e = _agent_entity(
+            em,
+            Vector2(0, 0),
+            behavior="pursuit",
+            target=Vector2(200, 0),
+            target_velocity=Vector2(0, 150),
+            max_speed=250,
+        )
+        _run(SteeringSystem(em))
+        pos = e.get_component(Transform).position
+        assert pos.x > 20
+        assert pos.y > 20  # led the target, not aimed at its old spot
+
+    def test_evade_flees_a_moving_threat(self):
+        em = EntityManager()
+        e = _agent_entity(
+            em,
+            Vector2(0, 0),
+            behavior="evade",
+            target=Vector2(40, 0),
+            target_velocity=Vector2(-50, 0),
+            max_speed=200,
+        )
+        _run(SteeringSystem(em))
+        assert e.get_component(Transform).position.x < -10
+
+
+class TestArriveSettles:
+    """Regression: arrive overshot the target and orbited it forever."""
+
+    def test_arrive_comes_to_rest_at_the_target(self):
+        em = EntityManager()
+        e = _agent_entity(
+            em,
+            Vector2(0, 0),
+            behavior="arrive",
+            target=Vector2(300, 0),
+            max_speed=200,
+            slowing_radius=100,
+        )
+        system = SteeringSystem(em)
+        _run(system, frames=1200)
+
+        transform = e.get_component(Transform)
+        agent = e.get_component(SteeringAgent)
+        assert (Vector2(300, 0) - transform.position).length < 2.0
+        assert agent.velocity.length < 1.0
+
+    def test_arrive_does_not_oscillate_once_settled(self):
+        em = EntityManager()
+        e = _agent_entity(
+            em,
+            Vector2(0, 0),
+            behavior="arrive",
+            target=Vector2(150, 0),
+            max_speed=180,
+            slowing_radius=80,
+        )
+        system = SteeringSystem(em)
+        _run(system, frames=1500)
+
+        transform = e.get_component(Transform)
+        settled = transform.position
+        _run(system, frames=120)
+        assert (transform.position - settled).length < 0.5
+
+
+class TestWanderState:
+    """Per-entity wander target persistence and its cleanup."""
+
+    def test_wander_target_persists_across_frames(self):
+        em = EntityManager()
+        e = _agent_entity(em, Vector2(0, 0), behavior="wander")
+        system = SteeringSystem(em)
+        system.update(1 / 60)
+        assert e.id in system._wander_targets
+
+    def test_cleanup_clears_wander_targets(self):
+        em = EntityManager()
+        _agent_entity(em, Vector2(0, 0), behavior="wander")
+        system = SteeringSystem(em)
+        system.update(1 / 60)
+        assert system._wander_targets
+
+        system.cleanup()
+        assert system._wander_targets == {}
+
+
+class TestTargetResolution:
+    def test_non_wander_agent_without_a_target_is_skipped(self):
+        em = EntityManager()
+        e = _agent_entity(em, Vector2(0, 0), behavior="seek")  # no target
+        _run(SteeringSystem(em), frames=30)
+        # No movement, no crash.
+        assert e.get_component(Transform).position == Vector2(0, 0)
+
+    def test_navigator_path_drives_seek_when_no_direct_target(self):
+        em = EntityManager()
+        e = _agent_entity(em, Vector2(0, 0), behavior="seek", max_speed=200)
+        nav = Navigator(reach_threshold=8.0)
+        nav.set_path([Vector2(120, 0), Vector2(120, 120)])
+        e.add_component(nav)
+
+        _run(SteeringSystem(em), frames=240)
+
+        # Advanced past the first waypoint toward the second.
+        assert nav.current_index >= 1
+        assert e.get_component(Transform).position.y > 20


### PR DESCRIPTION
Phase A–D of the `pyguara/ai` subsystem audit (FSM, blackboard, steering, behavior trees, navmesh, pathfinding — ~2,100 lines, one slice). Independent branch, cut from `main`.

## Defects (each reproduced with a probe against the real code first)

| # | Fix |
|---|-----|
| **F1** | `world_to_grid_coords()` used `int()` (truncates toward zero) not `floor`, so a non-zero grid `offset` or any negative local coord resolved to the wrong cell — world `(-10,-10)` → grid `(0,0)`, a sign flip. Now `math.floor`. |
| **F2** | `AISystem` passed the bare `Entity` as the behavior-tree context, so `WaitNode` (any `context.dt` reader) fell back to a hardcoded `1/60` and drifted with the frame rate: `WaitNode(1.0)` ≈ 2.1 s @30fps, 3.5 s @144fps. The engine's own game hand-rolled its own AI system to dodge this. New `AIContext` (entity + dt + blackboard), built per frame, passed to `tree.tick()`. |
| **F3** | `SteeringSystem` only dispatched `seek/arrive/flee/wander`; `pursuit`/`evade` (the only moving-target behaviors) were implemented but unreachable, and an unknown `behavior` string produced zero force silently. `behavior` is now a validated `SteeringBehaviorType` enum, all six wired; `SteeringAgent` gains `target_velocity`. |
| **F7** | `behavior="arrive"` overshot the target and orbited it forever. `SteeringSystem` now enforces the arrive speed ramp on the resulting velocity and snaps to rest within `_ARRIVE_STOP_DISTANCE`. |
| **F4** | Generic `AStarPathfinder` raised `TypeError` on a priority tie when graph nodes were not order-comparable (`Node` is only `Hashable`; ties are the common case). Added the monotonic `itertools.count` tie-breaker; same for `NavMeshPathfinder`. |
| **F5** | `NavMesh.remove_polygon()` left the dangling id in other polygons' `neighbors` lists. Now pruned. |
| **F6** | FSM `set_initial_state()` / an unknown transition target were silent no-ops — now logged; a second `set_initial_state()` exits the prior state. `NavMeshPathfinder` docstring claimed a funnel algorithm it lacks — corrected. |

Two decisions were put to the repo owner: **F2** → a real `AIContext` object (vs. a `WaitNode`-only patch); **F3** → a full `SteeringBehaviorType` enum with construction-time validation (vs. validate-only). Both change what `AISystem` / `SteeringAgent` callers see (bare `Entity` → `AIContext`; `behavior: str` → enum) — acceptable pre-alpha, and `AISystem` was unusable for timed nodes anyway.

## Tests

+29 (1770 → 1799). Rewritten `test_ai.py` (FSM warnings, `AISystem`/`AIContext` incl. a frame-rate-independence regression); new `test_steering.py` (all six behaviors reachable through the system, arrive settles without re-oscillating, enum validation, wander state, Navigator path-follow); plus negative/offset `world_to_grid_coords`, an A* test over a non-orderable-node graph, `remove_polygon` neighbor pruning, and `WaitNode`-honours-real-`dt`. **Phase B verdict:** the BT/navmesh/pathfinding suites are load-bearing, but `test_ai.py` was 54 lines, there was no `test_steering.py`, no `AISystem` test, and uniform setup (`TestCoordinateConversion` all-positive) hid F1.

## Phase D (not in this PR)

- **BT/FSM authoring gaps** → propose a new issue (sibling of #37/#40/#43): no *reactive* `Sequence`/`Selector` (a front guard `ConditionNode` stops being re-checked once the sequence advances), `ParallelNode` re-ticks completed children, FSM has no transition table / event transitions, every BT leaf is a hand-written closure.
- **Navmesh** funnel string-pulling / partial-edge portals / mesh generation → parked (flow-field pathfinding is #28's).
- **Steering vs. physics** (agents write `transform.position` directly, no collision/separation) → parked for the top-down `CharacterMover` slice.
- `_wander_targets` is evicted only on scene exit, not per destroyed entity → left-open note.

## Verification

`pytest` 1799 pass · `ruff check .` clean · `ruff format --check` clean · `mypy pyguara` clean (226 files) · `mkdocs build --strict` exit 0 · `test_docs_api.py` (54) pass. Both commits verified standalone in a detached `git worktree`.

PR is final — nothing else coming on this branch. Phase D follow-ups go on new branches from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5