### PR TITLE
refactor(ui): wire the constraint layout pass; live theme lookup

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -79,9 +79,75 @@ how the subject is *constructed*, not just what is asserted.
 
 ## Active Subsystem
 
-**None — `pyguara/ai` closed 2026-09-08 (branch `refactor/ai-audit`).**
-Next in the queue is Tier 4: `pyguara/ui` (layout engine, widgets, theming).
-Open `REFACTOR_STATE.md` "How to resume" and take it.
+**None — `pyguara/ui` closed 2026-09-08 (branch `refactor/ui-audit`).**
+Next in the queue is Tier 4: `pyguara/prefabs` (prefab definition and
+instantiation). Open `REFACTOR_STATE.md` "How to resume" and take it.
+
+`pyguara/ui` in one slice, ~1,900 lines (`base`, `layout`, `constraints`,
+`manager`, `theme`, `theme_presets`, `types`, `components/*`). Two headline
+"declared and wired to nothing" defects sat under 84 green tests because
+every test exercised a unit in isolation from the runtime loop.
+**The constraint layout system never ran.** `UIElement.apply_layout()` had
+no caller anywhere in the repo — `UIManager.update()`/`render()` had no
+layout pass, and root elements can't even be constrained (`apply_layout`
+early-outs unless `self.parent` is set). Probe: a child with
+`create_fill_constraints(margin=20)` under an 800×600 parent stayed at
+`Rect(0,0,10,10)` through three manager frames. So `constraints.py`
+(314 lines), `element.padding`, and every `create_*_constraints` helper were
+inert — yet documented as "the heart of the UI system's power" across two
+guides with non-runnable examples. Per the user's choice (unify, not a
+minimal shim, not park), `UIElement.apply_layout()` → `UIElement.layout(
+available_rect, renderer)`: `UIManager` holds a screen `Rect` (seeded by
+`Application` via a new `set_screen_size()`, refreshed by a
+`WindowResizeEvent` subscription), and runs `layout()` over every root
+before rendering, **dirty-gated** — `add_element` / `set_screen_size` / a
+new public `invalidate_layout()` arm it, a steady frame is free. Roots
+constrain against the screen rect; children against the parent's
+padding-aware content rect (so `padding` finally does something).
+`BoxContainer.layout()` was folded into the same signature/pass and now
+resolves its **own** constraints first, honours `LayoutAlignment.STRETCH`
+(declared, no branch → was silently `START`), skips hidden children in
+`render()` (every other traversal already did), and recurses into nested
+containers. **Theme was snapshotted per element at construction** —
+`UIElement.__init__` did `self.theme = get_theme()`, so `set_theme()` after
+the UI was built re-skinned nothing (probe: build `Button`,
+`set_theme(CYBERPUNK)`, still steel-blue). `get_theme()` is a function
+precisely to allow runtime swaps. Now `UIElement.theme` is a property doing
+the live lookup; `ProgressBar`/`Canvas`/`NavBar` (which cached a `Color` in
+`__init__`) defer to render time. **`ThemeConstants` `@dataclass(frozen=
+True)` decorated nothing** — `DARK = …` etc. had no annotations, so
+`fields() == []`, `frozen` protected nothing, and the docstring's "All
+themes are immutable" was false: probe mutated `Themes.DARK.colors.primary`
+in place, corrupting the process-wide singleton. Now a `__getattr__`
+accessor hands back a **fresh copy** per access. Smaller: `Slider` now
+rejects `max_val <= min_val` / non-positive width at construction (both
+divided by zero on interaction); dead `UIElement.anchor` / `Label(anchor=)`
+param removed (`LayoutConstraints.anchor` is the real mechanism). Recurring
+shapes: "declared and wired to nothing" (`apply_layout`, `STRETCH`,
+`anchor`, fake `frozen`), "cached snapshot where a live lookup was intended"
+(per-element theme), and uniform test setup — `test_ui_constraints.py`
+(513 lines) only ever called `LayoutConstraints.apply()` on hand-built
+`Rect`s, never through the manager; theme tests never built a `UIElement`.
+Tests: added `test_ui_manager_layout.py` (manager-driven layout, dirty
+gate, resize, live theme swap, preset copies) and rebuilt
+`test_ui_layout.py` for the new signature + STRETCH + visibility + nesting.
+See the iteration log entry below. **BREAKING** (pre-alpha): `BoxContainer.
+layout()` / `UIElement.layout()` signature changed; the four in-repo games
+that hand-called `container.layout(renderer)` had the now-redundant call
+removed (the manager does it).
+
+**Capability gaps (Phase D) → new issue.** The theme carries
+`ShadowScheme`, `BorderScheme.radius`, `ColorScheme.hover_overlay/
+press_overlay` that **no widget consumes** (`Widget.get_state_color` even
+says "you might blend colors here" and doesn't); no keyboard/gamepad focus
+navigation (`set_focus` exists, nothing moves it); no scroll/clip container
+(`UIRenderer` has no push/pop clip) for inventory lists and message logs;
+only linear `BoxContainer`, no grid/flex; real text input still rides
+`KEY_DOWN`+`chr()` with no shift/unicode/IME and `UIEventType.TEXT_INPUT`
+is declared but never dispatched (needs a `pyguara/input` SDL-TEXTINPUT
+surface); layout invalidation is manual (`invalidate_layout()`) rather than
+a dirty-tracking `set_text`/`visible`. Coherent and sizeable → sibling of
+#37/#40/#43/#46.
 
 `pyguara/ai` in one slice, ~2,100 lines (`fsm`, `blackboard`, `components`,
 `ai_system`, `steering`, `steering_system`, `behavior_tree`, `navmesh`,
@@ -402,7 +468,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 - [x] `pyguara/ai` — FSM, steering, pathfinding, navmesh, behaviour trees *(done)*
 
 ### Tier 4 — Tooling & authoring
-- [ ] `pyguara/ui` — layout engine, widgets, theming
+- [x] `pyguara/ui` — layout engine, widgets, theming *(done)*
 - [ ] `pyguara/prefabs` — prefab definition and instantiation
 - [ ] `pyguara/editor` — in-engine editor, inspector tools
 - [ ] `pyguara/scripting` — coroutines, script hosting
@@ -417,6 +483,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/ui` | 2026-09-08 | One slice (`base`, `layout`, `constraints`, `manager`, `theme`, `theme_presets`, `types`, `components/*`; ~1,900 lines). Two "declared and wired to nothing" headliners under 84 green tests. **The constraint layout system never ran** — `UIElement.apply_layout()` had no caller in the repo; `UIManager` had no layout pass; roots couldn't be constrained at all (`apply_layout` needs `self.parent`). Probe: `create_fill_constraints(margin=20)` under an 800×600 parent → child stays `Rect(0,0,10,10)` across three manager frames. So `constraints.py` (314 lines) + `element.padding` + every `create_*_constraints` helper were inert, though documented as "the heart of the UI system's power" with non-runnable examples. Per the user's choice (unify): `apply_layout()` → `UIElement.layout(available_rect, renderer)`; `UIManager` holds a screen `Rect` (seeded by `Application.set_screen_size()`, refreshed via a `WindowResizeEvent` subscription) and runs `layout()` over every root before render, **dirty-gated** (`add_element` / `set_screen_size` / new public `invalidate_layout()` arm it). Roots constrain against the screen; children against the parent's padding-aware content rect. `BoxContainer.layout()` folded into the same pass: resolves its own constraints first, honours `LayoutAlignment.STRETCH` (declared, no branch), skips hidden children in `render()`, recurses. **Theme was snapshotted per element at construction** (`self.theme = get_theme()` in `__init__`) so `set_theme()` re-skinned nothing already built (probe confirmed) — now `UIElement.theme` is a live property; `ProgressBar`/`Canvas`/`NavBar` defer their cached `Color`. **`ThemeConstants` `@dataclass(frozen=True)` decorated nothing** (`fields() == []`) — "All themes are immutable" was false, presets were mutable process-wide singletons; now a `__getattr__` hands back a fresh copy per access. Smaller: `Slider` rejects `max_val <= min_val` / non-positive width at construction; dead `UIElement.anchor` / `Label(anchor=)` param removed. Recurring shapes: "declared and wired to nothing" (`apply_layout`, `STRETCH`, `anchor`, fake `frozen`), "cached snapshot vs live lookup" (theme), uniform test setup (`test_ui_constraints.py`'s 513 lines only ever called `.apply()` on hand-built Rects; theme tests never built a `UIElement`). BREAKING (pre-alpha): `layout()` signature changed; four in-repo games had their now-redundant `container.layout(renderer)` call removed. Tests: new `test_ui_manager_layout.py` + rebuilt `test_ui_layout.py`. Phase D → new issue (sibling of #37/#40/#43/#46): `ShadowScheme`/`BorderScheme.radius`/`hover_overlay`/`press_overlay` consumed by no widget, no focus navigation, no scroll/clip container, no grid layout, no real text-input path (`TEXT_INPUT` declared/never dispatched), manual layout invalidation. |
 | `pyguara/ai` | 2026-09-08 | One slice (`fsm`, `blackboard`, `components`, `ai_system`, `steering`, `steering_system`, `behavior_tree`, `navmesh`, `pathfinding/*`; ~2,100 lines). **`world_to_grid_coords()` used `int()` not `floor`** — a non-zero grid `offset` or any negative local coord resolved to the wrong cell, and the quadrant left of/above the origin collapsed onto row/col 0 (world `(-10,-10)` → grid `(0,0)`, a sign flip). "Formula that returns a wrong answer" → `math.floor`. **`AISystem` passed the bare `Entity` as the BT context**, so `WaitNode` (any `context.dt` reader) fell back to a hardcoded `1/60` and drifted with frame rate — `WaitNode(1.0)` = ~2.1s @30fps, ~3.5s @144fps; the engine's own game hand-rolled its own AI system to dodge this. Fixed with a small `AIContext` (entity+dt+blackboard), passed to `tree.tick()`. **`SteeringSystem` only dispatched `seek/arrive/flee/wander`** — `pursuit`/`evade` (the only moving-target behaviors) were implemented but unreachable, and an unknown `behavior` string produced zero force silently. `behavior` is now a validated `SteeringBehaviorType` enum, all six wired, `SteeringAgent` gained `target_velocity`. **`behavior="arrive"` overshot and orbited the target forever** — system now enforces the arrive speed ramp on velocity and snaps to rest. **Generic `AStarPathfinder` crashed on a priority tie** with non-order-comparable nodes (`Node` is only `Hashable`; ties are common) — added the monotonic tie-break counter (also to `NavMeshPathfinder`). **`NavMesh.remove_polygon()` left dangling ids in other polygons' `neighbors`** — now pruned. FSM `set_initial_state()` / unknown transition targets were silent no-ops — now logged; a second `set_initial_state()` exits the prior state. `NavMeshPathfinder` docstring claimed a funnel algorithm it lacks — corrected. Recurring shapes: "guard/formula returns a wrong answer", "declared and wired to nothing" (`pursuit`/`evade`, `dt` never threaded), "hardcoded dt", uniform test setup (`TestCoordinateConversion` all-positive; **zero** tests for `AISystem`/`SteeringSystem`). Tests +29 (1770 → 1799). Phase D: BT/FSM authoring gaps (no reactive composites, no FSM transition table, no declarative blackboard nodes) → **#46** (sibling of #37/#40/#43); navmesh funnel/partial-portals/generation → parked (flow-field is #28's); steering-vs-physics → parked for the top-down `CharacterMover` slice. Left open: `WaitNode` keeps a named `getattr` dt fallback; the arrive fix is a velocity clamp (`_ARRIVE_STOP_DISTANCE = 1.0`), not a force-model redesign; `NavMeshPolygon.contains_point` has a fragile-but-unreachable `xinters`-before-assignment. |
 | `pyguara/persistence` | 2026-09-08 | One slice (`manager`, `storage`, `serializer`, `migration`, `types`; ~970 lines). The **migration half was sound** — the chain-integrity guards compose and the path loop provably terminates; overshoot/infinite-loop probes came back negative. The save/load half held the recurring shapes. **`save_data()` discarded `storage.save()`'s return** — `FileStorageBackend.save` returns `False` on `OSError`, so a full disk logged "Successfully saved" and returned `True`; now checked. **`FileStorageBackend` sanitised keys by deleting bad chars** — `"slot 1"`/`"slot/1"`/`"slot.1"` all collapsed onto `slot1` and silently overwrote each other (the resources F2 stem-collision shape); non-round-tripping keys now raise `ValueError`. **Data + meta were two independent `os.replace` calls** while the load path claimed "atomic save ensures both or neither" — a crash between them made an intact save unreadable (stale checksum → `None`). User chose the systemic fix: metadata is framed into **one blob** (`{header json}\n<payload>`), `StorageBackend` drops its `metadata` param (plain key→blob store), `FileStorageBackend` writes one `{key}.save` file + dir fsync + temp-sweep. **`compress=` was a documented no-op** → gzip, recorded in the header. **`SerializationFormat.MSGPACK` was a public enum member with no impl** though `msgpack` is a declared dep → implemented via the existing `prepare_for_json`/`game_object_hook` path, exposed through a new `fmt=` arg. `SaveMetadata` was hand-copied field by field and never read back on load → now carries `format`/`compressed`, used via `asdict`, engine version from `importlib.metadata` (was `"1.0.0"`), UTC timestamp. Migration gained `from_version >= 1` / `current_version >= 1` guards; `MigrationRegistry` is `eq=False`. Recurring shapes: "declared and wired to nothing" (`compress`, `MSGPACK`, `SaveMetadata`'s metadata half), "guard that returns a wrong answer" (swallowed `save()` failure, key mangling), "identity vs value" (`MigrationRegistry`), uniform test setup (every storage test used an already-safe key; every migration test used versions from 1). BREAKING: on-disk save format changed (`.dat`+`.meta` → `.save`); pre-alpha, no migration. Tests +35 (1735 → 1770). Phase D capability gaps: no backup/retention, no save-menu API (`list_saves`, cheap metadata read, `delete`/`exists` facade), CWD-relative save dir — grouped into #43 ("persistence production layer", sibling of #37); envelope `format_version` parked; run/meta split is #28's. Left open: `BINARY`/pickle load unauthenticated (trusted-input-only); mypy `python_version` 3.10 vs `requires-python` 3.12 forces a `# noqa: UP017` (possible CC). |
 | `pyguara/resources` | 2026-09-08 | One slice (`manager`, `meta`, `loader`, `types`, `data`, `data_loader`; hot reload lives downstream in `pyguara/dev`). No headline crash — better shape than recent subsystems — but the recurring shapes held. **Reference counting was internally inconsistent and wired to nothing**: `load()` auto-incremented on every call incl. cache hits, `release()` auto-unloaded at 0, so `unload_unused()` could never evict anything in use and a released resource was already gone — dead. No engine caller of acquire/release/unload/unload_unused; `AudioManager` `load()`s per play → count climbs forever. `Resource._ref_count` was a *third* dead counter. Reworked (user: "fix the model + add reload()"): `load()` is a pure cache-get → unpinned (0); `acquire()`/`release()` pin; `unload_unused()` now sweeps. `index_directory()` **silently resolved a stem collision to the last file walked** — now the ambiguous bare stem is dropped with a warning, full-name keys always win. `MetaLoader` **cached parsed meta by path with no invalidation** (stale after a disk change — wrong under hot reload) and the path-only key **swallowed the `expected_type` mismatch warning** after the first call — now mtime-pinned + re-read + `invalidate()`, check runs every call. `DataResource` docstring claimed "hot-reloaded by the ResourceManager" with **no reload API** — added `ResourceManager.reload()` (re-run loader, re-read `.meta`, swap in place, keep count). The **`.meta` import pipeline was ~70% scaffolding** (`AudioMeta`/`SpritesheetMeta` had no consumer, GL loader hardcoded `LINEAR`) — wired end to end (user: "wire it up in this slice"): `Resource.import_meta` carries the resolved sidecar; `GLTextureLoader` honours `filter` (default flips to `NEAREST`, matching the pygame path); audio backend applies `AudioMeta.volume_db` as a per-asset channel gain; `SpriteSheet` gained `margin`/`spacing` (previously meaningless) + `slice_from_meta`. Recurring shapes: "declared and wired to nothing" (the whole ref-count half; `AudioMeta`; `_ref_count`) and uniform test setup (`test_resources.py` asserted on `_reference_counts`/`_cache`/`_path_index` privates and hand-poked an impossible state into `test_unload_unused`; every `test_meta.py` test used a fresh `MetaLoader()`). Tests +21. Left open: `AudioMeta.loop_*`/`normalize`/`load_mode`, `TextureMeta.mipmaps`/`wrap_*` still unconsumed (need streaming/DSP/GL-state — authoring-layer gap, sibling of #37); audio should `acquire()` its clips under the new model (small `pyguara/audio` follow-up, no behaviour change today); no lock on the cache dicts (no concurrent caller, parked CC). |

--- a/docs/graphics/rendering.md
+++ b/docs/graphics/rendering.md
@@ -138,10 +138,15 @@ Game code using these features runs unchanged on Pygame - stubs accept the API c
 The UI system (`pyguara.ui`) is immediate-mode friendly but retains state via an Object-Oriented widget tree.
 
 ## Architecture
-- **UIManager**: Routes input events (`OnMouseEvent`) to widgets.
+- **UIManager**: Routes input events (`OnMouseEvent`) to widgets, and runs a
+  layout pass over every root before rendering -- applying `LayoutConstraints`
+  and container stacking -- re-run on window resize or `invalidate_layout()`.
 - **UIElement**: Base class for all widgets (`Button`, `Panel`, `Label`).
-- **Layouts**: `BoxContainer` handles automatic positioning (Vertical/Horizontal).
-- **Theme**: A centralized `UITheme` controls colors and spacing.
+- **Layouts**: `LayoutConstraints` position/size an element against its parent
+  (anchor, margin, percentage); `BoxContainer` stacks children
+  vertically/horizontally with alignment.
+- **Theme**: a global `UITheme` (`get_theme()`/`set_theme()`) controls colors
+  and spacing; elements read it live, so a swap re-skins existing widgets.
 
 ## Integration
 The UI is rendered via the `UIRenderer` protocol, allowing it to sit on top of the main game render pass.

--- a/docs/guides/ONBOARDING.md
+++ b/docs/guides/ONBOARDING.md
@@ -194,6 +194,7 @@ Before diving into individual systems, it's crucial to understand the three core
     5.  Add the element to the `UIManager`.
 
     ```python
+    from pyguara.common.types import Vector2
     from pyguara.ui.components import Button
     from pyguara.ui.constraints import create_centered_constraints
 

--- a/docs/guides/zero_to_hero.md
+++ b/docs/guides/zero_to_hero.md
@@ -327,33 +327,37 @@ ground.add_component(Collider(shape_type=ShapeType.BOX, dimensions=[800, 40]))
 Creating buttons, health bars, and overlay dialogs requires a layout-agnostic framework to handle resolution adjustments automatically. PyGuara provides a constraint-based UI layout system.
 
 ### 1. Building responsive buttons and panels
-You instantiate UI widgets, attach declarative constraints, and add them to the `UIManager`:
+You instantiate UI widgets, attach declarative `LayoutConstraints`, and add
+the roots to the `UIManager`. The manager runs a layout pass over every root
+before it draws (and again after a window resize), so a constrained element's
+`position`/`size` are placeholders -- the constraints decide the final rect.
 
 ```python
+from pyguara.common.types import Vector2
 from pyguara.ui.manager import UIManager
 from pyguara.ui.components import Panel, Button
-from pyguara.ui.constraints import UIAnchor, LayoutConstraints
+from pyguara.ui.constraints import LayoutConstraints
+from pyguara.ui.types import UIAnchor
 
 # 1. Grab UIManager from DI Container
 ui_manager = self.container.get(UIManager)
 
-# 2. Setup container panel centered on screen
-panel = Panel()
+# 2. A panel covering the centre 50% x 60% of the screen.
+#    position/size are placeholders; the constraint wins.
+panel = Panel(Vector2(0, 0), Vector2(10, 10))
 panel.constraints = LayoutConstraints(
-    anchor_left=UIAnchor.CENTER,
-    anchor_top=UIAnchor.CENTER,
+    anchor=UIAnchor.CENTER,
     width_percent=0.5,
-    height_percent=0.6
+    height_percent=0.6,
 )
 ui_manager.add_element(panel)
 
-# 3. Create active action button inside the panel
-button = Button(text="Start Game")
+# 3. A button centred inside the panel's content rect.
+button = Button("Start Game", Vector2(0, 0))
 button.constraints = LayoutConstraints(
-    anchor_left=UIAnchor.CENTER,
-    anchor_top=UIAnchor.CENTER,
+    anchor=UIAnchor.CENTER,
     width_percent=0.3,
-    height_percent=0.1
+    height_percent=0.1,
 )
 
 def on_click(btn: Button):
@@ -363,6 +367,10 @@ def on_click(btn: Button):
 button.on_click = on_click
 panel.add_child(button)
 ```
+
+> If you mutate something a layout depends on after the first frame -- a
+> label's text, an element's `visible` flag -- call
+> `ui_manager.invalidate_layout()` so the next render re-runs the pass.
 
 ---
 

--- a/games/guara_falcao/scenes.py
+++ b/games/guara_falcao/scenes.py
@@ -91,7 +91,6 @@ class TitleScene(Scene):
         btn_quit.on_click = self._on_quit_click
         container.add_child(btn_quit)
 
-        container.layout(self.container.get(UIRenderer))  # type: ignore[type-abstract]
         ui_manager.add_element(container)
 
     def _on_start_click(self, el) -> None:

--- a/games/protocolo_bandeira/scenes.py
+++ b/games/protocolo_bandeira/scenes.py
@@ -80,7 +80,6 @@ class MenuScene(Scene):
         btn_quit.on_click = self._on_quit_click
         container.add_child(btn_quit)
 
-        container.layout(self.container.get(UIRenderer))  # type: ignore[type-abstract]
         ui_manager.add_element(container)
 
     def _on_start_click(self, el) -> None:
@@ -568,7 +567,6 @@ class GameOverScene(Scene):
         btn_menu.on_click = self._on_menu_click
         container.add_child(btn_menu)
 
-        container.layout(self.container.get(UIRenderer))  # type: ignore[type-abstract]
         ui_manager.add_element(container)
 
     def _on_retry_click(self, el) -> None:

--- a/games/true_coral/scenes.py
+++ b/games/true_coral/scenes.py
@@ -74,7 +74,6 @@ class MenuScene(Scene):
         btn_quit.on_click = self._on_quit_click
         container.add_child(btn_quit)
 
-        container.layout(self.container.get(UIRenderer))  # type: ignore[type-abstract]
         ui_manager.add_element(container)
 
     def _on_start_click(self, el) -> None:

--- a/games/ui_scene_graph/scenes.py
+++ b/games/ui_scene_graph/scenes.py
@@ -90,7 +90,6 @@ class MenuScene(Scene):
         container.add_child(btn_quit)
 
         # Apply layout
-        container.layout(self.container.get(UIRenderer))  # type: ignore[type-abstract]
 
         # Add to manager
         ui_manager.add_element(container)

--- a/pyguara/application/application.py
+++ b/pyguara/application/application.py
@@ -77,6 +77,7 @@ class Application:
         self._scene_manager.set_screen_size(self._window.width, self._window.height)
         self._config_manager = container.get(ConfigManager)
         self._ui_manager = container.get(UIManager)
+        self._ui_manager.set_screen_size(self._window.width, self._window.height)
         self._coroutine_manager = container.get(CoroutineManager)
         self._audio_system = container.get(IAudioSystem)  # type: ignore[type-abstract]
 

--- a/pyguara/ui/base.py
+++ b/pyguara/ui/base.py
@@ -7,10 +7,11 @@ from typing import TYPE_CHECKING
 from pyguara.common.types import Rect, Vector2
 from pyguara.graphics.protocols import UIRenderer
 from pyguara.ui.theme import get_theme
-from pyguara.ui.types import UIAnchor, UIElementState, UIEventType
+from pyguara.ui.types import UIElementState, UIEventType
 
 if TYPE_CHECKING:
     from pyguara.ui.constraints import LayoutConstraints, Padding
+    from pyguara.ui.theme import UITheme
 
 
 class UIElement(ABC):
@@ -20,13 +21,11 @@ class UIElement(ABC):
         self,
         position: Vector2,
         size: Vector2,
-        anchor: UIAnchor = UIAnchor.TOP_LEFT,
         visible: bool = True,
     ) -> None:
         """Initialize the UI element."""
         # Use Engine Types, not Pygame Types
         self.rect = Rect(int(position.x), int(position.y), int(size.x), int(size.y))
-        self.anchor = anchor
         self.visible = visible
         self.enabled = True
 
@@ -38,11 +37,17 @@ class UIElement(ABC):
         self.constraints: LayoutConstraints | None = None
         self.padding: Padding | None = None
 
-        # Theme Integration
-        self.theme = get_theme()
-
         # Callbacks
         self.on_click: Callable[[UIElement], None] | None = None
+
+    @property
+    def theme(self) -> "UITheme":
+        """The active global theme.
+
+        Looked up live on every access rather than captured at construction,
+        so `set_theme()` re-skins elements that already exist.
+        """
+        return get_theme()
 
     @abstractmethod
     def render(self, renderer: UIRenderer) -> None:
@@ -135,20 +140,34 @@ class UIElement(ABC):
         child.parent = self
         self.children.append(child)
 
-    def apply_layout(self) -> None:
-        """Apply layout constraints to this element and its children.
+    def layout(self, available_rect: Rect, renderer: UIRenderer) -> None:
+        """Resolve this element's rect, then its children's, for one frame.
 
-        Applies constraints relative to parent if present.
-        Then recursively applies layout to children.
+        `UIManager` runs this over every root before rendering, and again
+        after a window resize or an explicit `UIManager.invalidate_layout()`.
+        `available_rect` is the space this element may occupy: the screen for
+        a root element, the parent's content rect for a child.
+
+        The default implementation measures the element, applies its
+        `constraints` against `available_rect` if it has any, then lays each
+        visible child out inside this element's content rect (so `padding`
+        finally takes effect). Containers that position their own children --
+        see `BoxContainer` -- override this.
+
+        Args:
+            available_rect: The rectangle this element may lay itself out in.
+            renderer: Passed to `measure()` so text-sized elements report a
+                real size before constraint math reads it.
         """
-        # Apply own constraints if present and has parent
-        if self.constraints and self.parent:
-            self.rect = self.constraints.apply(self.rect, self.parent.rect)
+        self.measure(renderer)
 
-        # Apply layout to children
+        if self.constraints:
+            self.rect = self.constraints.apply(self.rect, available_rect)
+
+        content = self.get_content_rect()
         for child in self.children:
             if child.visible:
-                child.apply_layout()
+                child.layout(content, renderer)
 
     def get_content_rect(self) -> Rect:
         """Get the rectangle for content area (rect minus padding).

--- a/pyguara/ui/components/canvas.py
+++ b/pyguara/ui/components/canvas.py
@@ -14,14 +14,18 @@ class Canvas(Widget):
     def __init__(
         self, position: Vector2, size: Vector2, bg_color: Color | None = None
     ) -> None:
-        """Initialize the canvas."""
+        """Initialize the canvas.
+
+        `bg_color` defaults to the active theme's background, resolved at
+        render time so a later `set_theme()` is honoured.
+        """
         super().__init__(position, size)
-        self.bg_color = bg_color or self.theme.colors.background
+        self.bg_color = bg_color
 
     def render(self, renderer: UIRenderer) -> None:
         """Render the background and children."""
         # Draw background / Clear
-        renderer.draw_rect(self.rect, self.bg_color)
+        renderer.draw_rect(self.rect, self.bg_color or self.theme.colors.background)
 
         # The 'custom drawing' is usually done by attaching children
         # or overriding render() in a subclass of Canvas.

--- a/pyguara/ui/components/navbar.py
+++ b/pyguara/ui/components/navbar.py
@@ -22,10 +22,10 @@ class NavBar(BoxContainer):
             alignment=LayoutAlignment.START,
             spacing=10,
         )
-        # Add background panel manually since BoxContainer doesn't render itself
-        self.background = Panel(
-            Vector2(0, 0), Vector2(width, height), color=self.theme.colors.background
-        )
+        # Add background panel manually since BoxContainer doesn't render
+        # itself. No explicit colour, so the Panel resolves the active theme's
+        # background live at render time.
+        self.background = Panel(Vector2(0, 0), Vector2(width, height))
 
     def render(self, renderer: UIRenderer) -> None:
         """Render the background and then children."""

--- a/pyguara/ui/components/progress_bar.py
+++ b/pyguara/ui/components/progress_bar.py
@@ -1,6 +1,6 @@
 """Progress indicator."""
 
-from pyguara.common.types import Rect, Vector2
+from pyguara.common.types import Color, Rect, Vector2
 from pyguara.graphics.protocols import UIRenderer
 from pyguara.ui.components.widget import Widget
 
@@ -9,13 +9,22 @@ class ProgressBar(Widget):
     """Visualizes progress 0.0 to 1.0."""
 
     def __init__(
-        self, position: Vector2, size: Vector2 = Vector2(200, 20), value: float = 0.5
+        self,
+        position: Vector2,
+        size: Vector2 = Vector2(200, 20),
+        value: float = 0.5,
+        fill_color: Color | None = None,
+        bg_color: Color | None = None,
     ) -> None:
-        """Initialize the progress bar."""
+        """Initialize the progress bar.
+
+        `fill_color`/`bg_color` default to the active theme, resolved at
+        render time so a later `set_theme()` is honoured.
+        """
         super().__init__(position, size)
         self.value = max(0.0, min(1.0, value))
-        self.fill_color = self.theme.colors.secondary
-        self.bg_color = self.theme.colors.background
+        self.fill_color = fill_color
+        self.bg_color = bg_color
 
     def set_value(self, value: float) -> None:
         """Update the progress value (clamped 0.0-1.0)."""
@@ -24,7 +33,7 @@ class ProgressBar(Widget):
     def render(self, renderer: UIRenderer) -> None:
         """Render the progress bar."""
         # Background
-        renderer.draw_rect(self.rect, self.bg_color)
+        renderer.draw_rect(self.rect, self.bg_color or self.theme.colors.background)
 
         # Border
         renderer.draw_rect(self.rect, self.theme.colors.border, width=1)
@@ -33,4 +42,6 @@ class ProgressBar(Widget):
         if self.value > 0:
             fill_width = int(self.rect.width * self.value)
             fill_rect = Rect(self.rect.x, self.rect.y, fill_width, self.rect.height)
-            renderer.draw_rect(fill_rect, self.fill_color)
+            renderer.draw_rect(
+                fill_rect, self.fill_color or self.theme.colors.secondary
+            )

--- a/pyguara/ui/components/slider.py
+++ b/pyguara/ui/components/slider.py
@@ -17,7 +17,19 @@ class Slider(Widget):
         max_val: float = 1.0,
         step: float = 0.0,
     ) -> None:
-        """Initialize the slider."""
+        """Initialize the slider.
+
+        Raises:
+            ValueError: If `max_val` is not greater than `min_val`, or
+                `width` is not positive -- both leave the slider with no
+                usable range and would divide by zero on interaction.
+        """
+        if max_val <= min_val:
+            raise ValueError(
+                f"Slider max_val ({max_val}) must be greater than min_val ({min_val})"
+            )
+        if width <= 0:
+            raise ValueError(f"Slider width must be positive, got {width}")
         super().__init__(position, Vector2(width, 20))
         self.min_val = min_val
         self.max_val = max_val

--- a/pyguara/ui/components/text.py
+++ b/pyguara/ui/components/text.py
@@ -3,7 +3,6 @@
 from pyguara.common.types import Color, Vector2
 from pyguara.graphics.protocols import UIRenderer
 from pyguara.ui.components.widget import Widget
-from pyguara.ui.types import UIAnchor
 
 
 class Label(Widget):
@@ -15,10 +14,9 @@ class Label(Widget):
         position: Vector2 = Vector2(0, 0),
         font_size: int = 16,
         color: Color | None = None,
-        anchor: UIAnchor = UIAnchor.TOP_LEFT,
     ) -> None:
         """Initialize the label."""
-        super().__init__(position, Vector2(0, 0), anchor=anchor)
+        super().__init__(position, Vector2(0, 0))
         self.text = text
         self.font_size = font_size
         self._custom_color = color

--- a/pyguara/ui/layout.py
+++ b/pyguara/ui/layout.py
@@ -1,6 +1,6 @@
 """Layout containers."""
 
-from pyguara.common.types import Vector2
+from pyguara.common.types import Rect, Vector2
 from pyguara.graphics.protocols import UIRenderer
 from pyguara.ui.base import UIElement
 from pyguara.ui.types import LayoutAlignment, LayoutDirection
@@ -28,69 +28,82 @@ class BoxContainer(UIElement):
         # Containers usually don't render themselves, just children
         # But we could draw a debug background here if needed
         for child in self.children:
-            child.render(renderer)
+            if child.visible:
+                child.render(renderer)
 
-    def layout(self, renderer: UIRenderer) -> None:
-        """Recalculate positions based on alignment and direction.
+    def layout(self, available_rect: Rect, renderer: UIRenderer) -> None:
+        """Recalculate child positions based on alignment and direction.
+
+        Overrides `UIElement.layout`: the container first resolves its own
+        rect (its `constraints` against `available_rect`, if any), then
+        measures every visible child and stacks them along `direction`,
+        distributing free space per `alignment` on the main axis and either
+        centring or stretching them on the cross axis. Nested containers are
+        laid out recursively afterwards.
 
         Args:
-            renderer: Passed to each visible child's `measure()` before
-                reading its size, so renderer-dependent sizing (e.g. text)
-                is current for this pass's stacking math.
+            available_rect: The rectangle this container may occupy.
+            renderer: Passed to each visible child's `measure()` before its
+                size is read, so text-sized children stack correctly.
         """
-        if not self.children:
+        self.measure(renderer)
+        if self.constraints:
+            self.rect = self.constraints.apply(self.rect, available_rect)
+
+        visible_children = [c for c in self.children if c.visible]
+        if not visible_children:
             return
 
-        # 1. Calculate total used space
-        total_size = 0
-        visible_children = [c for c in self.children if c.visible]
+        is_vertical = self.direction == LayoutDirection.VERTICAL
 
+        # 1. Measure children, then sum the space they need on the main axis.
         for child in visible_children:
             child.measure(renderer)
 
-        for child in visible_children:
-            if self.direction == LayoutDirection.VERTICAL:
-                total_size += child.rect.height
-            else:
-                total_size += child.rect.width
-
+        total_size = sum(
+            child.rect.height if is_vertical else child.rect.width
+            for child in visible_children
+        )
         total_size += self.spacing * (len(visible_children) - 1)
 
-        # 2. Determine Start Offset based on Alignment
+        # 2. Distribute free space on the main axis per alignment.
+        container_main = self.rect.height if is_vertical else self.rect.width
         start_offset = 0
         if self.alignment == LayoutAlignment.CENTER:
-            container_size = (
-                self.rect.height
-                if self.direction == LayoutDirection.VERTICAL
-                else self.rect.width
-            )
-            start_offset = (container_size - total_size) // 2
+            start_offset = (container_main - total_size) // 2
         elif self.alignment == LayoutAlignment.END:
-            container_size = (
-                self.rect.height
-                if self.direction == LayoutDirection.VERTICAL
-                else self.rect.width
-            )
-            start_offset = container_size - total_size
+            start_offset = container_main - total_size
 
-        # 3. Position Children
-        current_x = self.rect.x
-        current_y = self.rect.y
-
-        if self.direction == LayoutDirection.VERTICAL:
-            current_y += start_offset
-        else:
-            current_x += start_offset
+        # 3. Position children.
+        current_x = self.rect.x + (0 if is_vertical else start_offset)
+        current_y = self.rect.y + (start_offset if is_vertical else 0)
+        stretch = self.alignment == LayoutAlignment.STRETCH
 
         for child in visible_children:
-            child.rect.x = current_x
-            child.rect.y = current_y
-
-            if self.direction == LayoutDirection.VERTICAL:
+            if is_vertical:
+                child.rect.y = current_y
                 current_y += child.rect.height + self.spacing
-                # Handle cross-axis alignment (e.g. center horizontally in a vertical box)
-                child.rect.x = self.rect.x + (self.rect.width - child.rect.width) // 2
+                if stretch:
+                    child.rect.x = self.rect.x
+                    child.rect.width = self.rect.width
+                else:
+                    child.rect.x = (
+                        self.rect.x + (self.rect.width - child.rect.width) // 2
+                    )
             else:
+                child.rect.x = current_x
                 current_x += child.rect.width + self.spacing
-                # Handle cross-axis alignment
-                child.rect.y = self.rect.y + (self.rect.height - child.rect.height) // 2
+                if stretch:
+                    child.rect.y = self.rect.y
+                    child.rect.height = self.rect.height
+                else:
+                    child.rect.y = (
+                        self.rect.y + (self.rect.height - child.rect.height) // 2
+                    )
+
+        # 4. Recurse into children that have their own subtree, so a nested
+        #    container stacks its own children against the slot it was just
+        #    given.
+        for child in visible_children:
+            if child.children:
+                child.layout(child.rect, renderer)

--- a/pyguara/ui/manager.py
+++ b/pyguara/ui/manager.py
@@ -1,11 +1,15 @@
 """UI Manager and event integration."""
 
-from pyguara.common.types import Vector2
+from pyguara.common.types import Rect, Vector2
 from pyguara.events.dispatcher import EventDispatcher
+from pyguara.events.window import WindowResizeEvent
 from pyguara.graphics.protocols import UIRenderer
 from pyguara.input.events import OnMouseEvent, OnRawKeyEvent
+from pyguara.log import get_logger
 from pyguara.ui.base import UIElement
 from pyguara.ui.types import UIEventType
+
+logger = get_logger(__name__)
 
 
 class UIManager:
@@ -17,13 +21,44 @@ class UIManager:
         self._dispatcher = dispatcher
         self._focused_element: UIElement | None = None
 
+        # Space the roots lay themselves out in. Seeded by Application via
+        # set_screen_size(); a resize refreshes it. Layout is skipped while
+        # this is degenerate (nothing has told us the screen size yet).
+        self._screen_rect = Rect(0, 0, 0, 0)
+        self._layout_dirty = True
+        self._warned_no_screen = False
+
         # Subscribe to Engine Input Events
         self._dispatcher.subscribe(OnMouseEvent, self._on_mouse_event)
         self._dispatcher.subscribe(OnRawKeyEvent, self._on_key_event)
+        self._dispatcher.subscribe(WindowResizeEvent, self._on_resize_event)
 
     def add_element(self, element: UIElement) -> None:
         """Add a root-level UI element."""
         self._root_elements.append(element)
+        self._layout_dirty = True
+
+    def set_screen_size(self, width: int, height: int) -> None:
+        """Tell the UI the size of the surface its roots lay out against.
+
+        Called once at startup and again whenever the window is resized, so
+        percentage- and anchor-based constraints resolve against the real
+        drawable area.
+        """
+        new_rect = Rect(0, 0, width, height)
+        if new_rect == self._screen_rect:
+            return
+        self._screen_rect = new_rect
+        self._layout_dirty = True
+
+    def invalidate_layout(self) -> None:
+        """Force a layout pass on the next render.
+
+        Call after mutating something a layout depends on but the manager
+        cannot see -- a label's text, an element's `visible` flag, a
+        container's child list.
+        """
+        self._layout_dirty = True
 
     def update(self, dt: float) -> None:
         """Update all managed UI elements."""
@@ -32,9 +67,40 @@ class UIManager:
 
     def render(self, renderer: UIRenderer) -> None:
         """Draw the entire UI stack using the abstract renderer."""
+        if self._layout_dirty:
+            self._run_layout(renderer)
+            self._layout_dirty = False
+
         for element in self._root_elements:
             if element.visible:
                 element.render(renderer)
+
+    def _run_layout(self, renderer: UIRenderer) -> None:
+        """Lay every root out against the current screen rect."""
+        if self._screen_rect.width <= 0 or self._screen_rect.height <= 0:
+            has_constraints = any(
+                self._subtree_has_constraints(el) for el in self._root_elements
+            )
+            if has_constraints and not self._warned_no_screen:
+                logger.warning(
+                    "UI layout skipped: screen size unknown. Call "
+                    "UIManager.set_screen_size() before adding constrained "
+                    "elements."
+                )
+                self._warned_no_screen = True
+            return
+
+        for element in self._root_elements:
+            element.layout(self._screen_rect, renderer)
+
+    @staticmethod
+    def _subtree_has_constraints(element: UIElement) -> bool:
+        """Report whether `element` or any descendant carries constraints."""
+        if element.constraints is not None:
+            return True
+        return any(
+            UIManager._subtree_has_constraints(child) for child in element.children
+        )
 
     def set_focus(self, element: UIElement | None) -> None:
         """Set the focused element.
@@ -98,3 +164,7 @@ class UIManager:
 
         # Route to focused element
         self._focused_element.handle_event(event_type, Vector2(0, 0), event.key_code)
+
+    def _on_resize_event(self, event: WindowResizeEvent) -> None:
+        """Re-lay the UI out against the new window size."""
+        self.set_screen_size(event.width, event.height)

--- a/pyguara/ui/theme_presets.py
+++ b/pyguara/ui/theme_presets.py
@@ -16,8 +16,6 @@ Example:
     >>> set_theme(my_theme)
 """
 
-from dataclasses import dataclass
-
 from pyguara.common.types import Color
 from pyguara.ui.theme import UITheme
 from pyguara.ui.types import (
@@ -199,21 +197,37 @@ def _create_retro_theme() -> UITheme:
     )
 
 
-@dataclass(frozen=True)
 class ThemeConstants:
-    """Container for pre-built theme presets.
+    """Accessor for the pre-built theme presets.
 
-    All themes are immutable. To customize, clone and modify:
-        >>> my_theme = Themes.DARK.clone()
+    Each attribute access returns a **fresh copy** of the preset, so callers
+    cannot corrupt the canonical definition for the rest of the process:
+
+        >>> my_theme = Themes.DARK          # already a private copy
         >>> my_theme.colors.primary = Color(255, 0, 0)
+        >>> Themes.DARK.colors.primary     # unaffected
+        Color(r=70, g=130, b=180, a=255)
+
+    Pass one straight to ``set_theme(Themes.DARK)`` when you want it verbatim.
     """
 
-    DARK = _create_dark_theme()
-    LIGHT = _create_light_theme()
-    HIGH_CONTRAST = _create_high_contrast_theme()
-    CYBERPUNK = _create_cyberpunk_theme()
-    FOREST = _create_forest_theme()
-    RETRO = _create_retro_theme()
+    _FACTORIES = {
+        "DARK": _create_dark_theme,
+        "LIGHT": _create_light_theme,
+        "HIGH_CONTRAST": _create_high_contrast_theme,
+        "CYBERPUNK": _create_cyberpunk_theme,
+        "FOREST": _create_forest_theme,
+        "RETRO": _create_retro_theme,
+    }
+
+    def __getattr__(self, name: str) -> UITheme:
+        """Build and return a fresh instance of the named preset."""
+        try:
+            return self._FACTORIES[name]()
+        except KeyError:
+            raise AttributeError(
+                f"{type(self).__name__!r} has no theme preset {name!r}"
+            ) from None
 
 
 # Singleton instance

--- a/tests/test_ui_layout.py
+++ b/tests/test_ui_layout.py
@@ -1,11 +1,13 @@
 from unittest.mock import MagicMock
 
-from pyguara.common.types import Vector2
+from pyguara.common.types import Rect, Vector2
 from pyguara.graphics.protocols import UIRenderer
 from pyguara.ui.components.text import Label
 from pyguara.ui.components.widget import Widget
 from pyguara.ui.layout import BoxContainer
 from pyguara.ui.types import LayoutAlignment, LayoutDirection
+
+SCREEN = Rect(0, 0, 800, 600)
 
 
 class MockWidget(Widget):
@@ -13,11 +15,12 @@ class MockWidget(Widget):
         pass
 
 
+def _renderer():
+    return MagicMock(spec=UIRenderer)
+
+
 def test_box_layout_vertical():
-    """
-    Unit Test: Vertical Box Layout
-    Verifies children are stacked vertically.
-    """
+    """Vertical Box Layout stacks children top to bottom with spacing."""
     container = BoxContainer(
         Vector2(0, 0), Vector2(100, 200), direction=LayoutDirection.VERTICAL, spacing=10
     )
@@ -28,7 +31,7 @@ def test_box_layout_vertical():
     container.add_child(w1)
     container.add_child(w2)
 
-    container.layout(MagicMock(spec=UIRenderer))
+    container.layout(SCREEN, _renderer())
 
     # W1 at top (0,0 relative to container)
     assert w1.rect.y == 0
@@ -38,11 +41,7 @@ def test_box_layout_vertical():
 
 
 def test_box_layout_horizontal_alignment_center():
-    """
-    Unit Test: Horizontal Layout with Center Alignment
-    Verifies children are centered within the container.
-    """
-    # Container Width 200
+    """Horizontal layout with CENTER alignment centres the child run."""
     container = BoxContainer(
         Vector2(0, 0),
         Vector2(200, 50),
@@ -51,27 +50,22 @@ def test_box_layout_horizontal_alignment_center():
         spacing=0,
     )
 
-    # Children total width = 50 + 50 = 100
     w1 = MockWidget(Vector2(0, 0), Vector2(50, 20))
     w2 = MockWidget(Vector2(0, 0), Vector2(50, 20))
 
     container.add_child(w1)
     container.add_child(w2)
 
-    container.layout(MagicMock(spec=UIRenderer))
+    container.layout(SCREEN, _renderer())
 
-    # Total Used = 100
-    # Remaining = 100
-    # Start Offset = 50
-
+    # Total used = 100, remaining = 100, start offset = 50
     assert w1.rect.x == 50
-    assert w2.rect.x == 100  # 50 + 50
+    assert w2.rect.x == 100
 
 
 def test_box_layout_measures_children_before_stacking():
-    """BoxContainer.layout() must measure() auto-sizing children (e.g. Label)
-    before reading their rect for stacking math, not their construction-time
-    placeholder size (regression for the render()-time-mutation bug)."""
+    """layout() must measure() auto-sizing children (e.g. Label) before it
+    reads their rect for stacking, not their construction-time placeholder."""
     container = BoxContainer(
         Vector2(0, 0), Vector2(200, 200), direction=LayoutDirection.VERTICAL, spacing=0
     )
@@ -81,17 +75,106 @@ def test_box_layout_measures_children_before_stacking():
     container.add_child(label1)
     container.add_child(label2)
 
-    # Both labels start at their construction-time placeholder size (0, 0) --
-    # nothing has ever rendered them yet.
     assert label1.rect.height == 0
     assert label2.rect.height == 0
 
-    renderer = MagicMock(spec=UIRenderer)
+    renderer = _renderer()
     renderer.get_text_size.side_effect = lambda text, size: (len(text) * 8, 20)
 
-    container.layout(renderer)
+    container.layout(SCREEN, renderer)
 
-    # Sibling stacking must reflect the real measured height (20), not the
-    # placeholder (0) -- label2 sits directly below label1's real height.
     assert label1.rect.height == 20
     assert label2.rect.y == 20
+
+
+def test_box_layout_skips_hidden_children_in_stacking_and_render():
+    """A hidden child takes no space in the stack and is not drawn."""
+    container = BoxContainer(
+        Vector2(0, 0), Vector2(100, 200), direction=LayoutDirection.VERTICAL, spacing=10
+    )
+    top = MockWidget(Vector2(0, 0), Vector2(50, 20))
+    hidden = MockWidget(Vector2(0, 0), Vector2(50, 20))
+    hidden.visible = False
+    bottom = MockWidget(Vector2(0, 0), Vector2(50, 20))
+    for c in (top, hidden, bottom):
+        container.add_child(c)
+
+    container.layout(SCREEN, _renderer())
+
+    # `bottom` sits directly under `top` (+spacing); the hidden widget is
+    # not counted.
+    assert bottom.rect.y == 30
+
+    drawn = []
+    for c in (top, hidden, bottom):
+        c.render = lambda r, c=c: drawn.append(c)
+    container.render(_renderer())
+    assert drawn == [top, bottom]
+
+
+def test_box_layout_stretch_fills_cross_axis():
+    """STRETCH alignment makes each child fill the container's cross axis."""
+    container = BoxContainer(
+        Vector2(10, 10),
+        Vector2(120, 300),
+        direction=LayoutDirection.VERTICAL,
+        alignment=LayoutAlignment.STRETCH,
+        spacing=0,
+    )
+    a = MockWidget(Vector2(0, 0), Vector2(30, 20))
+    b = MockWidget(Vector2(0, 0), Vector2(80, 20))
+    container.add_child(a)
+    container.add_child(b)
+
+    container.layout(SCREEN, _renderer())
+
+    for child in (a, b):
+        assert child.rect.x == 10
+        assert child.rect.width == 120
+
+
+def test_box_layout_applies_own_constraints_then_stacks():
+    """A container with constraints resolves its own rect against the
+    available rect before positioning children inside it."""
+    from pyguara.ui.constraints import create_centered_constraints
+
+    container = BoxContainer(
+        Vector2(0, 0), Vector2(100, 100), direction=LayoutDirection.VERTICAL, spacing=0
+    )
+    container.constraints = create_centered_constraints(
+        width_percent=0.5, height_percent=0.5
+    )
+    child = MockWidget(Vector2(0, 0), Vector2(20, 20))
+    container.add_child(child)
+
+    container.layout(SCREEN, _renderer())
+
+    # 50% of 800x600 -> 400x300, centred -> origin (200, 150).
+    assert (container.rect.x, container.rect.y) == (200, 150)
+    assert (container.rect.width, container.rect.height) == (400, 300)
+    # Child stacked at the container's (post-constraint) top.
+    assert child.rect.y == 150
+
+
+def test_nested_box_containers_resolve():
+    """A BoxContainer nested in another gets its own children stacked."""
+    outer = BoxContainer(
+        Vector2(0, 0), Vector2(200, 400), direction=LayoutDirection.VERTICAL, spacing=0
+    )
+    inner = BoxContainer(
+        Vector2(0, 0), Vector2(200, 100), direction=LayoutDirection.VERTICAL, spacing=5
+    )
+    leaf1 = MockWidget(Vector2(0, 0), Vector2(20, 10))
+    leaf2 = MockWidget(Vector2(0, 0), Vector2(20, 10))
+    inner.add_child(leaf1)
+    inner.add_child(leaf2)
+    outer.add_child(MockWidget(Vector2(0, 0), Vector2(20, 30)))
+    outer.add_child(inner)
+
+    outer.layout(SCREEN, _renderer())
+
+    # inner is the 2nd child of outer: y = 30 (first child height) + 0 spacing
+    assert inner.rect.y == 30
+    # leaf1/leaf2 stacked inside inner, starting at inner's y
+    assert leaf1.rect.y == 30
+    assert leaf2.rect.y == 45  # 30 + 10 + 5 spacing

--- a/tests/test_ui_manager_layout.py
+++ b/tests/test_ui_manager_layout.py
@@ -1,0 +1,144 @@
+"""UIManager drives the layout pass and honours a live theme swap.
+
+These are the integration checks the older UI suite lacked: every existing
+test exercised a widget, a constraint, or a container in isolation, so two
+defects -- constraints that were never applied at runtime, and a theme
+snapshotted per element at construction -- sat under a green suite.
+"""
+
+from unittest.mock import MagicMock
+
+from pyguara.common.types import Color, Vector2
+from pyguara.events.dispatcher import EventDispatcher
+from pyguara.events.window import WindowResizeEvent
+from pyguara.graphics.protocols import UIRenderer
+from pyguara.ui.base import UIElement
+from pyguara.ui.components.button import Button
+from pyguara.ui.constraints import create_centered_constraints, create_fill_constraints
+from pyguara.ui.manager import UIManager
+from pyguara.ui.theme import UITheme, set_theme
+from pyguara.ui.theme_presets import Themes
+
+
+class Box(UIElement):
+    def render(self, renderer: UIRenderer) -> None:
+        for child in self.children:
+            if child.visible:
+                child.render(renderer)
+
+
+def _manager(width: int = 800, height: int = 600) -> UIManager:
+    mgr = UIManager(EventDispatcher())
+    mgr.set_screen_size(width, height)
+    return mgr
+
+
+def test_manager_applies_root_constraints_on_render() -> None:
+    """A constrained root is positioned against the screen rect by the
+    manager's own layout pass -- no manual apply_layout()/layout() call."""
+    mgr = _manager()
+    root = Box(Vector2(0, 0), Vector2(10, 10))
+    root.constraints = create_fill_constraints(margin=20)
+    mgr.add_element(root)
+
+    mgr.render(MagicMock(spec=UIRenderer))
+
+    assert (root.rect.x, root.rect.y) == (20, 20)
+    assert (root.rect.width, root.rect.height) == (760, 560)
+
+
+def test_manager_applies_nested_constraints() -> None:
+    """Constraints on a child resolve against the parent's content rect."""
+    mgr = _manager()
+    parent = Box(Vector2(0, 0), Vector2(400, 400))
+    parent.constraints = create_fill_constraints()
+    child = Box(Vector2(0, 0), Vector2(10, 10))
+    child.constraints = create_centered_constraints(
+        width_percent=0.5, height_percent=0.5
+    )
+    parent.add_child(child)
+    mgr.add_element(parent)
+
+    mgr.render(MagicMock(spec=UIRenderer))
+
+    # parent fills 800x600; child is 50% centred -> 400x300 at (200, 150).
+    assert (child.rect.width, child.rect.height) == (400, 300)
+    assert (child.rect.x, child.rect.y) == (200, 150)
+
+
+def test_layout_pass_is_dirty_gated() -> None:
+    """Layout runs when something changed, not on every render."""
+    mgr = _manager()
+    root = Box(Vector2(0, 0), Vector2(10, 10))
+    root.constraints = create_fill_constraints()
+    mgr.add_element(root)
+
+    r = MagicMock(spec=UIRenderer)
+    mgr.render(r)  # dirty from add_element -> lays out
+    assert root.rect.width == 800
+
+    # Manually stomp the rect; a plain re-render must NOT re-run layout.
+    root.rect.width = 1
+    mgr.render(r)
+    assert root.rect.width == 1
+
+    # invalidate_layout() re-arms the pass.
+    mgr.invalidate_layout()
+    mgr.render(r)
+    assert root.rect.width == 800
+
+
+def test_resize_event_relayouts() -> None:
+    """A WindowResizeEvent updates the screen rect and re-lays out."""
+    dispatcher = EventDispatcher()
+    mgr = UIManager(dispatcher)
+    mgr.set_screen_size(800, 600)
+    root = Box(Vector2(0, 0), Vector2(10, 10))
+    root.constraints = create_fill_constraints()
+    mgr.add_element(root)
+    mgr.render(MagicMock(spec=UIRenderer))
+    assert root.rect.width == 800
+
+    dispatcher.dispatch(WindowResizeEvent(width=1024, height=768))
+    mgr.render(MagicMock(spec=UIRenderer))
+    assert (root.rect.width, root.rect.height) == (1024, 768)
+
+
+def test_layout_skipped_without_screen_size(caplog) -> None:
+    """With no screen size yet, a constrained tree is left alone and warns."""
+    mgr = UIManager(EventDispatcher())  # no set_screen_size()
+    root = Box(Vector2(5, 5), Vector2(10, 10))
+    root.constraints = create_fill_constraints()
+    mgr.add_element(root)
+
+    mgr.render(MagicMock(spec=UIRenderer))
+
+    assert (root.rect.x, root.rect.width) == (5, 10)  # untouched
+    assert any("screen size unknown" in r.message for r in caplog.records)
+
+
+def test_theme_swap_reskins_existing_element() -> None:
+    """set_theme() after a widget is built changes what it renders with."""
+    original = UITheme()
+    set_theme(original)
+    try:
+        btn = Button("OK", Vector2(0, 0))
+        assert btn.theme.colors.primary == original.colors.primary
+
+        set_theme(Themes.CYBERPUNK)
+        assert btn.theme.colors.primary == Color(255, 0, 255)
+
+        r = MagicMock(spec=UIRenderer)
+        r.get_text_size.return_value = (10, 10)
+        btn.render(r)
+        # First draw_rect is the background, in the new theme's primary.
+        first_fill = r.draw_rect.call_args_list[0]
+        assert first_fill.args[1] == Color(255, 0, 255)
+    finally:
+        set_theme(original)
+
+
+def test_theme_presets_are_copies() -> None:
+    """Mutating a preset does not corrupt it for the next reader."""
+    Themes.DARK.colors.primary = Color(1, 2, 3)
+    assert Themes.DARK.colors.primary != Color(1, 2, 3)


### PR DESCRIPTION
Subsystem audit — `pyguara/ui` (Tier 4). One slice, ~1,900 lines. Every
defect reproduced with a probe against the real code before fixing. Not
stacked on anything; cut from `main`.

## Phase A — code

Two "declared and wired to nothing" defects sat under 84 green tests because
every test exercised a unit in isolation from the runtime loop.

- **The constraint layout system never ran.** `UIElement.apply_layout()` had
  no caller anywhere in the repo; `UIManager.update()/render()` had no layout
  pass; a root element could not be constrained at all (`apply_layout`
  early-outs unless `self.parent` is set). Probe: a child with
  `create_fill_constraints(margin=20)` under an 800×600 parent stayed at
  `Rect(0,0,10,10)` across three manager frames. So `constraints.py`
  (314 lines), `element.padding` and every `create_*_constraints` helper were
  inert — yet documented as "the heart of the UI system's power" with
  non-runnable examples.
  → `apply_layout()` → `UIElement.layout(available_rect, renderer)`.
  `UIManager` holds a screen `Rect` (seeded by `Application` via a new
  `set_screen_size()`, refreshed by a `WindowResizeEvent` subscription) and
  runs `layout()` over every root before rendering, **dirty-gated**:
  `add_element` / `set_screen_size` / a new public `invalidate_layout()` arm
  the pass, a steady frame is free. Roots constrain against the screen rect,
  children against the parent's padding-aware content rect.
- **`BoxContainer.layout()`** folded into the same signature/pass: resolves
  its own constraints first, honours `LayoutAlignment.STRETCH` (declared,
  no branch → silently `START`), skips hidden children in `render()` (every
  other traversal already did), recurses into nested containers.
- **Theme was snapshotted per element at construction** (`self.theme =
  get_theme()` in `__init__`), so `set_theme()` re-skinned nothing already
  built (probe confirmed). → `UIElement.theme` is a live property;
  `ProgressBar`/`Canvas`/`NavBar` defer their cached `Color` to render time.
- **`ThemeConstants` `@dataclass(frozen=True)` decorated nothing** —
  `fields() == []`, "All themes are immutable" was false, presets were
  mutable process-wide singletons. → `__getattr__` hands back a fresh copy
  per access.
- **`Slider`** rejects `max_val <= min_val` / non-positive width at
  construction (both divided by zero on interaction).
- Removed the dead `UIElement.anchor` / `Label(anchor=)` parameter;
  `LayoutConstraints.anchor` is the real mechanism.

**BREAKING** (pre-alpha): `UIElement.layout()` / `BoxContainer.layout()`
signature changed; the four in-repo games that hand-called
`container.layout(renderer)` had the now-redundant call removed (the manager
does it).

## Phase B — tests

Broad but every test exercised a unit in isolation from the runtime loop.
`test_ui_constraints.py` (513 lines) only ever called `LayoutConstraints
.apply()` on hand-built `Rect`s; theme tests never built a `UIElement`. Added
`tests/test_ui_manager_layout.py` (manager-driven layout, dirty gate, resize
re-layout, live theme swap, preset copies); rebuilt `tests/test_ui_layout.py`
for the new signature plus STRETCH, hidden-child and nesting coverage.

## Phase C — docs

`zero_to_hero.md`'s UI section was non-runnable (`Panel()` / `Button(text=)`
with no position, `LayoutConstraints(anchor_left=/anchor_top=)` — no such
params) and described the constraint system, now actually wired, as inert.
`ONBOARDING.md` and `graphics/rendering.md` reconciled.

## Phase D — capability gaps → new issue

Theme carries `ShadowScheme`, `BorderScheme.radius`,
`ColorScheme.hover_overlay/press_overlay` that no widget consumes; no
keyboard/gamepad focus navigation; no scroll/clip container; only linear
`BoxContainer`; no real text-input path (`UIEventType.TEXT_INPUT` declared,
never dispatched); manual layout invalidation. Filed as #49 (sibling of #37/#40/#43/#46).

## Verification

Clean worktree at the tip: `1810 passed`, `ruff check .` clean, `mypy
pyguara` clean (226 files). `ff0e407` (the fix) passes on its own.
`guara_falcao`'s menu still renders correctly headless.

PR is final — nothing else coming on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5