### PR TITLE
refactor(prefabs): wire child hierarchies, guard extends cycles, fail loud on bad data

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -79,9 +79,82 @@ how the subject is *constructed*, not just what is asserted.
 
 ## Active Subsystem
 
-**None — `pyguara/ui` closed 2026-09-08 (branch `refactor/ui-audit`).**
-Next in the queue is Tier 4: `pyguara/prefabs` (prefab definition and
-instantiation). Open `REFACTOR_STATE.md` "How to resume" and take it.
+**None — `pyguara/prefabs` closed 2026-09-08 (branch `refactor/prefabs-audit`).**
+Next in the queue is Tier 4: `pyguara/editor` (in-engine editor, inspector
+tools). Open `REFACTOR_STATE.md` "How to resume" and take it.
+
+`pyguara/prefabs` in one slice, ~1,000 lines (`types`, `registry`, `loader`,
+`factory`). Headline: **a prefab with `children` crashed on any real scene.**
+`PrefabFactory._create_children` called `parent_entity.get_component_by_name(
+"Transform")` — a method that exists nowhere on `Entity` — so `factory.create()`
+raised `AttributeError` whenever a `prefab_resolver` was set, which
+`Scene.resolve_dependencies()` always does (`prefab_resolver=PrefabCache.load`).
+Past the crash, the parent-link step was `for _child in children: pass` with a
+"Optionally link children to parent here" comment — children were never
+attached despite `Transform` carrying a full `set_parent`/`children` API. There
+is **not one `.prefab` file in the repo** (tests build `PrefabData` by hand or
+via `tempfile`), so the whole file→loader→factory→children path had never run.
+Per the user's choice ("wire it properly, unify"): `_create_children` now
+instantiates each child as its own entity and parents its `Transform` via
+`set_parent(keep_world_transform=False)`, so the child's authored position is
+local to the parent and follows it; `PrefabChild.offset` applies in that local
+space. Dropped the dead loop and the `parent_position` bake it fed (that bake
+ignored parent rotation/scale). **BREAKING** (pre-alpha): `create()` loses
+`parent_position`, gains `source_path`.
+
+Other defects, all probe-reproduced: **`_resolve_inheritance` had no cycle
+guard** — `A extends B extends A` recursed to `RecursionError`; now tracks the
+`extends` chain and raises `ValueError` naming it (`b -> a -> b`), the shape the
+`common` Transform parent-cycle guard already uses. **`create()` swallowed
+component construction errors** in a blanket `except Exception` — a prefab with
+one bad field yielded a half-built entity, the component silently absent; per
+the user's choice ("fail loud") it now raises, and `_instantiate_dataclass`
+additionally rejects keys matching no field (a typo'd field name used to vanish
+silently). **`_convert_value` enum handling was `EnumType[value.upper()]`** —
+any non-SCREAMING_CASE member raised `KeyError` → swallowed → component dropped;
+now accepts a member name in any case or a raw value, and raises `ValueError`
+naming the members on a miss. **`PrefabInstance.prefab_path` was always the
+display `name`** (`create()` hard-coded `prefab_path=prefab.name`;
+`create_from_path` had the real path and discarded it) — the component's stated
+purpose ("tracking and hot-reload") was unmeetable; now threaded through
+`create_from_path` and child resolution, falling back to `name` only for
+in-memory prefabs. **`ComponentRegistry.clear()` wiped `_deserializers`**
+(losing the built-in `Transform` special-case) but not `_type_converters` —
+asymmetric, and since `Transform` is not a dataclass and has a custom
+`__init__`, a cleared registry could not round-trip it even after
+re-registering; `clear()` now re-seeds the built-ins. **`PrefabLoader` raised
+`AttributeError`** from `raw.get()` on a non-mapping top-level document (empty
+file → `None`, a JSON list) despite documenting `ValueError`; now validates.
+Removed **`PrefabReference`** — exported in `__all__`, constructed and consumed
+nowhere. Recurring shapes: "declared and wired to nothing" (`children`
+link-up, `PrefabReference`, `PrefabInstance.prefab_path`, `PrefabData.version`
+— see Phase D), "guard that returns/holds a wrong answer" (swallowed component
+errors, enum `.upper()`, `prefab_path`), and uniform test setup — every factory
+test hand-built `PrefabData` against a `Transform`+`Tag`-only registry;
+`_create_children`, `create_from_path`, inheritance cycles, `PrefabInstance`,
+and any file→loader→factory round trip had **zero** coverage, and
+`test_create_warns_on_unknown_component` asserted `... or entity is not None`
+(always true). Tests +17 (1799 → 1835, incl. parametrise expansion). New
+`docs/systems/prefabs.md` (the subsystem had no doc page at all). See the
+iteration log entry below.
+
+**Capability gaps (Phase D) → new issue** (sibling of #37/#40/#43/#46 and the
+UI Phase-D issue): no spawn tables / weighted prefab pools (a roguelike spawns
+waves/loot from weighted random selection; `create` is one-at-a-time with no
+selection primitive); `PrefabData.version` declared for migration and read by
+nothing (no prefab-schema migration, while `persistence` has a whole
+`MigrationRegistry`); no named variant library (`overrides` is per-call only);
+prefab children are linked Transform↔Transform only — the child entity has no
+parent-*entity* back-reference and no shared lifetime, so destroying an enemy
+leaks its prefab-attached child entities (needs an ECS-hierarchy decision,
+cross-cutting with `pyguara/ecs`); no asset-reference validation at load.
+Latent/parked: `ComponentRegistry` is a process-global mutable singleton
+(`get_component_registry()` + the `@register_component` decorator) — same shape
+as other engine singletons, parked as a CC.
+
+---
+
+### `pyguara/ui` — closed 2026-09-08 (branch `refactor/ui-audit`)
 
 `pyguara/ui` in one slice, ~1,900 lines (`base`, `layout`, `constraints`,
 `manager`, `theme`, `theme_presets`, `types`, `components/*`). Two headline
@@ -469,7 +542,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 ### Tier 4 — Tooling & authoring
 - [x] `pyguara/ui` — layout engine, widgets, theming *(done)*
-- [ ] `pyguara/prefabs` — prefab definition and instantiation
+- [x] `pyguara/prefabs` — prefab definition and instantiation *(done)*
 - [ ] `pyguara/editor` — in-engine editor, inspector tools
 - [ ] `pyguara/scripting` — coroutines, script hosting
 - [ ] `pyguara/replay` — deterministic replay
@@ -483,6 +556,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/prefabs` | 2026-09-08 | One slice (`types`, `registry`, `loader`, `factory`; ~1,000 lines). Headline: **a prefab with `children` crashed on every real scene.** `PrefabFactory._create_children` called `parent_entity.get_component_by_name("Transform")` — a method that exists nowhere on `Entity` — so `factory.create()` raised `AttributeError` whenever a `prefab_resolver` was set, which `Scene.resolve_dependencies()` always does. Past the crash, the parent-link step was `for _child in children: pass` — children never attached despite `Transform` having a full `set_parent`/`children` API. **Zero `.prefab` files exist in the repo**, so the file→loader→factory→children path had never run. Per the user's choice (wire it properly, unify): children now instantiate as their own entities parented via `Transform.set_parent(keep_world_transform=False)` — authored position is local to the parent and follows it; `PrefabChild.offset` applies in local space. Dropped the dead loop and the `parent_position` bake (ignored parent rotation/scale). **BREAKING** (pre-alpha): `create()` loses `parent_position`, gains `source_path`. Also: **`_resolve_inheritance` had no cycle guard** (`A extends B extends A` → `RecursionError`) → now raises `ValueError` naming the chain. **`create()` swallowed component construction errors** in a blanket `except Exception`, yielding half-built entities → per the user's choice (fail loud) it now raises; `_instantiate_dataclass` also rejects unknown field keys (a typo used to vanish). **`_convert_value` enum handling was `EnumType[value.upper()]`** — non-SCREAMING_CASE members raised `KeyError` → swallowed → component dropped; now case-insensitive name or raw value, `ValueError` on a miss. **`PrefabInstance.prefab_path` was always the display `name`** (`create_from_path` had the real path and discarded it) → now threaded through, `name` only as the in-memory fallback. **`ComponentRegistry.clear()` wiped `_deserializers`** (losing the built-in `Transform` special-case; `Transform` is not a dataclass so a cleared registry couldn't round-trip it even re-registered) → now re-seeds built-ins. **`PrefabLoader` raised `AttributeError`** on a non-mapping top-level doc despite documenting `ValueError` → now validates. Removed **`PrefabReference`** (exported, used nowhere). Recurring shapes: "declared and wired to nothing" (`children` link-up, `PrefabReference`, `prefab_path`, `PrefabData.version`), "guard that holds a wrong answer" (swallowed errors, enum `.upper()`), uniform test setup (every factory test hand-built `PrefabData` against a `Transform`+`Tag`-only registry; `_create_children` / `create_from_path` / inheritance cycles / round-trip had **zero** coverage; `test_create_warns_on_unknown_component` asserted `... or entity is not None`). Tests +17 (1799 → 1835). New `docs/systems/prefabs.md` (no doc page existed). Phase D → **new issue** (sibling of #37/#40/#43/#46 + UI Phase-D): no spawn tables / weighted pools, `PrefabData.version` dead (no prefab-schema migration), no named variant library, prefab children lack an entity-level ownership/lifetime link (leak on parent destroy — needs an ECS-hierarchy decision), no asset-ref validation at load; `ComponentRegistry` process-global mutable singleton parked as a CC. |
 | `pyguara/ui` | 2026-09-08 | One slice (`base`, `layout`, `constraints`, `manager`, `theme`, `theme_presets`, `types`, `components/*`; ~1,900 lines). Two "declared and wired to nothing" headliners under 84 green tests. **The constraint layout system never ran** — `UIElement.apply_layout()` had no caller in the repo; `UIManager` had no layout pass; roots couldn't be constrained at all (`apply_layout` needs `self.parent`). Probe: `create_fill_constraints(margin=20)` under an 800×600 parent → child stays `Rect(0,0,10,10)` across three manager frames. So `constraints.py` (314 lines) + `element.padding` + every `create_*_constraints` helper were inert, though documented as "the heart of the UI system's power" with non-runnable examples. Per the user's choice (unify): `apply_layout()` → `UIElement.layout(available_rect, renderer)`; `UIManager` holds a screen `Rect` (seeded by `Application.set_screen_size()`, refreshed via a `WindowResizeEvent` subscription) and runs `layout()` over every root before render, **dirty-gated** (`add_element` / `set_screen_size` / new public `invalidate_layout()` arm it). Roots constrain against the screen; children against the parent's padding-aware content rect. `BoxContainer.layout()` folded into the same pass: resolves its own constraints first, honours `LayoutAlignment.STRETCH` (declared, no branch), skips hidden children in `render()`, recurses. **Theme was snapshotted per element at construction** (`self.theme = get_theme()` in `__init__`) so `set_theme()` re-skinned nothing already built (probe confirmed) — now `UIElement.theme` is a live property; `ProgressBar`/`Canvas`/`NavBar` defer their cached `Color`. **`ThemeConstants` `@dataclass(frozen=True)` decorated nothing** (`fields() == []`) — "All themes are immutable" was false, presets were mutable process-wide singletons; now a `__getattr__` hands back a fresh copy per access. Smaller: `Slider` rejects `max_val <= min_val` / non-positive width at construction; dead `UIElement.anchor` / `Label(anchor=)` param removed. Recurring shapes: "declared and wired to nothing" (`apply_layout`, `STRETCH`, `anchor`, fake `frozen`), "cached snapshot vs live lookup" (theme), uniform test setup (`test_ui_constraints.py`'s 513 lines only ever called `.apply()` on hand-built Rects; theme tests never built a `UIElement`). BREAKING (pre-alpha): `layout()` signature changed; four in-repo games had their now-redundant `container.layout(renderer)` call removed. Tests: new `test_ui_manager_layout.py` + rebuilt `test_ui_layout.py`. Phase D → new issue (sibling of #37/#40/#43/#46): `ShadowScheme`/`BorderScheme.radius`/`hover_overlay`/`press_overlay` consumed by no widget, no focus navigation, no scroll/clip container, no grid layout, no real text-input path (`TEXT_INPUT` declared/never dispatched), manual layout invalidation. |
 | `pyguara/ai` | 2026-09-08 | One slice (`fsm`, `blackboard`, `components`, `ai_system`, `steering`, `steering_system`, `behavior_tree`, `navmesh`, `pathfinding/*`; ~2,100 lines). **`world_to_grid_coords()` used `int()` not `floor`** — a non-zero grid `offset` or any negative local coord resolved to the wrong cell, and the quadrant left of/above the origin collapsed onto row/col 0 (world `(-10,-10)` → grid `(0,0)`, a sign flip). "Formula that returns a wrong answer" → `math.floor`. **`AISystem` passed the bare `Entity` as the BT context**, so `WaitNode` (any `context.dt` reader) fell back to a hardcoded `1/60` and drifted with frame rate — `WaitNode(1.0)` = ~2.1s @30fps, ~3.5s @144fps; the engine's own game hand-rolled its own AI system to dodge this. Fixed with a small `AIContext` (entity+dt+blackboard), passed to `tree.tick()`. **`SteeringSystem` only dispatched `seek/arrive/flee/wander`** — `pursuit`/`evade` (the only moving-target behaviors) were implemented but unreachable, and an unknown `behavior` string produced zero force silently. `behavior` is now a validated `SteeringBehaviorType` enum, all six wired, `SteeringAgent` gained `target_velocity`. **`behavior="arrive"` overshot and orbited the target forever** — system now enforces the arrive speed ramp on velocity and snaps to rest. **Generic `AStarPathfinder` crashed on a priority tie** with non-order-comparable nodes (`Node` is only `Hashable`; ties are common) — added the monotonic tie-break counter (also to `NavMeshPathfinder`). **`NavMesh.remove_polygon()` left dangling ids in other polygons' `neighbors`** — now pruned. FSM `set_initial_state()` / unknown transition targets were silent no-ops — now logged; a second `set_initial_state()` exits the prior state. `NavMeshPathfinder` docstring claimed a funnel algorithm it lacks — corrected. Recurring shapes: "guard/formula returns a wrong answer", "declared and wired to nothing" (`pursuit`/`evade`, `dt` never threaded), "hardcoded dt", uniform test setup (`TestCoordinateConversion` all-positive; **zero** tests for `AISystem`/`SteeringSystem`). Tests +29 (1770 → 1799). Phase D: BT/FSM authoring gaps (no reactive composites, no FSM transition table, no declarative blackboard nodes) → **#46** (sibling of #37/#40/#43); navmesh funnel/partial-portals/generation → parked (flow-field is #28's); steering-vs-physics → parked for the top-down `CharacterMover` slice. Left open: `WaitNode` keeps a named `getattr` dt fallback; the arrive fix is a velocity clamp (`_ARRIVE_STOP_DISTANCE = 1.0`), not a force-model redesign; `NavMeshPolygon.contains_point` has a fragile-but-unreachable `xinters`-before-assignment. |
 | `pyguara/persistence` | 2026-09-08 | One slice (`manager`, `storage`, `serializer`, `migration`, `types`; ~970 lines). The **migration half was sound** — the chain-integrity guards compose and the path loop provably terminates; overshoot/infinite-loop probes came back negative. The save/load half held the recurring shapes. **`save_data()` discarded `storage.save()`'s return** — `FileStorageBackend.save` returns `False` on `OSError`, so a full disk logged "Successfully saved" and returned `True`; now checked. **`FileStorageBackend` sanitised keys by deleting bad chars** — `"slot 1"`/`"slot/1"`/`"slot.1"` all collapsed onto `slot1` and silently overwrote each other (the resources F2 stem-collision shape); non-round-tripping keys now raise `ValueError`. **Data + meta were two independent `os.replace` calls** while the load path claimed "atomic save ensures both or neither" — a crash between them made an intact save unreadable (stale checksum → `None`). User chose the systemic fix: metadata is framed into **one blob** (`{header json}\n<payload>`), `StorageBackend` drops its `metadata` param (plain key→blob store), `FileStorageBackend` writes one `{key}.save` file + dir fsync + temp-sweep. **`compress=` was a documented no-op** → gzip, recorded in the header. **`SerializationFormat.MSGPACK` was a public enum member with no impl** though `msgpack` is a declared dep → implemented via the existing `prepare_for_json`/`game_object_hook` path, exposed through a new `fmt=` arg. `SaveMetadata` was hand-copied field by field and never read back on load → now carries `format`/`compressed`, used via `asdict`, engine version from `importlib.metadata` (was `"1.0.0"`), UTC timestamp. Migration gained `from_version >= 1` / `current_version >= 1` guards; `MigrationRegistry` is `eq=False`. Recurring shapes: "declared and wired to nothing" (`compress`, `MSGPACK`, `SaveMetadata`'s metadata half), "guard that returns a wrong answer" (swallowed `save()` failure, key mangling), "identity vs value" (`MigrationRegistry`), uniform test setup (every storage test used an already-safe key; every migration test used versions from 1). BREAKING: on-disk save format changed (`.dat`+`.meta` → `.save`); pre-alpha, no migration. Tests +35 (1735 → 1770). Phase D capability gaps: no backup/retention, no save-menu API (`list_saves`, cheap metadata read, `delete`/`exists` facade), CWD-relative save dir — grouped into #43 ("persistence production layer", sibling of #37); envelope `format_version` parked; run/meta split is #28's. Left open: `BINARY`/pickle load unauthenticated (trusted-input-only); mypy `python_version` 3.10 vs `requires-python` 3.12 forces a `# noqa: UP017` (possible CC). |
@@ -691,6 +765,189 @@ convert to explicit `is None` checks as each subsystem is audited.
 ---
 
 ## Iteration Log
+
+### `pyguara/prefabs` — CLOSED 2026-09-08 (branch `refactor/prefabs-audit`)
+
+One slice, ~1,000 lines: `prefabs/{types,registry,loader,factory}.py`. Every
+defect reproduced with a probe against the real code before any fix. Two
+upfront decisions put to the user:
+
+- **Child-prefab feature depth** — full crash-fix + real hierarchy wiring
+  vs. minimal crash-fix (flat, baked offset) vs. rip it out. User took
+  **wire it properly**.
+- **Malformed component data** — `create()` fail loud vs. keep
+  log-and-continue. User took **fail loud**.
+
+**Verification:** 1835 tests pass (up from 1799; +17 hand-written across a
+rebuilt `test_prefab.py` — parametrise expansion accounts for the rest).
+`ruff check .` clean; `ruff format --check` clean; `mypy pyguara` clean across
+226 files. Commits verified in a detached worktree at each SHA, not the
+working tree.
+
+**F1 — a prefab with `children` crashed on every real scene.**
+`PrefabFactory._create_children` (reached from `create()` whenever the prefab
+has children) did `parent_entity.get_component_by_name("Transform")`. `Entity`
+has no such method and its `__getattr__` only resolves snake_case component
+names from `_property_cache`, so the attribute access raised
+`AttributeError`. `_create_children` early-returns only when
+`self._prefab_resolver` is unset; `Scene.resolve_dependencies()` always sets
+one (`prefab_resolver=container.get(PrefabCache).load`), so in any real scene
+the crash was unconditional. Probe: `PrefabData` parent with one
+`PrefabChild`, resolver returning a child `PrefabData` →
+`AttributeError: 'Entity' object has no attribute or component
+'get_component_by_name'`. And past the crash the linking step was
+`for _child in children: pass` with a `# Optionally link children to parent
+here` comment — `Transform` has carried a full `set_parent`/`children`/
+`world_position` API since the `common` audit, unused here. There is **not
+one `.prefab` file in the repo** (`grep` for `*.prefab*` is empty; tests
+build `PrefabData` by hand or via `tempfile`), so nothing had ever exercised
+this path. Fix (user's "wire it properly"): `_create_children` instantiates
+each child via `self.create(child_prefab, entity_id=child.name,
+overrides=child.overrides, source_path=child.prefab)`, then, if both parent
+and child have a `Transform`, `child_t.set_parent(parent_t,
+keep_world_transform=False)` — the child's authored position stays as written
+and is now interpreted local to the parent, so the child follows the parent.
+`PrefabChild.offset` is added to the child's local position (an offset with
+no child `Transform` warns). The dead loop and the `parent_position`
+parameter that fed a one-time absolute-position bake (which ignored parent
+rotation and scale) are gone. **BREAKING** (pre-alpha): `create()` drops
+`parent_position`, adds `source_path`. Post-fix probe: child's
+`transform.parent is parent.transform`, child local `(10,0)` / world
+`(110,100)`, and moving the parent to `(200,100)` moves the child's world
+position to `(210,100)`.
+
+**F2 — `_resolve_inheritance` had no cycle guard.** It recurses on
+`prefab.extends` through the resolver with no visited set. Probe: `A extends
+"b"`, `B extends "a"`, resolver maps both → `RecursionError`. A self- or
+mutually-referential `extends` (an easy authoring slip) crashed with an
+opaque stack overflow rather than a diagnostic. Now threads the `extends`
+chain down the recursion and raises `ValueError("Prefab inheritance cycle
+detected: b -> a -> b")` — the shape the `common` `Transform.set_parent`
+cycle guard already uses.
+
+**F3 — `create()` swallowed component construction errors.** Each component
+was built inside `try: ... except Exception as e: logger.error(...)`, so a
+prefab with one bad field produced an entity silently missing that
+component. Compounded by **`_convert_value`'s enum branch**:
+`target_type[value.upper()]` assumes SCREAMING_CASE members, so a
+`class Facing(Enum): left = 1` with data `{"facing": "left"}` raised
+`KeyError` inside the swallow → component dropped, no error surfaced. Probe:
+entity built from `{"DcMover": {"facing": "left"}}` had no `DcMover`. Fix
+(user's "fail loud"): the `try/except` is gone — `registry.create` raising
+propagates out of `create()`. `_convert_enum` now accepts an exact or
+case-insensitive member name or a raw value and raises `ValueError` naming
+the members on a miss. `_instantiate_dataclass` additionally raises
+`ValueError` on any data key that matches no field (a typo'd field name used
+to be silently filtered out). Unregistered *component names* stay a
+warn-and-skip — distinct from malformed data, and plausibly a conditionally
+registered component.
+
+**F4 — `PrefabInstance.prefab_path` was always the display name.**
+`create()` hard-coded `prefab_path=prefab.name`; `create_from_path()`
+resolved the real path then called `self.create(prefab, ...)` without it. The
+component's docstring ("Stored on entities created from prefabs for tracking
+and hot-reload"; field: "Path to the source prefab") was unmeetable — you
+cannot reload an instance from a non-unique human label. Probe:
+`create_from_path("assets/prefabs/goblin.prefab.json")` →
+`PrefabInstance.prefab_path == "Goblin"`. Fix: `create()` takes
+`source_path`, uses `source_path or prefab.name`; `create_from_path` and
+`_create_children` pass the real path; a hand-built in-memory prefab still
+falls back to `name`.
+
+**F5 — `ComponentRegistry.clear()` was asymmetric and irreversible for
+`Transform`.** It cleared `_components` and `_deserializers` but not
+`_type_converters`, and did not re-seed the built-in `Transform` deserializer.
+`Transform` is **not** a dataclass and has a custom `__init__`, so the
+generic instantiation path can't build it from raw dict data — only the
+built-in `_deserialize_transform` can. Probe: `clear()` then re-`register(
+Transform)` then `create("Transform", {"position": {"x": 1, "y": 2}})` →
+`AttributeError: 'dict' object has no attribute 'x'`. Since
+`get_component_registry()` is a process-wide singleton, a caller doing this
+corrupts `Transform` deserialization for the whole process. Fix: `clear()`
+re-seeds `_type_converters = {Vector2: ...}` and re-runs
+`_register_builtin_deserializers()`; documented as "clear user registrations,
+restore built-in state".
+
+**F6 — `PrefabLoader` raised the wrong exception on a malformed file.**
+`_parse_prefab_data` calls `raw.get("name")` with no check that `raw` is a
+mapping. Probe: an empty `.prefab` (`yaml.safe_load` → `None`) →
+`AttributeError: 'NoneType' object has no attribute 'get'`; a JSON list →
+`AttributeError: 'list' ...`. The `load()` docstring promises
+`ValueError: If file format is invalid`. Now validates and raises
+`ValueError` naming the actual top-level type.
+
+**Removed `PrefabReference`** — a `@dataclass` in `types.py`, exported in
+`__all__`, with an `is_loaded()` method, constructed and consumed **nowhere**
+(grep: `types.py` + `__init__.py` only). Dead since it was written.
+
+**Phase B — test verdict.** `test_prefab.py` (346 lines, 27 tests) had solid
+deep-merge coverage (`test_deep_merge_nested_dicts`,
+`test_create_with_inheritance` genuinely exercise partial overrides) but the
+recurring blind spot in full force: **every `PrefabFactory` test hand-builds
+`PrefabData` against a fixture registry holding only `Transform` + `Tag`**
+(both trivial — no enum field, no non-Transform `Vector2`, no nested
+component), and **not one test goes file → `PrefabLoader` → `PrefabFactory`**
+— the "`test_config.py` mocked the filesystem" shape. `_create_children` had
+**zero** tests (the F1 crash lived exactly there); so did `create_from_path`,
+inheritance cycles, and any assertion that `PrefabInstance` is even attached.
+`test_create_warns_on_unknown_component` asserted
+`"UnknownComponent" in caplog.text or entity is not None` — the `or` clause
+is always true, so it could never fail (pure theatre). `test_clear_registry`
+checked `has()` returned `False` but not that the registry was still
+*usable*, so the F5 footgun was invisible. Rewritten: de-tautologised the
+warn test; added `TestPrefabChildren` (crash regression, parent-link +
+follow, local-space offset, source-path recording, no-resolver warning,
+offset-without-Transform warning), `TestPrefabInheritanceCycle`,
+`TestPrefabInstanceMetadata`, `TestPrefabFactoryFailsLoud`,
+`TestComponentRegistryConversion` (enum any-case + raw value, non-Transform
+`Vector2`, unknown-field raise, `clear()` still round-trips `Transform`),
+`TestPrefabLoaderRejectsMalformed`, `TestPrefabRoundTrip` (file → loader →
+factory). +17 hand-written tests; 1799 → 1835 including parametrise
+expansion.
+
+**Phase C — docs.** The subsystem had **no doc page**. Peripheral mentions
+(`docs/core/ecs.md`, `docs/core/scenes.md`) were accurate;
+`docs/guides/PROJECT_STRUCTURE.md` describes "prefabs" as hand-written
+factory functions (a convention doc, not an API reference — left as is);
+`docs/systems/resources.md`'s loader table listed only `.prefab` for the
+extension column. Wrote `docs/systems/prefabs.md` (layers, the registry's
+conversion rules and fail-loud contract, `extends` + cycle behavior, the
+child hierarchy semantics, `PrefabInstance` metadata, the JSON schema).
+Added it to `mkdocs.yml` nav and `docs/index.md`; corrected the
+`resources.md` row.
+
+**Phase D — capability gaps → new issue** (sibling of #37/#40/#43/#46 and
+the still-unfiled UI Phase-D issue):
+
+- **Spawn tables / weighted prefab pools.** `create` is one prefab at a
+  time; a roguelike spawns waves/loot from weighted random selection (ties
+  to #28's seeded RNG). None.
+- **`PrefabData.version` is dead** — declared "for migration support", read
+  by nothing. A renamed component field breaks every authored `.prefab`
+  with no upgrade path, while `pyguara/persistence` has a whole
+  `MigrationRegistry`.
+- **No named variant library** — `overrides` is per-call only; "elite
+  goblin = goblin + modifiers" needs an `extends` file per variant or raw
+  dicts at every spawn site.
+- **Prefab children have no entity-level ownership** — linked
+  `Transform`↔`Transform` only; the child entity has no parent-*entity*
+  back-reference and no shared lifetime, so despawning an enemy leaks its
+  prefab-attached child entities. A real fix likely needs an
+  `EntityManager` hierarchy (cross-cutting with `pyguara/ecs`).
+- **No asset-reference validation at load** — a prefab naming a missing
+  sprite fails only when the renderer reaches for it (overlaps #40).
+
+Parked as a CC: `ComponentRegistry` is a process-global mutable singleton
+(`get_component_registry()` + the `@register_component` decorator) — same
+shape as other engine singletons.
+
+**Left open.** `_deep_merge` replaces lists wholesale and has no way to
+*remove* an inherited component (design limitation, not a defect).
+`_create_children` partial state on a mid-way failure is not rolled back
+(consistent with fail-loud and with how other subsystems behave). The
+`SceneSerializer` shares this registry and has its own `try/except` fallback
+around `registry.create`, so the F3 fail-loud change is masked on that path —
+noted, not touched (serializer is `pyguara/scene`, already audited).
 
 ### `pyguara/ai` — CLOSED 2026-09-08 (branch `refactor/ai-audit`)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ Essential engine features:
 *   **[Animation](systems/animation.md)**: Powerful tweening and easing system.
 *   **[Scripting](systems/scripting.md)**: Coroutine-based sequential logic.
 *   **[Resources](systems/resources.md)**: Caching and type-safe asset loading.
+*   **[Prefabs](systems/prefabs.md)**: Data-driven entity templates with inheritance and child hierarchies.
 *   **[Editor & Tools](systems/editor.md)**: In-game debug overlay and inspector.
 
 ## 🚀 Quick Start

--- a/docs/systems/prefabs.md
+++ b/docs/systems/prefabs.md
@@ -1,0 +1,132 @@
+# Prefab System
+
+`pyguara.prefabs` turns a **data description of an entity** — components and
+their field values, optional inheritance, optional child entities — into a
+live entity in a scene's `EntityManager`. Prefabs can be built in memory or
+loaded from `.prefab` / `.prefab.json` / `.prefab.yaml` files.
+
+## Layers
+
+1. **`PrefabData`** (`pyguara.prefabs.types`) — the template: a `name`, a
+   `components` dict (`{ComponentName: {field: value}}`), an optional
+   `extends` path, an optional `children` list, `tags`, and a `version`.
+2. **`ComponentRegistry`** (`pyguara.prefabs.registry`) — maps a component
+   *name* to its class so `{"Transform": {...}}` can be turned into a
+   `Transform` instance. The bootstrap registers every core engine component
+   (`Transform`, `Tag`, `RigidBody`, `Collider`, the AI/animation/audio
+   components, `PrefabInstance`, …) on a process-global registry, exposed
+   through DI as `ComponentRegistry`.
+3. **`PrefabLoader`** / **`PrefabCache`** (`pyguara.prefabs.loader`) — read a
+   file into `PrefabData`. `PrefabLoader` is also registered with the
+   `ResourceManager` for the `.prefab` extension. `PrefabCache` adds a
+   path→`PrefabData` cache and is the DI-registered singleton.
+4. **`PrefabFactory`** (`pyguara.prefabs.factory`) — instantiates a
+   `PrefabData` into an entity. One is created per scene in
+   `Scene.resolve_dependencies()`, bound to that scene's `EntityManager` and
+   with its resolver wired to `PrefabCache.load`, so `extends` and `children`
+   paths resolve against files on disk.
+
+```python
+from pyguara.prefabs import PrefabData
+
+goblin = PrefabData(
+    name="Goblin",
+    components={
+        "Transform": {"position": {"x": 100, "y": 80}},
+        "Tag": {"name": "enemy"},
+    },
+)
+entity = self.prefab_factory.create(goblin)
+```
+
+## The component registry
+
+`registry.create(name, data)` builds one component:
+
+- **Dataclass components** are filled field by field. `{"x": ..., "y": ...}`
+  dicts become `Vector2`; an `Enum` field accepts a member name
+  (case-insensitive) or a raw member value.
+- **A key that matches no field raises `ValueError`.** A typo in a prefab
+  (`"colour"` for `"color"`) is an authoring error, caught at instantiation
+  rather than surfacing later as a missing value.
+- **`Transform`** has a custom `__init__` and is not a dataclass, so it goes
+  through a built-in deserializer. `clear()` wipes user registrations and
+  **re-seeds the built-ins**, so a cleared registry can still round-trip
+  `Transform` once it is re-registered.
+
+Register your own components with the class or the decorator:
+
+```python
+from pyguara.prefabs import register_component
+
+@register_component
+class Health(BaseComponent):
+    current: int = 100
+    maximum: int = 100
+```
+
+## Inheritance — `extends`
+
+`extends` names another prefab (by resolver path). Parent components are
+resolved first, then the child's `components` are **deep-merged** over them:
+nested dicts merge key by key, so a child can override
+`Transform.position.x` alone and inherit `y` and `scale`.
+
+A resolver is required for `extends` to do anything — the per-scene factory
+has one. An `extends` chain that refers back to a prefab already being
+resolved raises `ValueError` naming the cycle (`a -> b -> a`) instead of
+recursing until the stack runs out.
+
+## Children
+
+`PrefabData.children` is a list of `PrefabChild(prefab, offset, name,
+overrides)`. Each child is instantiated as its **own entity** and its
+`Transform` is parented to the parent entity's `Transform`
+(`set_parent(..., keep_world_transform=False)`):
+
+- The child's authored position is treated as **local** to the parent.
+- `offset` (`{"x": .., "y": ..}`) is added to that local position.
+- Moving the parent entity moves the children with it.
+
+A child needs a resolver to be found (the per-scene factory has one); without
+one, children are skipped with a warning. A child with an `offset` but no
+`Transform` component logs a warning and the offset is ignored.
+
+## Instantiation and metadata
+
+`factory.create(prefab, entity_id=None, overrides=None, source_path=None)`
+returns the entity. `overrides` is a second deep-merge layer applied after
+inheritance. Every created entity gets a **`PrefabInstance`** component
+recording `prefab_path` (the `source_path`, or `prefab.name` for an in-memory
+prefab) and the `instance_overrides` that were applied.
+
+`factory.create_from_path(path, ...)` resolves the path through the resolver
+and passes it as `source_path`, so instances carry the real file path.
+
+A component whose data cannot be built (unknown field, bad enum value, type
+mismatch) makes `create()` **raise** rather than return a half-populated
+entity. An unregistered component name is skipped with a warning — register
+it if it is meant to be there.
+
+## File format
+
+```json
+{
+  "name": "Goblin",
+  "version": 1,
+  "extends": "enemies/base_enemy.prefab.json",
+  "tags": ["enemy", "melee"],
+  "components": {
+    "Transform": { "position": { "x": 0, "y": 0 } },
+    "Health": { "current": 30, "maximum": 30 }
+  },
+  "children": [
+    { "prefab": "fx/torch.prefab.json", "name": "torch", "offset": { "x": 8, "y": -4 } }
+  ]
+}
+```
+
+`PrefabLoader` accepts `.prefab.json`, `.prefab.yaml` / `.prefab.yml` (when
+PyYAML is installed), and `.prefab` (format auto-detected). A file whose
+top-level value is not a mapping raises `ValueError`. If `name` is omitted the
+file stem is used.

--- a/docs/systems/resources.md
+++ b/docs/systems/resources.md
@@ -27,7 +27,7 @@ bootstrap wires:
 | `JsonLoader` | `.json`, `.manifest`, `.config` | `DataResource` |
 | `PygameImageLoader` / `GLTextureLoader` | `.png`, `.jpg`, `.jpeg`, `.bmp`, `.tga` | `Texture` |
 | `PygameSoundLoader` | `.wav`, `.ogg`, `.mp3` | `AudioClip` |
-| `PrefabLoader` | `.prefab` | prefab data |
+| `PrefabLoader` | `.prefab`, `.prefab.json`, `.prefab.yaml` | `PrefabData` (see [Prefabs](prefabs.md)) |
 
 Registering a second loader for an extension logs a warning and wins.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,5 +40,6 @@ nav:
       - Editor Tools: systems/editor.md
       - Input: systems/input.md
       - Persistence: systems/persistence.md
+      - Prefabs: systems/prefabs.md
       - Resources: systems/resources.md
       - Scripting: systems/scripting.md

--- a/pyguara/prefabs/__init__.py
+++ b/pyguara/prefabs/__init__.py
@@ -19,7 +19,6 @@ from pyguara.prefabs.types import (
     PrefabChild,
     PrefabData,
     PrefabInstance,
-    PrefabReference,
 )
 
 __all__ = [
@@ -27,7 +26,6 @@ __all__ = [
     "PrefabChild",
     "PrefabData",
     "PrefabInstance",
-    "PrefabReference",
     # Registry
     "ComponentRegistry",
     "get_component_registry",

--- a/pyguara/prefabs/factory.py
+++ b/pyguara/prefabs/factory.py
@@ -10,6 +10,7 @@ import copy
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from pyguara.common.components import Transform
 from pyguara.common.types import Vector2
 from pyguara.log import get_logger
 from pyguara.prefabs.types import PrefabChild, PrefabData, PrefabInstance
@@ -75,7 +76,7 @@ class PrefabFactory:
         prefab: PrefabData,
         entity_id: str | None = None,
         overrides: dict[str, dict[str, Any]] | None = None,
-        parent_position: Vector2 | None = None,
+        source_path: str | None = None,
     ) -> Entity:
         """Create an entity from a prefab.
 
@@ -83,10 +84,18 @@ class PrefabFactory:
             prefab: The prefab data to instantiate.
             entity_id: Optional custom entity ID.
             overrides: Optional component data overrides.
-            parent_position: Optional parent position for offset calculation.
+            source_path: Path the prefab was loaded from. Recorded on the
+                entity's `PrefabInstance` so an instance can be traced back
+                to (and reloaded from) its source. Falls back to `prefab.name`
+                when the prefab was built in memory.
 
         Returns:
             The created entity with all components.
+
+        Raises:
+            ValueError: If the prefab's `extends` chain contains a cycle, or a
+                component's serialized data cannot be converted to its type.
+            KeyError: If a custom deserializer references an unregistered type.
         """
         # Resolve inheritance
         resolved_components = self._resolve_inheritance(prefab)
@@ -101,37 +110,24 @@ class PrefabFactory:
         # Add prefab metadata component
         entity.add_component(
             PrefabInstance(
-                prefab_path=prefab.name,
+                prefab_path=source_path or prefab.name,
                 instance_overrides=overrides or {},
             )
         )
 
-        # Create and add components
+        # Create and add components. A component whose data cannot be
+        # instantiated is an authoring error: let it raise rather than
+        # returning a half-built entity that fails mysteriously at runtime.
         for comp_name, comp_data in resolved_components.items():
             if not self._registry.has(comp_name):
                 logger.warning(f"Component '{comp_name}' not registered, skipping")
                 continue
 
-            try:
-                component = self._registry.create(comp_name, comp_data)
+            component = self._registry.create(comp_name, comp_data)
+            entity.add_component(component)
 
-                # Apply parent position offset for Transform
-                if comp_name == "Transform" and parent_position is not None:
-                    if hasattr(component, "position"):
-                        component.position = Vector2(
-                            component.position.x + parent_position.x,
-                            component.position.y + parent_position.y,
-                        )
-
-                entity.add_component(component)
-            except Exception as e:
-                logger.error(f"Failed to create component '{comp_name}': {e}")
-
-        # Create children
-        children = self._create_children(prefab.children, entity)
-        for _child in children:
-            # Optionally link children to parent here
-            pass
+        # Create children and parent them to this entity's Transform.
+        self._create_children(prefab.children, entity)
 
         logger.debug(f"Created entity from prefab '{prefab.name}': {entity.id}")
         return entity
@@ -161,21 +157,37 @@ class PrefabFactory:
             logger.error(f"Failed to resolve prefab: {prefab_path}")
             return None
 
-        return self.create(prefab, entity_id, overrides)
+        return self.create(prefab, entity_id, overrides, source_path=prefab_path)
 
-    def _resolve_inheritance(self, prefab: PrefabData) -> dict[str, dict[str, Any]]:
+    def _resolve_inheritance(
+        self,
+        prefab: PrefabData,
+        _chain: list[str] | None = None,
+    ) -> dict[str, dict[str, Any]]:
         """Resolve prefab inheritance chain.
 
         Merges component data from parent prefabs, with child overriding parent.
 
         Args:
             prefab: The prefab to resolve.
+            _chain: Internal. The `extends` paths already followed on this
+                branch, used to detect a cycle.
 
         Returns:
             Merged component data dictionary.
+
+        Raises:
+            ValueError: If the `extends` chain refers back to a prefab already
+                being resolved (a cycle would otherwise recurse until the
+                stack ran out).
         """
         if not prefab.extends or not self._prefab_resolver:
             return copy.deepcopy(prefab.components)
+
+        chain = _chain or []
+        if prefab.extends in chain:
+            cycle = " -> ".join([*chain, prefab.extends])
+            raise ValueError(f"Prefab inheritance cycle detected: {cycle}")
 
         # Load parent prefab
         parent_prefab = self._prefab_resolver(prefab.extends)
@@ -184,7 +196,9 @@ class PrefabFactory:
             return copy.deepcopy(prefab.components)
 
         # Recursively resolve parent inheritance
-        parent_components = self._resolve_inheritance(parent_prefab)
+        parent_components = self._resolve_inheritance(
+            parent_prefab, [*chain, prefab.extends]
+        )
 
         # Deep merge: child overrides parent
         merged = self._deep_merge(parent_components, prefab.components)
@@ -241,7 +255,13 @@ class PrefabFactory:
         children: list[PrefabChild],
         parent_entity: Entity,
     ) -> list[Entity]:
-        """Create child entities from prefab children.
+        """Create child entities and parent them to `parent_entity`.
+
+        Each child's Transform (if it has one) is attached to the parent's
+        Transform via `Transform.set_parent(..., keep_world_transform=False)`,
+        so the child's authored position is treated as local to the parent and
+        the child follows the parent when it moves. `PrefabChild.offset` is
+        added to that local position.
 
         Args:
             children: List of child prefab references.
@@ -250,8 +270,21 @@ class PrefabFactory:
         Returns:
             List of created child entities.
         """
-        if not self._prefab_resolver:
+        if not children:
             return []
+
+        if not self._prefab_resolver:
+            logger.warning(
+                "Prefab declares children but the factory has no prefab_resolver; "
+                "children skipped"
+            )
+            return []
+
+        parent_transform = (
+            parent_entity.get_component(Transform)
+            if parent_entity.has_component(Transform)
+            else None
+        )
 
         created: list[Entity] = []
 
@@ -261,24 +294,34 @@ class PrefabFactory:
                 logger.warning(f"Child prefab not found: {child.prefab}")
                 continue
 
-            # Calculate parent position for offset
-            parent_pos = None
-            transform = parent_entity.get_component_by_name("Transform")
-            if transform and hasattr(transform, "position"):
-                parent_pos = transform.position
-                if child.offset:
-                    parent_pos = Vector2(
-                        parent_pos.x + child.offset.get("x", 0),
-                        parent_pos.y + child.offset.get("y", 0),
-                    )
-
-            # Create child entity
             child_entity = self.create(
                 child_prefab,
                 entity_id=child.name,
                 overrides=child.overrides,
-                parent_position=parent_pos,
+                source_path=child.prefab,
             )
+
+            child_transform = (
+                child_entity.get_component(Transform)
+                if child_entity.has_component(Transform)
+                else None
+            )
+
+            if child.offset:
+                if child_transform is not None:
+                    child_transform.position = Vector2(
+                        child_transform.position.x + child.offset.get("x", 0.0),
+                        child_transform.position.y + child.offset.get("y", 0.0),
+                    )
+                else:
+                    logger.warning(
+                        f"Child prefab '{child.prefab}' has an offset but no "
+                        f"Transform component; offset ignored"
+                    )
+
+            if parent_transform is not None and child_transform is not None:
+                child_transform.set_parent(parent_transform, keep_world_transform=False)
+
             created.append(child_entity)
 
         return created

--- a/pyguara/prefabs/loader.py
+++ b/pyguara/prefabs/loader.py
@@ -137,7 +137,7 @@ class PrefabLoader:
         result = json.loads(content)
         return result
 
-    def _parse_prefab_data(self, raw: dict[str, Any], source_path: str) -> PrefabData:
+    def _parse_prefab_data(self, raw: Any, source_path: str) -> PrefabData:
         """Parse raw dictionary into PrefabData.
 
         Args:
@@ -148,8 +148,15 @@ class PrefabLoader:
             Parsed PrefabData.
 
         Raises:
-            ValueError: If required fields are missing.
+            ValueError: If the top-level document is not a mapping, or a
+                required field is missing.
         """
+        if not isinstance(raw, dict):
+            raise ValueError(
+                f"Prefab '{source_path}' must contain a mapping at the top "
+                f"level, got {type(raw).__name__}"
+            )
+
         # Required field
         name = raw.get("name")
         if not name:

--- a/pyguara/prefabs/registry.py
+++ b/pyguara/prefabs/registry.py
@@ -7,6 +7,7 @@ enabling dynamic component instantiation from serialized data.
 from __future__ import annotations
 
 import dataclasses
+import enum
 from collections.abc import Callable
 from typing import Any, get_type_hints
 
@@ -182,6 +183,22 @@ class ComponentRegistry:
         except Exception:
             hints = {}
 
+        assignable = {
+            f.name
+            for f in dataclasses.fields(cls)  # type: ignore[arg-type]
+            if not f.name.startswith("_")
+        }
+
+        # A key that matches no field is an authoring mistake (a typo, a
+        # renamed field, wrong component). Silently dropping it — the old
+        # behaviour — hid the error until the value was missing at runtime.
+        unknown = set(data) - assignable
+        if unknown:
+            raise ValueError(
+                f"{cls.__name__} has no field(s) {sorted(unknown)}; "
+                f"valid fields: {sorted(assignable)}"
+            )
+
         for dc_field in dataclasses.fields(cls):  # type: ignore[arg-type]
             field_name = dc_field.name
 
@@ -223,13 +240,38 @@ class ComponentRegistry:
         if isinstance(value, dict) and "x" in value and "y" in value:
             return Vector2(value["x"], value["y"])
 
-        # Handle enums
-        if hasattr(target_type, "__members__"):
-            if isinstance(value, str):
-                return target_type[value.upper()]
-            return target_type(value)
+        # Handle enums: accept a member name (case-insensitive) or a raw value.
+        if isinstance(target_type, type) and issubclass(target_type, enum.Enum):
+            return self._convert_enum(value, target_type)
 
         return value
+
+    def _convert_enum(self, value: Any, enum_type: type[enum.Enum]) -> Any:
+        """Coerce serialized data to an enum member.
+
+        Accepts an existing member, an exact or case-insensitive member name,
+        or a raw member value. A string that matches nothing raises
+        ``ValueError`` naming the valid members rather than a bare ``KeyError``.
+        """
+        if isinstance(value, enum_type):
+            return value
+
+        if isinstance(value, str):
+            if value in enum_type.__members__:
+                return enum_type[value]
+            for member in enum_type:
+                if member.name.lower() == value.lower():
+                    return member
+            try:
+                return enum_type(value)
+            except ValueError:
+                members = ", ".join(m.name for m in enum_type)
+                raise ValueError(
+                    f"{value!r} is not a valid {enum_type.__name__} "
+                    f"(expected one of: {members})"
+                ) from None
+
+        return enum_type(value)
 
     def _convert_vector2(self, value: Any) -> Vector2:
         """Convert data to Vector2.
@@ -284,9 +326,19 @@ class ComponentRegistry:
         return sorted(self._components.keys())
 
     def clear(self) -> None:
-        """Clear all registrations."""
+        """Clear user registrations, restoring the registry's built-in state.
+
+        Removes every component type and custom deserializer/type converter
+        added since construction, then re-seeds the built-ins (the ``Vector2``
+        type converter and the ``Transform`` deserializer). Without the
+        re-seed, a cleared registry could no longer round-trip ``Transform`` —
+        it has a custom ``__init__`` and is not a dataclass, so the generic
+        instantiation path cannot build it from raw dict data.
+        """
         self._components.clear()
         self._deserializers.clear()
+        self._type_converters = {Vector2: self._convert_vector2}
+        self._register_builtin_deserializers()
 
 
 # Global registry instance

--- a/pyguara/prefabs/types.py
+++ b/pyguara/prefabs/types.py
@@ -54,27 +54,6 @@ class PrefabChild:
 
 
 @dataclass
-class PrefabReference:
-    """Lightweight reference to a prefab for lazy loading.
-
-    Used when you want to reference a prefab without loading it immediately.
-
-    Attributes:
-        path: Path to the prefab file.
-        loaded: Whether the prefab data has been loaded.
-        data: The loaded prefab data, or None if not loaded.
-    """
-
-    path: str
-    loaded: bool = False
-    data: PrefabData | None = None
-
-    def is_loaded(self) -> bool:
-        """Check if the prefab data has been loaded."""
-        return self.loaded and self.data is not None
-
-
-@dataclass
 class PrefabInstance(BaseComponent):
     """Metadata about an instantiated prefab.
 

--- a/tests/test_prefab.py
+++ b/tests/test_prefab.py
@@ -1,5 +1,7 @@
 """Tests for the prefab system."""
 
+import dataclasses
+import enum
 import json
 import tempfile
 from pathlib import Path
@@ -7,11 +9,13 @@ from pathlib import Path
 import pytest
 
 from pyguara.common.components import Tag, Transform
+from pyguara.common.types import Vector2
+from pyguara.ecs.component import BaseComponent
 from pyguara.ecs.manager import EntityManager
 from pyguara.prefabs.factory import PrefabFactory
 from pyguara.prefabs.loader import Prefab, PrefabCache, PrefabLoader
 from pyguara.prefabs.registry import ComponentRegistry
-from pyguara.prefabs.types import PrefabChild, PrefabData
+from pyguara.prefabs.types import PrefabChild, PrefabData, PrefabInstance
 
 
 @pytest.fixture
@@ -295,17 +299,23 @@ class TestPrefabFactory:
         assert transform.rotation == 45.0
 
     def test_create_warns_on_unknown_component(self, prefab_factory, caplog):
-        """Test that unknown components log a warning."""
+        """An unregistered component is skipped with a warning, not fatal."""
         import logging
 
         prefab = PrefabData(
-            name="WithUnknown", components={"UnknownComponent": {"foo": "bar"}}
+            name="WithUnknown",
+            components={
+                "Tag": {"name": "ok"},
+                "UnknownComponent": {"foo": "bar"},
+            },
         )
 
         with caplog.at_level(logging.WARNING):
             entity = prefab_factory.create(prefab)
 
-        assert "UnknownComponent" in caplog.text or entity is not None
+        assert "UnknownComponent" in caplog.text
+        # The registered component still lands; only the unknown one is dropped.
+        assert entity.get_component(Tag).name == "ok"
 
 
 class TestDeepMerge:
@@ -344,3 +354,276 @@ class TestDeepMerge:
         # scale should be inherited
         assert transform.scale.x == 1
         assert transform.scale.y == 1
+
+
+class Facing(enum.Enum):
+    """Non-SCREAMING_CASE enum: the old `value.upper()` path could not build it."""
+
+    left = 1
+    right = 2
+
+
+@dataclasses.dataclass
+class Mover(BaseComponent):
+    """A component with an enum field and a non-Transform Vector2 field."""
+
+    facing: Facing = Facing.left
+    speed: float = 0.0
+    anchor: Vector2 = dataclasses.field(default_factory=lambda: Vector2(0, 0))
+
+
+@pytest.fixture
+def registry_with_mover(component_registry):
+    component_registry.register(Mover)
+    return component_registry
+
+
+@pytest.fixture
+def factory_with_mover(entity_manager, registry_with_mover):
+    return PrefabFactory(entity_manager, registry_with_mover)
+
+
+class TestPrefabChildren:
+    """`_create_children` had zero tests; the headline defect lived here."""
+
+    def _resolver(self, mapping):
+        return lambda path: mapping.get(path)
+
+    def test_children_do_not_raise_with_a_resolver_set(
+        self, prefab_factory, entity_manager
+    ):
+        """Regression: a prefab with children used to hit a nonexistent
+        `Entity.get_component_by_name` and raise AttributeError whenever a
+        resolver was set (every real Scene sets one)."""
+        child = PrefabData(
+            name="Child", components={"Transform": {"position": {"x": 0, "y": 0}}}
+        )
+        parent = PrefabData(
+            name="Parent",
+            components={"Transform": {"position": {"x": 100, "y": 100}}},
+            children=[PrefabChild(prefab="child", name="the_child")],
+        )
+        prefab_factory.set_prefab_resolver(self._resolver({"child": child}))
+
+        prefab_factory.create(parent)  # must not raise
+
+        assert entity_manager.get_entity("the_child") is not None
+
+    def test_child_transform_is_parented_and_follows_the_parent(
+        self, prefab_factory, entity_manager
+    ):
+        child = PrefabData(
+            name="Child", components={"Transform": {"position": {"x": 0, "y": 0}}}
+        )
+        parent = PrefabData(
+            name="Parent",
+            components={"Transform": {"position": {"x": 100, "y": 100}}},
+            children=[
+                PrefabChild(prefab="child", name="kid", offset={"x": 10, "y": 0})
+            ],
+        )
+        prefab_factory.set_prefab_resolver(self._resolver({"child": child}))
+
+        parent_entity = prefab_factory.create(parent)
+        child_t = entity_manager.get_entity("kid").get_component(Transform)
+        parent_t = parent_entity.get_component(Transform)
+
+        assert child_t.parent is parent_t
+        # offset is applied in the parent's local space
+        assert (child_t.position.x, child_t.position.y) == (10, 0)
+        assert (child_t.world_position.x, child_t.world_position.y) == (110, 100)
+
+        parent_t.position = Vector2(200, 100)
+        assert (child_t.world_position.x, child_t.world_position.y) == (210, 100)
+
+    def test_child_records_its_source_path(self, prefab_factory, entity_manager):
+        child = PrefabData(name="Child", components={"Tag": {"name": "c"}})
+        parent = PrefabData(
+            name="Parent",
+            components={"Tag": {"name": "p"}},
+            children=[PrefabChild(prefab="enemies/child.prefab.json", name="kid")],
+        )
+        prefab_factory.set_prefab_resolver(
+            self._resolver({"enemies/child.prefab.json": child})
+        )
+
+        prefab_factory.create(parent)
+        kid = entity_manager.get_entity("kid")
+        assert (
+            kid.get_component(PrefabInstance).prefab_path == "enemies/child.prefab.json"
+        )
+
+    def test_children_without_resolver_are_skipped_with_a_warning(
+        self, prefab_factory, entity_manager, caplog
+    ):
+        import logging
+
+        parent = PrefabData(
+            name="Parent",
+            components={"Tag": {"name": "p"}},
+            children=[PrefabChild(prefab="child")],
+        )
+        # no resolver set
+        with caplog.at_level(logging.WARNING):
+            entity = prefab_factory.create(parent)
+
+        assert "resolver" in caplog.text.lower()
+        assert list(entity_manager.get_all_entities()) == [entity]
+
+    def test_offset_without_a_child_transform_warns(
+        self, prefab_factory, entity_manager, caplog
+    ):
+        import logging
+
+        child = PrefabData(name="Child", components={"Tag": {"name": "c"}})
+        parent = PrefabData(
+            name="Parent",
+            components={"Transform": {"position": {"x": 0, "y": 0}}},
+            children=[PrefabChild(prefab="child", name="kid", offset={"x": 5, "y": 5})],
+        )
+        prefab_factory.set_prefab_resolver(self._resolver({"child": child}))
+
+        with caplog.at_level(logging.WARNING):
+            prefab_factory.create(parent)
+
+        assert "offset" in caplog.text.lower()
+
+
+class TestPrefabInheritanceCycle:
+    def test_direct_self_reference_raises_valueerror(self, prefab_factory):
+        prefab = PrefabData(name="A", extends="a", components={"Tag": {"name": "a"}})
+        prefab_factory.set_prefab_resolver(lambda p: prefab)
+
+        with pytest.raises(ValueError, match="cycle"):
+            prefab_factory.create(prefab)
+
+    def test_mutual_reference_raises_and_names_the_chain(self, prefab_factory):
+        a = PrefabData(name="A", extends="b", components={"Tag": {"name": "a"}})
+        b = PrefabData(name="B", extends="a", components={"Tag": {"name": "b"}})
+        prefab_factory.set_prefab_resolver(lambda p: a if p == "a" else b)
+
+        with pytest.raises(ValueError, match="a -> b -> a|b -> a -> b"):
+            prefab_factory.create(a)
+
+
+class TestPrefabInstanceMetadata:
+    def test_in_memory_prefab_records_its_name(self, prefab_factory):
+        entity = prefab_factory.create(PrefabData(name="Goblin", components={}))
+        assert entity.get_component(PrefabInstance).prefab_path == "Goblin"
+
+    def test_create_from_path_records_the_path(self, prefab_factory):
+        pf = PrefabData(name="Goblin", components={"Tag": {"name": "enemy"}})
+        prefab_factory.set_prefab_resolver(lambda p: pf)
+
+        entity = prefab_factory.create_from_path("assets/prefabs/goblin.prefab.json")
+
+        assert (
+            entity.get_component(PrefabInstance).prefab_path
+            == "assets/prefabs/goblin.prefab.json"
+        )
+
+    def test_overrides_are_recorded(self, prefab_factory):
+        entity = prefab_factory.create(
+            PrefabData(name="P", components={"Tag": {"name": "a"}}),
+            overrides={"Tag": {"name": "b"}},
+        )
+        assert entity.get_component(PrefabInstance).instance_overrides == {
+            "Tag": {"name": "b"}
+        }
+
+
+class TestPrefabFactoryFailsLoud:
+    def test_unknown_field_raises(self, prefab_factory):
+        prefab = PrefabData(
+            name="P", components={"Tag": {"name": "ok", "colour": "red"}}
+        )
+        with pytest.raises(ValueError, match="no field"):
+            prefab_factory.create(prefab)
+
+    def test_bad_enum_value_raises(self, factory_with_mover):
+        prefab = PrefabData(name="P", components={"Mover": {"facing": "sideways"}})
+        with pytest.raises(ValueError, match="not a valid Facing"):
+            factory_with_mover.create(prefab)
+
+
+class TestComponentRegistryConversion:
+    @pytest.mark.parametrize("given", ["left", "LEFT", "Left", 1])
+    def test_enum_field_accepts_name_any_case_or_raw_value(
+        self, registry_with_mover, given
+    ):
+        mover = registry_with_mover.create("Mover", {"facing": given})
+        assert mover.facing is Facing.left
+
+    def test_non_transform_vector2_field_is_converted(self, registry_with_mover):
+        mover = registry_with_mover.create("Mover", {"anchor": {"x": 3, "y": 4}})
+        assert isinstance(mover.anchor, Vector2)
+        assert (mover.anchor.x, mover.anchor.y) == (3, 4)
+
+    def test_unknown_field_raises(self, registry_with_mover):
+        with pytest.raises(ValueError, match="no field"):
+            registry_with_mover.create("Mover", {"speeed": 1.0})
+
+    def test_clear_leaves_registry_able_to_round_trip_transform(self):
+        registry = ComponentRegistry()
+        registry.register(Transform)
+        registry.clear()
+        # Transform is not a dataclass and has a custom __init__; only the
+        # re-seeded builtin deserializer can rebuild it from raw dict data.
+        registry.register(Transform)
+
+        t = registry.create("Transform", {"position": {"x": 1, "y": 2}})
+
+        assert isinstance(t, Transform)
+        assert (t.position.x, t.position.y) == (1, 2)
+
+    def test_clear_drops_user_registrations(self):
+        registry = ComponentRegistry()
+        registry.register(Tag)
+        registry.clear()
+        assert not registry.has("Tag")
+
+
+class TestPrefabLoaderRejectsMalformed:
+    @pytest.mark.parametrize(
+        "body,suffix",
+        [("[1, 2, 3]", ".prefab.json"), ("- a\n- b\n", ".prefab")],
+    )
+    def test_non_mapping_top_level_raises_valueerror(self, body, suffix):
+        loader = PrefabLoader()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=suffix, delete=False) as f:
+            f.write(body)
+            f.flush()
+            try:
+                with pytest.raises(ValueError, match="mapping"):
+                    loader.load(f.name)
+            finally:
+                Path(f.name).unlink()
+
+
+class TestPrefabRoundTrip:
+    """No existing test went file -> PrefabLoader -> PrefabFactory."""
+
+    def test_load_then_instantiate(self, prefab_factory):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".prefab.json", delete=False
+        ) as f:
+            json.dump(
+                {
+                    "name": "Crate",
+                    "components": {
+                        "Transform": {"position": {"x": 12, "y": 34}},
+                        "Tag": {"name": "prop"},
+                    },
+                },
+                f,
+            )
+            f.flush()
+            try:
+                data = PrefabLoader().load(f.name).data
+                entity = prefab_factory.create(data, source_path=f.name)
+            finally:
+                Path(f.name).unlink()
+
+        assert entity.get_component(Transform).position.x == 12
+        assert entity.get_component(Tag).name == "prop"
+        assert entity.get_component(PrefabInstance).prefab_path == f.name


### PR DESCRIPTION
Subsystem audit, Tier 4: `pyguara/prefabs` (~1,000 lines — `types`,
`registry`, `loader`, `factory`). Independent branch from `main`.

## Headline

**A prefab with `children` crashed on every real scene.**
`PrefabFactory._create_children` called
`parent_entity.get_component_by_name("Transform")` — a method that exists
nowhere on `Entity` — so `factory.create()` raised `AttributeError` whenever
a `prefab_resolver` was set, which `Scene.resolve_dependencies()` always does
(`prefab_resolver=PrefabCache.load`). Past the crash, the parent-link step
was `for _child in children: pass` — children were never attached despite
`Transform` carrying a full `set_parent`/`children` API. There is **not one
`.prefab` file in the repo**, so the whole file → loader → factory →
children path had never run.

Two decisions taken with the maintainer up front: **wire the child feature
properly** (real hierarchy, not a minimal crash-fix or a rip-out), and
**fail loud** on malformed component data.

## Fixes (all probe-reproduced against the real code first)

- **Children** now instantiate as their own entities parented via
  `Transform.set_parent(keep_world_transform=False)` — authored position is
  local to the parent and follows it; `PrefabChild.offset` applies in local
  space. Dropped the dead loop and the `parent_position` bake (it ignored
  parent rotation/scale). **BREAKING** (pre-alpha): `create()` loses
  `parent_position`, gains `source_path`.
- **`_resolve_inheritance`** tracked no `extends` chain — `A extends B
  extends A` recursed to `RecursionError`. Now raises `ValueError` naming the
  cycle (`b -> a -> b`).
- **`create()`** wrapped each component build in a blanket `except Exception`
  that logged and continued, yielding half-built entities. The `try/except`
  is gone; `_instantiate_dataclass` also rejects keys matching no field (a
  typo'd field name used to be silently filtered out).
- **`_convert_value`** enum handling was `EnumType[value.upper()]` — any
  non-SCREAMING_CASE member raised `KeyError` → swallowed → component
  dropped. Now accepts a member name in any case or a raw value, and raises
  `ValueError` naming the members on a miss.
- **`PrefabInstance.prefab_path`** was always the display `name`
  (`create_from_path` had the real path and discarded it). Now threaded
  through, `name` only as the in-memory fallback.
- **`ComponentRegistry.clear()`** wiped `_deserializers` (losing the
  built-in `Transform` special-case; `Transform` is not a dataclass, so a
  cleared registry couldn't round-trip it even re-registered) but not
  `_type_converters`. Now re-seeds the built-ins.
- **`PrefabLoader`** raised `AttributeError` from `raw.get()` on a
  non-mapping top-level document despite documenting `ValueError`. Now
  validates.
- Removed **`PrefabReference`** — exported in `__all__`, constructed and
  consumed nowhere.

## Tests

`test_prefab.py` had the recurring blind spot at full strength: every
`PrefabFactory` test hand-built `PrefabData` against a `Transform`+`Tag`-only
registry, and **not one test** went file → `PrefabLoader` → `PrefabFactory`.
`_create_children`, `create_from_path`, inheritance cycles, and
`PrefabInstance` had **zero** coverage; `test_create_warns_on_unknown_component`
asserted `... or entity is not None` (always true).

+17 hand-written tests (1799 → 1835 incl. `test_docs_api` parametrise
expansion): child crash regression + parent-link + follow + local-space
offset, inheritance-cycle `ValueError`, `create_from_path` path recording,
fail-loud on unknown field / bad enum value, enum any-case + raw value,
`clear()` still round-trips `Transform`, loader rejects non-mapping, and a
file → loader → factory round trip.

## Docs

The subsystem had **no doc page**. Added `docs/systems/prefabs.md` (layers,
registry conversion rules + fail-loud contract, `extends` + cycle behaviour,
child hierarchy semantics, `PrefabInstance` metadata, JSON schema), wired
into `mkdocs.yml` nav and `docs/index.md`, and corrected the loader row in
`docs/systems/resources.md`.

## Phase D

Capability gaps grouped into a follow-up issue (sibling of #37/#40/#43/#46):
spawn tables / weighted pools, dead `PrefabData.version` (no prefab-schema
migration), no named variant library, prefab children lack an entity-level
ownership/lifetime link (leak on parent destroy — needs an ECS-hierarchy
decision), no asset-ref validation at load. `ComponentRegistry` as a
process-global mutable singleton parked as a CC.

## Verification

`pytest` (1835), `ruff check .`, `ruff format --check`, `mypy pyguara` (226
files), `mkdocs build --strict`, `test_docs_api.py` (56) all pass. Both
commits verified independently in detached worktrees (`fix:` alone: 1833).

**PR is final — nothing else coming on this branch.** The Phase D issue and
its tracker row are the only follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5
