### PR TITLE
refactor(replay): fix the serializer data-loss path, record gamepad, make playback deterministic

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -79,9 +79,77 @@ how the subject is *constructed*, not just what is asserted.
 
 ## Active Subsystem
 
-**None — `pyguara/scripting` closed 2026-09-08 (branch `refactor/scripting-audit`).**
-Next in the queue is Tier 4: `pyguara/replay` (deterministic replay). Open
+**None — `pyguara/replay` closed 2026-09-08 (branch `refactor/replay-audit`).**
+Next in the queue is Tier 4: `pyguara/dev` (dev-only helpers). Open
 `REFACTOR_STATE.md` "How to resume" and take it.
+
+`pyguara/replay` in one slice, ~1,030 lines (`types`, `recorder`, `player`,
+`serializer`), wired via `Application` (`start_recording` / `stop_recording` /
+`save_recording` / `load_replay`) and `InputManager`
+(`attach_recorder` / `process_replayed_event`) since wayfinder ticket 18. The
+defects were all "declared and wired to nothing" or "guard that returns a wrong
+answer", and every one hid behind uniform test setup. **`ReplaySerializer.save()`
+wrote an unloadable file on its default call.** It only appended an extension
+when the path had none, but `if compress or endswith(".gz")` still gzipped —
+`save(data, "run.replay")` (and `compress=True` is the default) put a gzip
+stream in a `.replay` file, which `load()` reads as text, `json.loads` chokes on
+the magic byte, the blanket `except Exception` swallows it, `load()` returns
+`None`. `save()` had already returned `True`. Now the on-disk format is derived
+from the extension and an explicit one wins, so a gzip is never named `.replay`;
+`load()` also refuses a `metadata.version` above `SUPPORTED_VERSION` (it was
+written and never read — replay has no migration). **`get_metadata()` returned
+`None` for any replay over ~10 KB** — it read the first 10 KB and sliced at the
+last `}`, unbalanced JSON for a 400-frame file, while the metadata sat in the
+first ~120 bytes; now it parses the file and returns the block. **Gamepad input
+was never recorded** — `record_gamepad_button` / `record_gamepad_axis` had zero
+callers (gamepad flows through `GamepadManager` → `_on_gamepad_*`, which never
+touched the recorder), so a controller session recorded as empty input while
+`process_replayed_event` carried GAMEPAD branches for events recording never
+produced; both callbacks now feed the recorder. **Playback dropped pointer
+position and the raw UI stream** — `process_replayed_event` rebuilt only bound
+actions, discarding `event.position` and never re-emitting
+`OnRawKeyEvent` / `OnMouseEvent`, so menu clicks and pointer-aimed gameplay did
+not replay; it now re-dispatches the raw key/mouse stream with recorded position
+and modifiers (`RecordedInputEvent` gained a `modifiers` field) and replays
+MOUSE_MOVE. `ReplayRecorder` stamps the installed `pyguara` version (was
+hard-coded `"0.0.0"`) and a UTC `recorded_at` — the pair `pyguara/persistence`
+already fixed.
+
+Per the user's choice (maximal on all three forks): **playback now re-drives the
+loop from the recorded per-frame `delta_time`.** `Application.run()`, while a
+replay is playing, takes each frame's duration from `ReplayPlayer.peek_delta()`
+instead of the wall clock, so the fixed-step accumulator count, `_update()`
+deltas, tweens, particles and `WaitForSeconds` reproduce on any machine — before
+this, only discrete input→action chains replayed and anything time-dependent
+diverged. Touches the already-closed `pyguara/application` loop (cross-cutting;
+`SandboxApplication` inherits `run()`). The `ReplayPlayer` scrubbing surface
+(`update()` timestamp model, `seek_to_frame`, `pause`/`resume`, `playback_speed`)
+is kept as a supported public API for a caller driving its own loop, with
+`advance_frame()`/`update()` now sharing `_emit_frame()` / `_finish_if_exhausted()`
+instead of two copies. Tests +22 (1869 → 1891): the old 25 were broad but
+shallow and uniform — every player test drove one fixture through
+`advance_frame()` only (`update()` had zero coverage), every serializer test
+saved to an extensionless path (hiding the compress/extension bug), nothing
+recorded or replayed gamepad. New `docs/systems/replay.md` (the subsystem had no
+page). See the iteration log entry below.
+
+**Capability gaps (Phase D) → new issue** ("replay production layer", sibling of
+#37/#40/#43/#46/#51/#55; **needs `gh issue create`** — draft in the iteration
+log): the recorded `seed` is exposed as `ReplayPlayer.seed` but nothing reseeds
+a random source on playback (no engine RNG service yet — cross-cut #28); no
+replay-library API (`list_replays` / `delete` / browse, the shape #43 names for
+saves) and `FileStorage`-style user-data-dir rooting; the scrubbing API has no
+`pyguara/tools` overlay driving it (scrub bar / step / slow-mo — cross-cut #53);
+capture is input+time only, so a game reading `time.time()` / the filesystem /
+the network directly breaks determinism silently; `record_action()` (synthetic
+AI/script-driven actions) has a playback branch but no in-repo consumer.
+**Left open:** format `version` is validated but there is no migration layer;
+a length-framed metadata line would let `get_metadata` skip the frame bytes —
+both small parked adds.
+
+---
+
+### `pyguara/scripting` — closed 2026-09-08 (branch `refactor/scripting-audit`)
 
 `pyguara/scripting` in one slice, ~310 lines (`coroutines.py` — the whole
 subsystem). Unlike `editor`, it **is** wired in: the bootstrap registers a
@@ -642,7 +710,8 @@ Ordered roughly by dependency depth: foundations first, leaves last.
   panels rebuilt as `UIRenderer` tools *(done — branch `refactor/editor-audit`)*
 - [x] `pyguara/scripting` — coroutines, script hosting *(done — branch
   `refactor/scripting-audit`)*
-- [ ] `pyguara/replay` — deterministic replay
+- [x] `pyguara/replay` — deterministic replay *(done — branch
+  `refactor/replay-audit`)*
 - [ ] `pyguara/dev` — dev-only helpers
 - [ ] `pyguara/cli` — command line entry points
 - [ ] `pyguara/tools` — atlas/build tooling
@@ -653,6 +722,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/replay` | 2026-09-08 | One slice, ~1,030 lines (`types`, `recorder`, `player`, `serializer`); wired via `Application` + `InputManager` since wayfinder ticket 18. Defects were all "wired to nothing" / "guard returns a wrong answer", each hidden by uniform test setup. **`ReplaySerializer.save()` wrote an unloadable file on its default call** — it appended an extension only when absent, but `if compress or endswith(".gz")` still gzipped, so `save(data, "run.replay")` (default `compress=True`) put a gzip stream in a `.replay` file; `load()` reads it as text, `json.loads` chokes on the magic byte, the blanket `except Exception` swallows it, returns `None` after `save()` returned `True`. Now the format is derived from the extension (explicit wins); `load()` also refuses a `metadata.version` over `SUPPORTED_VERSION` (written, never read — no migration layer). **`get_metadata()` returned `None` for any replay over ~10 KB** — read first 10 KB, sliced at the last `}`, unbalanced JSON for a 400-frame file while the metadata sat in the first ~120 bytes; now parses the file. **Gamepad input was never recorded** — `record_gamepad_button` / `record_gamepad_axis` had zero callers (gamepad flows `GamepadManager` → `_on_gamepad_*`, never touching the recorder), so a controller session recorded empty while `process_replayed_event` carried GAMEPAD branches for events recording never produced; both callbacks now feed it. **Playback dropped pointer position + the raw UI stream** — `process_replayed_event` rebuilt only bound actions, discarding `event.position` and never re-emitting `OnRawKeyEvent` / `OnMouseEvent`; it now re-dispatches the raw key/mouse stream with recorded position + modifiers (`RecordedInputEvent` gained `modifiers`) and replays MOUSE_MOVE. `ReplayRecorder` stamps the installed package version (was `"0.0.0"`) + UTC `recorded_at` (the persistence pair). **User chose maximal on all three forks: playback now re-drives the loop from recorded per-frame `delta_time`** — `Application.run()`, while a replay plays, takes each frame's duration from `ReplayPlayer.peek_delta()` not the wall clock, so fixed-step count, tweens, particles and `WaitForSeconds` reproduce on any machine (cross-cuts the closed `pyguara/application` loop; `SandboxApplication` inherits `run()`). `ReplayPlayer`'s scrubbing surface (`update()` timestamp model, `seek`, `pause`/`resume`, `playback_speed`) kept as supported public API; `advance_frame()`/`update()` now share `_emit_frame()` / `_finish_if_exhausted()`. Tests +22 (1869 → 1891): the old 25 were broad but shallow + uniform (every player test = one fixture through `advance_frame()`; `update()` had zero coverage; every serializer test saved to an extensionless path; nothing recorded/replayed gamepad). New `docs/systems/replay.md` (no page existed). Phase D → **new issue** ("replay production layer", sibling of #37/#40/#43/#46/#51/#55; needs `gh issue create`, draft in the iteration log): recorded `seed` reseeds nothing on playback (no RNG service — #28); no replay-library API (`list_replays`/`delete`/browse, user-data-dir rooting — the #43 shape); the scrubbing API has no `pyguara/tools` overlay (#53); capture is input+time only (a game reading `time.time()`/filesystem/network directly breaks determinism silently); `record_action()` has a playback branch but no in-repo consumer. Left open: no format migration layer; a length-framed metadata line would let `get_metadata` skip frame bytes. |
 | `pyguara/scripting` | 2026-09-08 | One slice, ~310 lines (`coroutines.py` is the whole subsystem). Unlike `editor` it **is** wired in — bootstrap registers a `CoroutineManager` singleton, `Application._update()` ticks it every frame. Headline: **one scripted sequence that raised took down the frame loop and abandoned every other coroutine.** `Coroutine.update()` caught only `StopIteration`; any other exception from the generator body propagated through `CoroutineManager.update()`'s list comprehension out of `Application._update()`, and the comprehension `self._coroutines = [c for c in self._coroutines if c.update(dt)]` also skipped every coroutine ordered after the raiser and left stale entries on a re-raise. Fixed with the shared `ErrorHandlingStrategy` (as `EventDispatcher`/`DIContainer`): `CoroutineManager(error_strategy=RAISE)` default logs + stops + re-raises; `LOG`/`IGNORE` contain it; under all three the offender is stopped and dropped and siblings still run. **`Coroutine.stop()` abandoned the generator** — `finally`/`with` cleanup in a sequence only ran at GC; now `stop()` calls `generator.close()` (guarded by `gi_running` for the self-stop case). **`CoroutineManager.update()` corrupted its list when a coroutine started/stopped coroutines from inside its own body** (the comprehension iterated the list the body mutated — stopping an earlier sibling skipped a later one; `stop_all()` from a body left survivors); now iterates a frame-start snapshot and reconciles. Recurring shapes: "catch only the happy exception", "mutate the container you're iterating", "cleanup deferred to GC", and uniform test setup — all 30 existing tests built the coroutine from a benign `yield` body; none raised, stopped a sibling, or needed `finally`, which is exactly where the defects were. Tests +12 (1835 → 1847). `docs/systems/scripting.md` rewritten (was 39 lines: omitted `WaitWhile` from its concepts, non-runnable example, documented no wiring / lifecycle / error model / `stop()` semantics). Phase D → **#55** ("scripting production layer", sibling of #37/#40/#43/#46/#51): no scene scoping (a coroutine outlives its scene, no teardown hook), no coroutine tagging/grouping (kill entity → its scripted sequences keep running), no `yield from` result to a parent, no frame-count / fixed-step / scaled-time waits (time-scale is #28's). Left open: `WaitForSeconds` timing is frame-granular — yielding frame uncounted, overshoot discarded, so a long chain of short waits drifts by ~1 frame each (documented; sub-frame precision is not a goal of the variable-rate step). |
 | `pyguara/prefabs` | 2026-09-08 | One slice (`types`, `registry`, `loader`, `factory`; ~1,000 lines). Headline: **a prefab with `children` crashed on every real scene.** `PrefabFactory._create_children` called `parent_entity.get_component_by_name("Transform")` — a method that exists nowhere on `Entity` — so `factory.create()` raised `AttributeError` whenever a `prefab_resolver` was set, which `Scene.resolve_dependencies()` always does. Past the crash, the parent-link step was `for _child in children: pass` — children never attached despite `Transform` having a full `set_parent`/`children` API. **Zero `.prefab` files exist in the repo**, so the file→loader→factory→children path had never run. Per the user's choice (wire it properly, unify): children now instantiate as their own entities parented via `Transform.set_parent(keep_world_transform=False)` — authored position is local to the parent and follows it; `PrefabChild.offset` applies in local space. Dropped the dead loop and the `parent_position` bake (ignored parent rotation/scale). **BREAKING** (pre-alpha): `create()` loses `parent_position`, gains `source_path`. Also: **`_resolve_inheritance` had no cycle guard** (`A extends B extends A` → `RecursionError`) → now raises `ValueError` naming the chain. **`create()` swallowed component construction errors** in a blanket `except Exception`, yielding half-built entities → per the user's choice (fail loud) it now raises; `_instantiate_dataclass` also rejects unknown field keys (a typo used to vanish). **`_convert_value` enum handling was `EnumType[value.upper()]`** — non-SCREAMING_CASE members raised `KeyError` → swallowed → component dropped; now case-insensitive name or raw value, `ValueError` on a miss. **`PrefabInstance.prefab_path` was always the display `name`** (`create_from_path` had the real path and discarded it) → now threaded through, `name` only as the in-memory fallback. **`ComponentRegistry.clear()` wiped `_deserializers`** (losing the built-in `Transform` special-case; `Transform` is not a dataclass so a cleared registry couldn't round-trip it even re-registered) → now re-seeds built-ins. **`PrefabLoader` raised `AttributeError`** on a non-mapping top-level doc despite documenting `ValueError` → now validates. Removed **`PrefabReference`** (exported, used nowhere). Recurring shapes: "declared and wired to nothing" (`children` link-up, `PrefabReference`, `prefab_path`, `PrefabData.version`), "guard that holds a wrong answer" (swallowed errors, enum `.upper()`), uniform test setup (every factory test hand-built `PrefabData` against a `Transform`+`Tag`-only registry; `_create_children` / `create_from_path` / inheritance cycles / round-trip had **zero** coverage; `test_create_warns_on_unknown_component` asserted `... or entity is not None`). Tests +17 (1799 → 1835). New `docs/systems/prefabs.md` (no doc page existed). Phase D → **new issue** (sibling of #37/#40/#43/#46 + UI Phase-D): no spawn tables / weighted pools, `PrefabData.version` dead (no prefab-schema migration), no named variant library, prefab children lack an entity-level ownership/lifetime link (leak on parent destroy — needs an ECS-hierarchy decision), no asset-ref validation at load; `ComponentRegistry` process-global mutable singleton parked as a CC. |
 | `pyguara/ui` | 2026-09-08 | One slice (`base`, `layout`, `constraints`, `manager`, `theme`, `theme_presets`, `types`, `components/*`; ~1,900 lines). Two "declared and wired to nothing" headliners under 84 green tests. **The constraint layout system never ran** — `UIElement.apply_layout()` had no caller in the repo; `UIManager` had no layout pass; roots couldn't be constrained at all (`apply_layout` needs `self.parent`). Probe: `create_fill_constraints(margin=20)` under an 800×600 parent → child stays `Rect(0,0,10,10)` across three manager frames. So `constraints.py` (314 lines) + `element.padding` + every `create_*_constraints` helper were inert, though documented as "the heart of the UI system's power" with non-runnable examples. Per the user's choice (unify): `apply_layout()` → `UIElement.layout(available_rect, renderer)`; `UIManager` holds a screen `Rect` (seeded by `Application.set_screen_size()`, refreshed via a `WindowResizeEvent` subscription) and runs `layout()` over every root before render, **dirty-gated** (`add_element` / `set_screen_size` / new public `invalidate_layout()` arm it). Roots constrain against the screen; children against the parent's padding-aware content rect. `BoxContainer.layout()` folded into the same pass: resolves its own constraints first, honours `LayoutAlignment.STRETCH` (declared, no branch), skips hidden children in `render()`, recurses. **Theme was snapshotted per element at construction** (`self.theme = get_theme()` in `__init__`) so `set_theme()` re-skinned nothing already built (probe confirmed) — now `UIElement.theme` is a live property; `ProgressBar`/`Canvas`/`NavBar` defer their cached `Color`. **`ThemeConstants` `@dataclass(frozen=True)` decorated nothing** (`fields() == []`) — "All themes are immutable" was false, presets were mutable process-wide singletons; now a `__getattr__` hands back a fresh copy per access. Smaller: `Slider` rejects `max_val <= min_val` / non-positive width at construction; dead `UIElement.anchor` / `Label(anchor=)` param removed. Recurring shapes: "declared and wired to nothing" (`apply_layout`, `STRETCH`, `anchor`, fake `frozen`), "cached snapshot vs live lookup" (theme), uniform test setup (`test_ui_constraints.py`'s 513 lines only ever called `.apply()` on hand-built Rects; theme tests never built a `UIElement`). BREAKING (pre-alpha): `layout()` signature changed; four in-repo games had their now-redundant `container.layout(renderer)` call removed. Tests: new `test_ui_manager_layout.py` + rebuilt `test_ui_layout.py`. Phase D → new issue (sibling of #37/#40/#43/#46): `ShadowScheme`/`BorderScheme.radius`/`hover_overlay`/`press_overlay` consumed by no widget, no focus navigation, no scroll/clip container, no grid layout, no real text-input path (`TEXT_INPUT` declared/never dispatched), manual layout invalidation. |
@@ -695,6 +765,7 @@ Concerns that outgrew this file, or that need a decision rather than a fix:
 | [#51](https://github.com/Wedeueis/pyguara/issues/51) | Prefab authoring & production layer (from the `pyguara/prefabs` audit, Phase D) — no spawn tables / weighted prefab pools (`create` is one at a time, no selection primitive); `PrefabData.version` declared "for migration support" and read by nothing (no prefab-schema migration, while `persistence` has a `MigrationRegistry`); no named variant library (`overrides` is per-call only); prefab children are linked `Transform`↔`Transform` only — the child entity has no parent-*entity* back-reference or shared lifetime, so despawning an enemy leaks its prefab-attached child entities (needs an ECS-hierarchy decision, cross-cutting with `pyguara/ecs`); no asset-reference validation at load. `ComponentRegistry` process-global mutable singleton parked as a CC |
 | [#53](https://github.com/Wedeueis/pyguara/issues/53) | PyGuara Studio — companion authoring app (from the `pyguara/editor` audit, which deleted a Dear ImGui editor that had never executed and rebuilt its useful parts as `UIRenderer` tools). Level/scene editor, animation editor, agentic authoring harness (grow `tools/agent_view.py`), data-table editors. Needs the build-vs-ImGui architecture decision; the "grow `pyguara/ui`" path is #49's scope. Gated on #49 / #28. In-overlay small items (custom inspector-drawer hook, `TransformGizmo` selection wiring) parked for the `pyguara/tools` slice |
 | [#55](https://github.com/Wedeueis/pyguara/issues/55) | Scripting production layer (from the `pyguara/scripting` audit, Phase D) — `CoroutineManager` is one app-global singleton with no scene scoping (a sequence outlives its scene and ticks against unloaded entities; no teardown hook, unlike `SystemManager`); no coroutine tagging / grouping (kill an entity → its scripted sequences keep running, cross-cutting with #51); no `yield from` result / return value or completion signal to a parent sequence; no frame-count / fixed-step waits (`WaitForFrames`, `WaitForFixedUpdate`) and no scaled-vs-realtime wait for a paused game (time-scale is #28's). `WaitForSeconds` frame-granular drift and missing arg validation left open, documented |
+| #NN *(pending `gh issue create` — draft in the `pyguara/replay` iteration log)* | Replay production layer (from the `pyguara/replay` audit, Phase D) — recorded `seed` is exposed as `ReplayPlayer.seed` but nothing reseeds a random source on playback (no engine RNG service yet — cross-cut #28; replay should reseed it on `load_replay()`); no replay-library API (`list_replays` / `delete` / browse, the shape #43 names for saves) and `FileStorage`-style user-data-dir rooting; the `ReplayPlayer` scrubbing surface (`seek`, `pause`/`resume`, `playback_speed`, `update()`) has no `pyguara/tools` overlay driving it (scrub bar / step / slow-mo — cross-cut #53); capture is input+time only, so a game reading `time.time()` / the filesystem / the network directly breaks determinism silently; `record_action()` (synthetic AI/script-driven actions) has a playback branch but no in-repo consumer. Left open: format `version` validated but no migration layer; a length-framed metadata line would let `get_metadata` skip the frame bytes |
 
 ---
 
@@ -874,6 +945,182 @@ convert to explicit `is None` checks as each subsystem is audited.
 ---
 
 ## Iteration Log
+
+### `pyguara/replay` — CLOSED 2026-09-08 (branch `refactor/replay-audit`)
+
+One slice, ~1,030 lines: `pyguara/replay/{types,recorder,player,serializer}.py`.
+Every defect reproduced with a probe against the real code before any fix.
+
+**Branch base.** Cut from `main` after PR #56 (`refactor/scripting-audit`)
+merged. History: `feat(replay)` (05b28d9) built the subsystem in isolation;
+wayfinder ticket 18 (65c6c9e) wired it into `Application` + `InputManager`,
+explicitly scoping to discrete keyboard / mouse-button input only.
+
+**Three forks put to the user, all answered maximal:**
+- *Playback determinism scope* → **feed recorded dt on playback** (touch the
+  closed `pyguara/application` loop), not "input-macro replay + document".
+- *Dead `ReplayPlayer` surface* (`update()`, `seek`, `pause`, `playback_speed`)
+  → **keep as public API, add tests**, not delete.
+- *Mouse / UI replay fidelity* → **full raw-event re-dispatch**
+  (`OnRawKeyEvent` / `OnMouseEvent` with recorded position + modifiers,
+  MOUSE_MOVE replayed), not action-path-only.
+
+**Verification:** 1891 tests pass (up from 1869; +22 — the C4 determinism test
+plus a rebuilt `test_replay.py`, 25 → 46). `ruff check .` / `ruff format
+--check` / `mypy pyguara` clean across 222 files. All five commits verified in a
+detached worktree at each SHA (1868 → 1868 → 1868 → 1869 → 1891).
+
+**F1 — `ReplaySerializer.save()` wrote an unloadable file on its default call.**
+It only appended an extension when the path carried none, but the write branch
+was `if compress or str(file_path).endswith(".gz")`. So `save(data,
+"run.replay")` — and `compress=True` is the default — wrote a gzip stream into a
+file named `.replay`. `load()` doesn't see `.gz`, opens it as text, `json.loads`
+hits the gzip magic byte `\x1f`, the blanket `except Exception` swallows it, and
+`load()` returns `None`. `save()` had already returned `True`. Probe: first
+bytes `b'\x1f\x8b\x08\x08'`, `load()` → `None`. Fix: the on-disk format is
+derived from the extension — `.replay.gz` gzip, `.replay` plain, a bare path
+gets one per `compress` — and an explicit extension wins, so a gzip is never
+named `.replay`. `save()` now catches only `OSError` (a `to_dict()` / `dumps()`
+failure is a data-model bug and should surface). `load()` catches
+`OSError` / `BadGzipFile` / `JSONDecodeError` and refuses a `metadata.version`
+above `SUPPORTED_VERSION` — `FORMAT_VERSION` was written and never read, and
+replay has no migration layer.
+
+**F2 — `get_metadata()` returned `None` for any replay over ~10 KB.** It read
+the first 10 KB and parsed `content[:content.rfind("}")+1]` — unbalanced JSON
+for a file whose frames overflow 10 KB. Probe: 3 frames OK, 50 OK, **400 frames
+(54 KB) → `None`**, while the metadata sits in the first ~120 bytes. The one
+function built for "replay info without loading all frames" failed exactly on
+the replays big enough to matter. Now it parses the file and returns the
+`metadata` block (a length-framed leading line would let it skip the frame
+bytes — parked).
+
+**F3 — gamepad input was never recorded.** `ReplayRecorder.record_gamepad_button`
+/ `record_gamepad_axis` / `record_action` had **zero callers**.
+`InputManager.process_event` fed the recorder from the KEY_* and MOUSE_*
+branches, but gamepad input never goes through `process_event` — `GamepadManager`
+polls device state and fires `GamepadButtonEvent` / `GamepadAxisEvent`, handled
+by `_on_gamepad_button` / `_on_gamepad_axis`, which never touched the recorder.
+Probe: recorder attached, keyboard press + A-button press + left-stick axis in
+one frame → recorded events `[KEY_DOWN]` only. Meanwhile `process_replayed_event`
+carried GAMEPAD_* / AXIS / ACTION playback branches — consuming events recording
+could not produce. Fix: both gamepad callbacks now feed the recorder.
+
+**F4 — playback dropped pointer position and the raw UI event stream.**
+`process_replayed_event` for MOUSE_DOWN/UP called `_handle_input(MOUSE, code)`
+and ignored `event.position`; MOUSE_MOVE was explicitly dropped ("nothing to
+replay"); it never re-dispatched `OnRawKeyEvent` / `OnMouseEvent`. Probe: replay
+a MOUSE_DOWN at (123, 456) → no `OnMouseEvent` seen. So the UI layer (menu
+clicks, drag) and any pointer-aimed gameplay did not replay — only
+keyboard/mouse-button → bound-action chains did. Fix: `RecordedInputEvent` gains
+`modifiers` (held shift/ctrl/alt, round-tripped); `process_event` captures the
+modifier set once (factored into `_current_modifiers()`, shared with the
+existing `OnRawKeyEvent` path) and threads it into `record_key_*` /
+`record_mouse_*`; `process_replayed_event` re-dispatches the raw key/mouse
+stream with recorded position + modifiers and replays MOUSE_MOVE.
+
+**F5 — recorder stamps were placeholders.** `Application.start_recording` built
+`ReplayRecorder()` with no `engine_version`, so every replay recorded
+`engine_version="0.0.0"`; `recorded_at` used naive local `datetime.now()`. Now
+`ReplayRecorder._ENGINE_VERSION = version("pyguara")` (guarded by
+`PackageNotFoundError`) is the default, and `recorded_at` is UTC — the exact
+pair `pyguara/persistence` fixed.
+
+**Determinism — the headline design fix.** Playback fed events to the input
+manager on the right *frame*, but `Application.run()` still advanced its clock
+by wall-clock `frame_time`. So `_update(dt)`, the `_accumulator += frame_time`
+fixed-step count, tweens, particles and coroutine `WaitForSeconds` all ran at
+the *playback* machine's cadence. Only discrete input→action chains reproduced;
+physics, animation and timed waits diverged — the "deterministic replay" the
+subsystem is named for. Probe: a session recorded at a lumpy 33/33/10/25/16/...
+ms cadence, replayed on a "machine" ticking a steady 16 ms, saw `_update()`
+deltas of 16 ms throughout. Fix: `ReplayPlayer.peek_delta()` returns the
+`delta_time` of the frame `advance_frame()` will emit next; `run()`, while a
+replay is playing, takes `frame_time` from it instead of `clock.tick()`.
+Rendering still throttles to the display rate. Base `Application` only —
+`SandboxApplication` inherits `run()`. Cross-cutting: `pyguara/application`
+closed 2026-09-06; this reopens its loop for one guarded branch. New integration
+test (`test_playback_steps_the_loop_by_recorded_dt_not_wall_clock`) records 10
+frames at a lumpy cadence and asserts the first 10 playback `_update()` deltas
+are the recorded ones.
+
+**Player model reconciliation (kept, per the user's choice).**
+`ReplayPlayer` had two playback models: `advance_frame()` (one frame per call,
+what `Application` uses) and `update(dt)` (timestamp-based, honours
+`playback_speed`) — plus `seek_to_frame`, `pause`/`resume`, `get_frame_events`,
+`get_current_frame_data`, all with **zero external callers**. Rather than
+delete, they are now a supported public API for a caller driving its own
+playback loop (a replay-scrubbing dev overlay is the intended consumer → Phase D
+issue). `advance_frame()` and `update()` now share `_emit_frame()` (handler
+dispatch with per-handler exception isolation) and `_finish_if_exhausted()`
+(single "playback complete" log — `advance_frame()` used to log it twice).
+
+**Phase B — test verdict.** 25 tests, broad but shallow and uniformly set up.
+Every `TestReplayPlayer` test drove one `sample_replay` fixture through
+`advance_frame()` — `update()`, a whole playback model, had **zero coverage**,
+as did `get_metadata`, `playback_speed`, out-of-range `seek`, and the
+handler-raises path. Every `TestReplaySerializer` test saved to an
+**extensionless tempfile path**, which is exactly the shape that hid F1. Nothing
+recorded or replayed gamepad; no test round-tripped a pointer position or
+`modifiers` through `to_dict`/`from_dict`. `test_replay_wiring.py` (the
+load-bearing integration test) asserted only a dt-independent entity position.
+Rebuilt: position/modifier + origin-position dict round-trips; the serializer
+extension/compression contract + the `SUPPORTED_VERSION` gate + truncated-JSON;
+`get_metadata` on a 500-frame (>20 KB) replay, compressed, and missing; recorder
+engine-version / tz-aware stamp, the double-`start_recording` guard,
+between-frames drop, gamepad/modifier helpers; the `update()` timestamp model
+incl. `playback_speed`, `peek_delta()`, rejected seeks, handler isolation; and
+an `InputManager` wiring class (headless bootstrap) for gamepad capture and the
+replayed `OnMouseEvent` / `OnRawKeyEvent` stream. `test_replay.py` 25 → 46;
+`test_replay_wiring.py` +1.
+
+**Phase C.** No `docs/systems/replay.md` existed. New page: wiring (the
+`Application` surface — you never build `ReplayRecorder`/`ReplayPlayer`
+yourself), what is captured, an explicit **what reproduces / what does not**
+determinism section (RNG, `time.time()`, filesystem, floating-point, starting
+state), the file format, and the API surface incl. the two playback models.
+Every API on the page verified to exist. Linked from `mkdocs.yml` and
+`docs/index.md`.
+
+**Phase D — capability gaps → new issue** (needs `gh issue create`;
+`gh issue create` was blocked in-session). Draft:
+
+> **Title:** Replay production layer — RNG seeding, replay library API, in-game
+> scrubbing overlay
+>
+> From the `pyguara/replay` audit (Phase D). Sibling of
+> #37 / #40 / #43 / #46 / #51 / #55.
+> - **Seed is recorded, consumed by nothing.** `metadata.seed` is captured and
+>   exposed as `ReplayPlayer.seed`, but no random source is reseeded on
+>   playback — there is no engine RNG service yet. Cross-cut #28; replay should
+>   reseed it on `load_replay()`.
+> - **No replay-library API.** One save/load path + `get_metadata`; no
+>   `list_replays()` / `delete` / browse for a "watch a past run" menu (the gap
+>   #43 names for saves), and `FileStorage`-style user-data-dir rooting.
+> - **The `ReplayPlayer` scrubbing surface has no UI.** `seek_to_frame`,
+>   `pause`/`resume`, `playback_speed`, `get_frame_events` are supported and
+>   tested but nothing in `pyguara/tools` drives them — a replay-debug overlay
+>   (scrub bar, step, slow-mo) belongs with the dev-tool suite / #53.
+> - **Capture is input+time only.** A game reading `time.time()` /
+>   `datetime.now()` / the filesystem / the network directly is not captured
+>   and breaks determinism silently — needs at minimum a documented "don't",
+>   ideally an engine time service replay drives.
+> - **`record_action()` is unproven** — the path for synthetic
+>   AI/script-driven actions exists with a matching playback branch but no
+>   in-repo consumer.
+>
+> Left open: `version` is validated on load but there is no migration layer; a
+> length-framed metadata line would let `get_metadata` skip the frame bytes.
+
+**Recurring shapes this iteration:** "declared and wired to nothing"
+(`record_gamepad_*`, `FORMAT_VERSION`, the whole `update()`/`seek`/`pause`
+surface, `RecordedInputEvent` position on playback), "guard that returns a wrong
+answer" (`save()`'s compress/extension mismatch → silent data loss;
+`get_metadata`'s brace heuristic → `None`; both blanket `except Exception`),
+"placeholder stamp never filled in" (`engine_version`, `recorded_at` — the
+persistence pair, third sighting), and uniform test setup — every serializer
+test's extensionless path, every player test's single fixture through one of the
+two models.
 
 ### `pyguara/scripting` — CLOSED 2026-09-08 (branch `refactor/scripting-audit`)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ Essential engine features:
 *   **[Input System](systems/input.md)**: Action-based input mapping for Keyboard/Gamepad.
 *   **[Animation](systems/animation.md)**: Powerful tweening and easing system.
 *   **[Scripting](systems/scripting.md)**: Coroutine-based sequential logic.
+*   **[Replay](systems/replay.md)**: Deterministic input recording and playback.
 *   **[Resources](systems/resources.md)**: Caching and type-safe asset loading.
 *   **[Prefabs](systems/prefabs.md)**: Data-driven entity templates with inheritance and child hierarchies.
 *   **[Developer Tools](systems/editor.md)**: In-game debug overlay -- hierarchy, inspector, assets browser.

--- a/docs/systems/replay.md
+++ b/docs/systems/replay.md
@@ -1,0 +1,110 @@
+# Replay System
+
+`pyguara.replay` records the **input event stream** of a session frame by
+frame and plays it back, re-driving the game loop from the recorded frame
+timings. It is meant for bug repro, regression tests, and sharing a run.
+
+## Wiring
+
+`Application` owns the whole surface — you do not construct a `ReplayRecorder`
+or `ReplayPlayer` yourself:
+
+```python
+app = create_application()
+app.run(scene)                       # ... play normally ...
+
+seed = app.start_recording(seed=42, description="boss fight bug")
+# ... frames pass; every input event is captured ...
+data = app.stop_recording()          # -> ReplayData
+app.save_recording(data, "runs/boss")  # -> writes runs/boss.replay.gz
+```
+
+```python
+app = create_application()
+app.load_replay("runs/boss.replay.gz")   # starts playback immediately
+app.run(scene)                            # the replay drives input; real
+                                          # input is swallowed until it ends
+```
+
+Recording and playback are **mutually exclusive**: `start_recording()` while a
+replay is loaded, or `load_replay()` while recording, raises `RuntimeError`.
+
+Internally `Application` frames each recorder frame around `poll_events()`
+(`begin_frame` / `end_frame`), feeds `ReplayRecorder` from
+`InputManager.process_event` / the gamepad callbacks, and on playback pumps
+each recorded frame's events back through `InputManager.process_replayed_event`,
+which re-runs them through the *same* binding logic a live event takes.
+
+## What is captured
+
+Per frame: `frame_id`, `timestamp`, `delta_time`, and an ordered list of
+`RecordedInputEvent` — keyboard up/down (with held modifiers), mouse
+up/down/move (with position and modifiers), and gamepad buttons/axes.
+Session metadata: `seed`, `start_scene`, engine version, UTC `recorded_at`,
+duration, frame count, `description`.
+
+`ReplayRecorder.record_action()` also exists for a game that wants to record a
+*synthetic* high-level action directly (AI- or script-driven), replayed via the
+`ACTION` branch of `process_replayed_event`.
+
+## Determinism — what reproduces, what does not
+
+On playback `Application.run()` takes each frame's duration from the recording
+(`ReplayPlayer.peek_delta()`) instead of the wall clock, so the fixed-step
+accumulator count, `_update()` deltas, tweens, particles and
+`WaitForSeconds` all advance exactly as they did while recording, on any
+machine and at any render rate.
+
+Reproduces:
+
+- bound actions and the raw `OnRawKeyEvent` / `OnMouseEvent` stream (position
+  and modifiers included), so both gameplay and UI interactions replay;
+- everything downstream of those that is a pure function of input + time —
+  fixed-step physics, animation, coroutine waits, camera smoothing.
+
+Does **not** reproduce, today:
+
+- **RNG.** The `seed` is recorded and exposed as `ReplayPlayer.seed`, but
+  nothing reseeds a random source on playback — there is no engine RNG service
+  yet (tracked in the roguelike-core issue). A game that seeds its own RNG from
+  `player.seed` on load will replay; one that calls `random.*` on the global
+  module state will not.
+- Anything a game reads from outside the input+time envelope directly:
+  `time.time()` / `datetime.now()`, the filesystem, the network, thread
+  scheduling.
+- Floating-point results across different CPU/BLAS builds.
+- Starting state. The game must rebuild an identical initial world; the
+  regression test seeds both runs from one template `Entity` via
+  `Entity.clone()`.
+
+## File format
+
+JSON, gzip by default. The on-disk format follows the extension: `.replay.gz`
+is gzip, `.replay` is plain, a path with neither gets one appended per the
+`compress` argument. `ReplaySerializer.get_metadata(path)` returns just the
+`metadata` block for a save/replay menu. `load()` refuses a file whose
+`metadata.version` exceeds `ReplaySerializer.SUPPORTED_VERSION` — there is no
+migration layer.
+
+## API surface
+
+| Call | Purpose |
+| --- | --- |
+| `Application.start_recording(seed=None, description="")` | begin capture; returns the seed |
+| `Application.stop_recording()` | end capture; returns `ReplayData` |
+| `Application.save_recording(data, path, compress=True)` | write to disk |
+| `Application.load_replay(path)` | load and start playback |
+| `save_replay(data, path, compress=True)` / `load_replay(path)` | module-level serializer helpers |
+| `ReplaySerializer.get_metadata(path)` | read the metadata block only |
+
+`ReplayPlayer` exposes two playback models for a caller driving its own loop
+(the `Application` path uses the first):
+
+| Call | Model |
+| --- | --- |
+| `advance_frame()` + `peek_delta()` | one recorded frame per host frame; host steps its clock by the recorded delta |
+| `update(dt)` | wall-clock; consumes every frame whose `timestamp` has elapsed; honours `playback_speed` |
+
+Plus `seek_to_frame`, `pause_playback` / `resume_playback`, `progress`,
+`current_frame` / `total_frames`, `is_playing` / `is_paused` / `is_finished`,
+and `add_event_handler` for a callback per replayed event.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,5 +41,6 @@ nav:
       - Input: systems/input.md
       - Persistence: systems/persistence.md
       - Prefabs: systems/prefabs.md
+      - Replay: systems/replay.md
       - Resources: systems/resources.md
       - Scripting: systems/scripting.md

--- a/pyguara/application/application.py
+++ b/pyguara/application/application.py
@@ -128,7 +128,10 @@ class Application:
         Each frame measures its own duration, clamps it to
         `physics.max_frame_time`, accumulates it, and runs as many fixed-rate
         updates as that buys before rendering once. Physics therefore behaves
-        identically regardless of display framerate.
+        identically regardless of display framerate. While a replay loaded via
+        `load_replay()` is driving the game, each frame's duration is taken from
+        the recording instead, so a replay reproduces time-dependent state on
+        any machine.
 
         Dispatches `ApplicationStartEvent` before the first frame, and always
         calls `shutdown()` on the way out.
@@ -175,6 +178,16 @@ class Application:
                 # (when updates take longer than real time, causing ever-growing backlog)
                 if frame_time > max_frame_time:
                     frame_time = max_frame_time
+
+                # While a replay drives the game, step the simulation by the
+                # recorded per-frame delta instead of wall-clock time, so the
+                # fixed-step count, tweens, particles and WaitForSeconds
+                # reproduce. clock.tick() above still throttles rendering to the
+                # display rate.
+                if self._replay_player is not None and self._replay_player.is_playing:
+                    recorded_dt = self._replay_player.peek_delta()
+                    if recorded_dt is not None:
+                        frame_time = recorded_dt
 
                 # 2. Input (once per frame, before physics)
                 # Gamepad state must be fresh before poll_events() drains this

--- a/pyguara/input/manager.py
+++ b/pyguara/input/manager.py
@@ -30,6 +30,13 @@ from pyguara.replay.types import InputEventType, RecordedInputEvent
 logger = get_logger(__name__)
 
 
+def _replayed_position(event: RecordedInputEvent) -> tuple[int, int]:
+    """Return the recorded pointer position as ints, or (0, 0) if none was captured."""
+    if event.position is None:
+        return (0, 0)
+    return (int(event.position[0]), int(event.position[1]))
+
+
 class InputManager:
     """Translates Hardware Events (Keyboard/Mouse/Gamepad) into Actions."""
 
@@ -142,20 +149,47 @@ class InputManager:
     def process_replayed_event(self, event: RecordedInputEvent) -> None:
         """Feed a recorded input event through the same handling as a live one.
 
+        Drives both the bound-action path (`_handle_input`/`_handle_axis`) and
+        the raw `OnRawKeyEvent`/`OnMouseEvent` stream, with the recorded pointer
+        position and modifier keys, so a replay reproduces what the UI layer and
+        pointer-aimed game code saw -- not just the actions.
+
         Args:
             event: A single event from a loaded `ReplayData` frame.
         """
+        modifiers = set(event.modifiers)
         if event.event_type in (InputEventType.KEY_DOWN, InputEventType.KEY_UP):
-            self._handle_input(
-                InputDevice.KEYBOARD,
-                event.code,
-                is_down=event.event_type == InputEventType.KEY_DOWN,
+            is_down = event.event_type == InputEventType.KEY_DOWN
+            self._handle_input(InputDevice.KEYBOARD, event.code, is_down=is_down)
+            self._dispatcher.dispatch(
+                OnRawKeyEvent(
+                    key_code=event.code,
+                    is_down=is_down,
+                    modifiers=modifiers,
+                    source=self,
+                )
             )
         elif event.event_type in (InputEventType.MOUSE_DOWN, InputEventType.MOUSE_UP):
-            self._handle_input(
-                InputDevice.MOUSE,
-                event.code,
-                is_down=event.event_type == InputEventType.MOUSE_DOWN,
+            is_down = event.event_type == InputEventType.MOUSE_DOWN
+            self._handle_input(InputDevice.MOUSE, event.code, is_down=is_down)
+            self._dispatcher.dispatch(
+                OnMouseEvent(
+                    position=_replayed_position(event),
+                    button=event.code,
+                    is_down=is_down,
+                    is_motion=False,
+                    source=self,
+                )
+            )
+        elif event.event_type == InputEventType.MOUSE_MOVE:
+            self._dispatcher.dispatch(
+                OnMouseEvent(
+                    position=_replayed_position(event),
+                    button=0,
+                    is_down=False,
+                    is_motion=True,
+                    source=self,
+                )
             )
         elif event.event_type in (
             InputEventType.GAMEPAD_BUTTON_DOWN,
@@ -170,7 +204,6 @@ class InputManager:
             self._handle_axis(event.code, event.value)
         elif event.event_type == InputEventType.ACTION and event.action is not None:
             self._dispatch_action(event.action, event.value)
-        # MOUSE_MOVE has no bound-action equivalent today; nothing to replay.
 
     def update(self) -> None:
         """Update input state. Call this once per frame before processing events.
@@ -188,10 +221,14 @@ class InputManager:
         self._handle_input(
             InputDevice.GAMEPAD, event.button.value, is_down=event.is_pressed
         )
+        if self._recorder is not None and self._recorder.is_recording:
+            self._recorder.record_gamepad_button(event.button.value, event.is_pressed)
 
     def _on_gamepad_axis(self, event: GamepadAxisEvent) -> None:
         """Translate a GamepadManager axis-state change into bound Actions."""
         self._handle_axis(event.axis.value, event.value)
+        if self._recorder is not None and self._recorder.is_recording:
+            self._recorder.record_gamepad_axis(event.axis.value, event.value)
 
     def register_action(
         self, name: str, action_type: ActionType, deadzone: float = 0.1
@@ -229,27 +266,18 @@ class InputManager:
         # --- Keyboard ---
         if event.type in (pygame.KEYDOWN, pygame.KEYUP):
             is_down = event.type == pygame.KEYDOWN
+            modifiers = self._current_modifiers()
             self._handle_input(InputDevice.KEYBOARD, event.key, is_down=is_down)
 
             if self._recorder is not None and self._recorder.is_recording:
-                if is_down:
-                    self._recorder.record_key_down(event.key)
-                else:
-                    self._recorder.record_key_up(event.key)
+                record_key = (
+                    self._recorder.record_key_down
+                    if is_down
+                    else self._recorder.record_key_up
+                )
+                record_key(event.key, sorted(modifiers))
 
             # Dispatch raw key event for UI system
-            modifiers = set()
-            try:
-                mods = pygame.key.get_mods()
-                if mods & pygame.KMOD_SHIFT:
-                    modifiers.add(pygame.KMOD_SHIFT)
-                if mods & pygame.KMOD_CTRL:
-                    modifiers.add(pygame.KMOD_CTRL)
-                if mods & pygame.KMOD_ALT:
-                    modifiers.add(pygame.KMOD_ALT)
-            except pygame.error:
-                pass
-
             raw_key_event = OnRawKeyEvent(
                 key_code=event.key, is_down=is_down, modifiers=modifiers, source=self
             )
@@ -261,10 +289,12 @@ class InputManager:
             self._handle_input(InputDevice.MOUSE, event.button, is_down=is_down)
 
             if self._recorder is not None and self._recorder.is_recording:
-                if is_down:
-                    self._recorder.record_mouse_down(event.button, event.pos)
-                else:
-                    self._recorder.record_mouse_up(event.button, event.pos)
+                record_mouse = (
+                    self._recorder.record_mouse_down
+                    if is_down
+                    else self._recorder.record_mouse_up
+                )
+                record_mouse(event.button, event.pos, sorted(self._current_modifiers()))
 
             # Dispatch mouse event for UI system
             mouse_event = OnMouseEvent(
@@ -295,6 +325,22 @@ class InputManager:
         # per frame from Application.run() before poll_events()), and its
         # GamepadButtonEvent/GamepadAxisEvent drive bound Actions via
         # _on_gamepad_button()/_on_gamepad_axis() above.
+
+    @staticmethod
+    def _current_modifiers() -> set[int]:
+        """Return the held shift/ctrl/alt flags, empty if SDL video is down."""
+        modifiers: set[int] = set()
+        try:
+            mods = pygame.key.get_mods()
+        except pygame.error:
+            return modifiers
+        if mods & pygame.KMOD_SHIFT:
+            modifiers.add(pygame.KMOD_SHIFT)
+        if mods & pygame.KMOD_CTRL:
+            modifiers.add(pygame.KMOD_CTRL)
+        if mods & pygame.KMOD_ALT:
+            modifiers.add(pygame.KMOD_ALT)
+        return modifiers
 
     def _handle_input(self, device: InputDevice, code: int, is_down: bool) -> None:
         """Handle binary inputs (Buttons/Keys)."""

--- a/pyguara/replay/player.py
+++ b/pyguara/replay/player.py
@@ -210,25 +210,26 @@ class ReplayPlayer:
 
         return []
 
-    def advance_frame(self) -> InputFrame | None:
-        """Advance to the next frame and return its data.
+    def peek_delta(self) -> float | None:
+        """Return the ``delta_time`` of the frame :meth:`advance_frame` will emit next.
+
+        Lets a fixed-cadence host loop (``Application``) step its simulation by
+        the *recorded* frame duration during playback instead of wall-clock time,
+        so anything time-dependent -- the fixed-step accumulator, tweens,
+        ``WaitForSeconds`` -- reproduces.
 
         Returns:
-            The next frame, or None if at end or not playing.
+            The next frame's delta, or None if playback is not running or the
+            replay is exhausted.
         """
         if self._state != ReplayState.PLAYING or not self._data:
             return None
-
         if self._current_frame_index >= len(self._data.frames):
-            # End of replay
-            self._state = ReplayState.IDLE
-            logger.info("Replay playback complete")
             return None
+        return self._data.frames[self._current_frame_index].delta_time
 
-        frame = self._data.frames[self._current_frame_index]
-        self._current_frame_index += 1
-
-        # Dispatch events to handlers
+    def _emit_frame(self, frame: InputFrame) -> None:
+        """Dispatch one frame's events to every registered handler."""
         for event in frame.events:
             for handler in self._event_handlers:
                 try:
@@ -236,57 +237,65 @@ class ReplayPlayer:
                 except Exception as e:
                     logger.error(f"Event handler error: {e}")
 
-        # Check if we've reached the end
-        if self._current_frame_index >= len(self._data.frames):
+    def _finish_if_exhausted(self) -> None:
+        """Drop to IDLE once the last frame has been consumed."""
+        if self._data and self._current_frame_index >= len(self._data.frames):
+            if self._state != ReplayState.IDLE:
+                logger.info("Replay playback complete")
             self._state = ReplayState.IDLE
-            logger.info("Replay playback complete")
 
+    def advance_frame(self) -> InputFrame | None:
+        """Consume exactly one recorded frame and return it.
+
+        The frame-stepping playback model: one call per host frame, paired with
+        :meth:`peek_delta` so the host advances its clock by the recorded delta.
+
+        Returns:
+            The frame consumed, or None if at end or not playing.
+        """
+        if self._state != ReplayState.PLAYING or not self._data:
+            return None
+
+        if self._current_frame_index >= len(self._data.frames):
+            self._finish_if_exhausted()
+            return None
+
+        frame = self._data.frames[self._current_frame_index]
+        self._current_frame_index += 1
+        self._elapsed_time += frame.delta_time
+        self._emit_frame(frame)
+        self._finish_if_exhausted()
         return frame
 
     def update(self, delta_time: float) -> list[InputFrame]:
-        """Update playback based on elapsed time.
+        """Consume every frame whose timestamp has been reached this update.
 
-        This method should be called each game frame. It returns all frames
-        that should be processed based on the elapsed time.
+        The wall-clock playback model, for a host that drives the player from
+        its own variable-rate loop rather than one-frame-at-a-time. Honours
+        :attr:`playback_speed`. Shares event dispatch and end-of-replay handling
+        with :meth:`advance_frame`.
 
         Args:
-            delta_time: Time since last update in seconds.
+            delta_time: Time since the last update, in seconds.
 
         Returns:
-            List of frames to process this update.
+            The frames consumed this update, in order.
         """
         if self._state != ReplayState.PLAYING or not self._data:
             return []
 
-        # Apply playback speed
-        adjusted_dt = delta_time * self._playback_speed
-        self._elapsed_time += adjusted_dt
+        self._elapsed_time += delta_time * self._playback_speed
 
         frames_to_process: list[InputFrame] = []
-
-        # Process all frames up to current time
         while self._current_frame_index < len(self._data.frames):
             frame = self._data.frames[self._current_frame_index]
-
-            if frame.timestamp <= self._elapsed_time:
-                frames_to_process.append(frame)
-                self._current_frame_index += 1
-
-                # Dispatch events
-                for event in frame.events:
-                    for handler in self._event_handlers:
-                        try:
-                            handler(event)
-                        except Exception as e:
-                            logger.error(f"Event handler error: {e}")
-            else:
+            if frame.timestamp > self._elapsed_time:
                 break
+            frames_to_process.append(frame)
+            self._current_frame_index += 1
+            self._emit_frame(frame)
 
-        # Check if replay finished
-        if self._current_frame_index >= len(self._data.frames):
-            self._state = ReplayState.IDLE
-            logger.info("Replay playback complete")
-
+        self._finish_if_exhausted()
         return frames_to_process
 
     def get_current_frame_data(self) -> InputFrame | None:

--- a/pyguara/replay/recorder.py
+++ b/pyguara/replay/recorder.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 
 import random
 import time
-from datetime import datetime
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
 
 from pyguara.log import get_logger
 from pyguara.replay.types import (
@@ -44,13 +45,19 @@ class ReplayRecorder:
     # Current replay format version
     FORMAT_VERSION = 1
 
-    def __init__(self, engine_version: str = "0.0.0") -> None:
+    try:
+        _ENGINE_VERSION = version("pyguara")
+    except PackageNotFoundError:  # pragma: no cover - editable/source checkout
+        _ENGINE_VERSION = "0.0.0"
+
+    def __init__(self, engine_version: str | None = None) -> None:
         """Initialize the recorder.
 
         Args:
-            engine_version: Version string of the engine.
+            engine_version: Version string to stamp into the replay. Defaults to
+                the installed ``pyguara`` package version.
         """
-        self._engine_version = engine_version
+        self._engine_version = engine_version or self._ENGINE_VERSION
         self._state = ReplayState.IDLE
         self._data: ReplayData | None = None
         self._current_frame: InputFrame | None = None
@@ -111,7 +118,7 @@ class ReplayRecorder:
                 seed=self._seed,
                 start_scene=scene_name,
                 engine_version=self._engine_version,
-                recorded_at=datetime.now().isoformat(),
+                recorded_at=datetime.now(timezone.utc).isoformat(),  # noqa: UP017
                 description=description,
             )
         )

--- a/pyguara/replay/recorder.py
+++ b/pyguara/replay/recorder.py
@@ -198,11 +198,12 @@ class ReplayRecorder:
 
         self._current_frame.events.append(event)
 
-    def record_key_down(self, code: int) -> None:
+    def record_key_down(self, code: int, modifiers: list[int] | None = None) -> None:
         """Record a keyboard key press.
 
         Args:
             code: Key code.
+            modifiers: Held modifier key codes at the time of the press.
         """
         self.record_event(
             RecordedInputEvent(
@@ -210,14 +211,16 @@ class ReplayRecorder:
                 device="keyboard",
                 code=code,
                 value=1.0,
+                modifiers=list(modifiers or []),
             )
         )
 
-    def record_key_up(self, code: int) -> None:
+    def record_key_up(self, code: int, modifiers: list[int] | None = None) -> None:
         """Record a keyboard key release.
 
         Args:
             code: Key code.
+            modifiers: Held modifier key codes at the time of the release.
         """
         self.record_event(
             RecordedInputEvent(
@@ -225,15 +228,22 @@ class ReplayRecorder:
                 device="keyboard",
                 code=code,
                 value=0.0,
+                modifiers=list(modifiers or []),
             )
         )
 
-    def record_mouse_down(self, button: int, position: tuple[float, float]) -> None:
+    def record_mouse_down(
+        self,
+        button: int,
+        position: tuple[float, float],
+        modifiers: list[int] | None = None,
+    ) -> None:
         """Record a mouse button press.
 
         Args:
             button: Mouse button code.
             position: Mouse position at time of press.
+            modifiers: Held modifier key codes at the time of the press.
         """
         self.record_event(
             RecordedInputEvent(
@@ -242,15 +252,22 @@ class ReplayRecorder:
                 code=button,
                 value=1.0,
                 position=position,
+                modifiers=list(modifiers or []),
             )
         )
 
-    def record_mouse_up(self, button: int, position: tuple[float, float]) -> None:
+    def record_mouse_up(
+        self,
+        button: int,
+        position: tuple[float, float],
+        modifiers: list[int] | None = None,
+    ) -> None:
         """Record a mouse button release.
 
         Args:
             button: Mouse button code.
             position: Mouse position at time of release.
+            modifiers: Held modifier key codes at the time of the release.
         """
         self.record_event(
             RecordedInputEvent(
@@ -259,6 +276,7 @@ class ReplayRecorder:
                 code=button,
                 value=0.0,
                 position=position,
+                modifiers=list(modifiers or []),
             )
         )
 

--- a/pyguara/replay/serializer.py
+++ b/pyguara/replay/serializer.py
@@ -26,6 +26,10 @@ class ReplaySerializer:
     EXTENSION = ".replay"
     COMPRESSED_EXTENSION = ".replay.gz"
 
+    # Highest replay format version this serializer can read. Replay has no
+    # migration layer (unlike persistence): a newer file is refused, not upgraded.
+    SUPPORTED_VERSION = 1
+
     def save(
         self,
         replay_data: ReplayData,
@@ -34,45 +38,47 @@ class ReplaySerializer:
     ) -> bool:
         """Save replay data to a file.
 
+        The on-disk format always matches the file extension: a ``.replay.gz``
+        path is gzip, a ``.replay`` path is plain JSON, and a path with neither
+        gets one appended according to ``compress``. An explicit extension wins
+        over ``compress`` so the file is never a gzip stream named ``.replay``
+        (which :meth:`load` would then reject).
+
         Args:
             replay_data: The replay data to save.
             path: File path to save to.
-            compress: Whether to use gzip compression.
+            compress: Whether to gzip, when ``path`` carries no known extension.
 
         Returns:
             True if save successful.
         """
+        base = str(path)
+        if base.endswith(self.COMPRESSED_EXTENSION):
+            file_path, compress = Path(base), True
+        elif base.endswith(self.EXTENSION):
+            file_path, compress = Path(base), False
+        else:
+            suffix = self.COMPRESSED_EXTENSION if compress else self.EXTENSION
+            file_path = Path(base + suffix)
+
+        # to_dict() / json.dumps() failures are programmer errors in the data
+        # model, not runtime conditions -- let them raise. Only I/O is caught.
+        data = replay_data.to_dict()
+        json_str = json.dumps(data, separators=(",", ":"))
+
         try:
-            file_path = Path(path)
-
-            # Add extension if not present
-            if not str(path).endswith((self.EXTENSION, self.COMPRESSED_EXTENSION)):
-                if compress:
-                    file_path = Path(str(path) + self.COMPRESSED_EXTENSION)
-                else:
-                    file_path = Path(str(path) + self.EXTENSION)
-
-            # Convert to dict
-            data = replay_data.to_dict()
-
-            # Serialize to JSON
-            json_str = json.dumps(data, separators=(",", ":"))
-
-            if compress or str(file_path).endswith(".gz"):
-                # Write compressed
+            if compress:
                 with gzip.open(file_path, "wt", encoding="utf-8") as f:
                     f.write(json_str)
             else:
-                # Write uncompressed
                 with open(file_path, "w", encoding="utf-8") as f:
                     f.write(json_str)
-
-            logger.info(f"Saved replay to {file_path}")
-            return True
-
-        except Exception as e:
+        except OSError as e:
             logger.error(f"Failed to save replay: {e}")
             return False
+
+        logger.info(f"Saved replay to {file_path}")
+        return True
 
     def load(self, path: str) -> ReplayData | None:
         """Load replay data from a file.
@@ -101,6 +107,17 @@ class ReplaySerializer:
             # Parse JSON
             data = json.loads(json_str)
 
+            raw_meta = data.get("metadata") if isinstance(data, dict) else None
+            file_version = (
+                raw_meta.get("version", 1) if isinstance(raw_meta, dict) else 1
+            )
+            if file_version > self.SUPPORTED_VERSION:
+                logger.error(
+                    f"Replay format v{file_version} in {file_path} is newer than "
+                    f"the supported v{self.SUPPORTED_VERSION}; cannot load"
+                )
+                return None
+
             # Convert to ReplayData
             replay_data = ReplayData.from_dict(data)
 
@@ -113,20 +130,24 @@ class ReplaySerializer:
         except json.JSONDecodeError as e:
             logger.error(f"Invalid replay file format: {e}")
             return None
-        except Exception as e:
+        except (OSError, gzip.BadGzipFile) as e:
             logger.error(f"Failed to load replay: {e}")
             return None
 
     def get_metadata(self, path: str) -> dict | None:
-        """Load only the metadata from a replay file.
+        """Read just the metadata block from a replay file.
 
-        Useful for displaying replay info without loading all frames.
+        Parses the file but returns only ``metadata`` -- for a save/replay menu
+        that needs seed, scene, duration and frame count without building every
+        :class:`~pyguara.replay.types.InputFrame`. (A leading length-framed
+        metadata line would let this skip the frame bytes entirely; that is a
+        possible future format change, tracked in the audit notes.)
 
         Args:
             path: File path to load from.
 
         Returns:
-            Metadata dictionary, or None if load failed.
+            Metadata dictionary, or None if the file is missing or unreadable.
         """
         try:
             file_path = Path(path)
@@ -134,25 +155,18 @@ class ReplaySerializer:
             if not file_path.exists():
                 return None
 
-            # Read file
             if str(file_path).endswith(".gz"):
                 with gzip.open(file_path, "rt", encoding="utf-8") as f:
-                    # Read just enough for metadata
-                    content = f.read(10000)  # First 10KB should have metadata
+                    json_str = f.read()
             else:
                 with open(file_path, encoding="utf-8") as f:
-                    content = f.read(10000)
+                    json_str = f.read()
 
-            # Try to parse just the metadata
-            # This is a simple heuristic - full parsing would be more robust
-            data = json.loads(
-                content[: content.rfind("}") + 1] if "frames" in content else content
-            )
+            data = json.loads(json_str)
+            metadata: Any = data.get("metadata") if isinstance(data, dict) else None
+            return metadata if isinstance(metadata, dict) else None
 
-            metadata: dict[str, Any] = data.get("metadata", {})
-            return metadata
-
-        except Exception as e:
+        except (OSError, json.JSONDecodeError, gzip.BadGzipFile) as e:
             logger.error(f"Failed to read replay metadata: {e}")
             return None
 

--- a/pyguara/replay/types.py
+++ b/pyguara/replay/types.py
@@ -36,6 +36,8 @@ class RecordedInputEvent:
         value: Event value (1.0 for press, 0.0 for release, or axis value).
         action: Optional action name if this is an action event.
         position: Optional mouse position for mouse events.
+        modifiers: Held modifier key codes (shift/ctrl/alt) at event time, for
+            keyboard and mouse events. Empty for other devices.
     """
 
     event_type: InputEventType
@@ -44,6 +46,7 @@ class RecordedInputEvent:
     value: float = 1.0
     action: str | None = None
     position: tuple[float, float] | None = None
+    modifiers: list[int] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to serializable dictionary."""
@@ -53,17 +56,19 @@ class RecordedInputEvent:
             "code": self.code,
             "value": self.value,
         }
-        if self.action:
+        if self.action is not None:
             data["action"] = self.action
-        if self.position:
+        if self.position is not None:
             data["position"] = list(self.position)
+        if self.modifiers:
+            data["modifiers"] = list(self.modifiers)
         return data
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RecordedInputEvent:
         """Create from dictionary."""
         position = None
-        if "position" in data:
+        if data.get("position") is not None:
             position = tuple(data["position"])
         return cls(
             event_type=InputEventType[data["event_type"]],
@@ -72,6 +77,7 @@ class RecordedInputEvent:
             value=data.get("value", 1.0),
             action=data.get("action"),
             position=position,
+            modifiers=list(data.get("modifiers", [])),
         )
 
 

--- a/tests/integration/test_replay_wiring.py
+++ b/tests/integration/test_replay_wiring.py
@@ -87,6 +87,74 @@ def _quit_pygame():
     pygame.quit()
 
 
+class _FakeClock:
+    """Stand-in for `pygame.time.Clock` whose `tick()` returns a scripted ms."""
+
+    def __init__(self, ms_sequence: list[int]) -> None:
+        self._it = iter(ms_sequence)
+
+    def tick(self, _fps: float = 0.0) -> int:
+        return next(self._it, 16)
+
+
+def _run_frames(app: Application, scene: BootScene, n: int) -> None:
+    """Drive `app.run()` for exactly `n` frames by stopping it from `_render`."""
+    remaining = n
+    real_render = app._render
+
+    def render_then_maybe_stop() -> None:
+        nonlocal remaining
+        real_render()
+        remaining -= 1
+        if remaining <= 0:
+            app._is_running = False
+
+    app._render = render_then_maybe_stop  # type: ignore[method-assign]
+    app.run(scene)
+
+
+def test_playback_steps_the_loop_by_recorded_dt_not_wall_clock(tmp_path):
+    # Record at a lumpy, machine-specific frame cadence...
+    record_ms = [33, 33, 10, 25, 16, 16, 16, 20, 8, 20]
+    # ...then play back on a "machine" running at a steady, different one.
+    playback_ms = [16] * 40
+
+    record_app = create_application()
+    scene = _boot(record_app)
+    record_app._window.poll_events = _make_poll_events(_scripted_frames())
+    record_app._clock = _FakeClock(record_ms)  # type: ignore[assignment]
+    record_app.start_recording(seed=7)
+    _run_frames(record_app, scene, len(record_ms))
+    replay_data = record_app.stop_recording()
+    assert replay_data is not None
+    recorded_dts = [round(f.delta_time, 6) for f in replay_data.frames]
+    assert recorded_dts == [round(ms / 1000.0, 6) for ms in record_ms]
+    replay_path = str(tmp_path / "cadence.replay.gz")
+    assert record_app.save_recording(replay_data, replay_path)
+    record_app.shutdown()
+
+    playback_app = create_application()
+    scene = _boot(playback_app)
+    seen_dts: list[float] = []
+    real_update = playback_app._update
+
+    def capture_update(dt: float) -> None:
+        seen_dts.append(round(dt, 6))
+        real_update(dt)
+
+    playback_app._update = capture_update  # type: ignore[method-assign]
+    playback_app._window.poll_events = _make_poll_events([[] for _ in playback_ms])
+    playback_app._clock = _FakeClock(playback_ms)  # type: ignore[assignment]
+    assert playback_app.load_replay(replay_path)
+    _run_frames(playback_app, scene, len(record_ms) + 5)
+    playback_app.shutdown()
+
+    # The first N _update() calls ran on the recorded deltas, not the 16 ms
+    # wall-clock cadence this "machine" was ticking at.
+    assert seen_dts[: len(recorded_dts)] == recorded_dts
+    assert playback_app._replay_player is None  # finished on schedule
+
+
 def test_recorded_session_replays_to_the_same_entity_state(tmp_path):
     template = Entity("template")
     template.add_component(Transform(position=Vector2(0.0, 0.0)))

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,7 +1,13 @@
 """Tests for the replay system."""
 
+import gzip
+import os
 import tempfile
+from datetime import datetime
 from pathlib import Path
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
 
 import pytest
 
@@ -438,3 +444,288 @@ class TestDeterminism:
         assert playback_events[0].event_type == InputEventType.KEY_DOWN
         assert playback_events[1].event_type == InputEventType.ACTION
         assert playback_events[2].event_type == InputEventType.KEY_UP
+
+
+class TestEventDictRoundtrip:
+    """to_dict/from_dict for the fields the old suite never exercised."""
+
+    def test_position_and_modifiers_survive_a_roundtrip(self):
+        event = RecordedInputEvent(
+            event_type=InputEventType.MOUSE_DOWN,
+            device="mouse",
+            code=1,
+            position=(10.0, 20.0),
+            modifiers=[1, 64],
+        )
+        restored = RecordedInputEvent.from_dict(event.to_dict())
+        assert restored.position == (10.0, 20.0)
+        assert restored.modifiers == [1, 64]
+
+    def test_origin_position_is_not_dropped_as_falsy(self):
+        # (0.0, 0.0) is a real recorded position, not "no position".
+        event = RecordedInputEvent(
+            event_type=InputEventType.MOUSE_MOVE,
+            device="mouse",
+            code=0,
+            position=(0.0, 0.0),
+        )
+        assert RecordedInputEvent.from_dict(event.to_dict()).position == (0.0, 0.0)
+
+    def test_missing_optional_fields_default_cleanly(self):
+        event = RecordedInputEvent.from_dict(
+            {"event_type": "KEY_DOWN", "device": "keyboard", "code": 32}
+        )
+        assert event.position is None
+        assert event.modifiers == []
+
+
+class TestSerializerFormat:
+    """The extension/compression contract and version gate (uniform-setup gaps)."""
+
+    @pytest.fixture
+    def replay(self):
+        return ReplayData(
+            metadata=ReplayMetadata(version=1, seed=5, frame_count=2),
+            frames=[InputFrame(i, i * 0.016, 0.016, []) for i in range(2)],
+        )
+
+    def test_compress_true_to_an_explicit_replay_path_stays_loadable(
+        self, replay, tmp_path
+    ):
+        # The old suite only ever saved to an extensionless path, so this
+        # (the default compress=True + a caller-supplied ".replay") slipped
+        # through as a gzip stream named ".replay" that load() then rejected.
+        path = str(tmp_path / "run.replay")
+        assert ReplaySerializer().save(replay, path, compress=True)
+        assert Path(path).read_bytes()[:1] == b"{"  # plain JSON, not gzip magic
+        assert ReplaySerializer().load(path) is not None
+
+    def test_gz_extension_forces_compression_even_with_compress_false(
+        self, replay, tmp_path
+    ):
+        path = str(tmp_path / "run.replay.gz")
+        assert ReplaySerializer().save(replay, path, compress=False)
+        with gzip.open(path, "rt", encoding="utf-8") as f:
+            assert f.read().startswith("{")
+
+    def test_load_refuses_a_newer_format_version(self, replay, tmp_path):
+        replay.metadata.version = ReplaySerializer.SUPPORTED_VERSION + 1
+        path = str(tmp_path / "future")
+        ReplaySerializer().save(replay, path, compress=False)
+        assert ReplaySerializer().load(path + ".replay") is None
+
+    def test_load_of_truncated_json_returns_none(self, tmp_path):
+        path = tmp_path / "broken.replay"
+        path.write_text('{"metadata": {"seed": 1}, "frames": [')
+        assert ReplaySerializer().load(str(path)) is None
+
+    def test_get_metadata_reads_a_large_multiframe_replay(self, tmp_path):
+        big = ReplayData(
+            metadata=ReplayMetadata(
+                version=1, seed=4242, start_scene="lvl", frame_count=500
+            ),
+            frames=[
+                InputFrame(
+                    i,
+                    i * 0.016,
+                    0.016,
+                    [
+                        RecordedInputEvent(
+                            InputEventType.KEY_DOWN, "keyboard", 32 + (i % 20)
+                        )
+                    ],
+                )
+                for i in range(500)
+            ],
+        )
+        path = str(tmp_path / "big")
+        ReplaySerializer().save(big, path, compress=False)
+        assert Path(path + ".replay").stat().st_size > 20_000
+        meta = ReplaySerializer().get_metadata(path + ".replay")
+        assert meta is not None and meta["seed"] == 4242
+
+    def test_get_metadata_on_compressed_and_missing(self, replay, tmp_path):
+        path = str(tmp_path / "c")
+        ReplaySerializer().save(replay, path, compress=True)
+        assert ReplaySerializer().get_metadata(path + ".replay.gz")["seed"] == 5
+        assert ReplaySerializer().get_metadata(str(tmp_path / "nope.replay")) is None
+
+
+class TestRecorderMetadata:
+    """Recorder stamps and the recording-state guards."""
+
+    def test_engine_version_is_the_package_version_not_a_placeholder(self):
+        recorder = ReplayRecorder()
+        recorder.start_recording(seed=1)
+        data = recorder.stop_recording()
+        assert data.metadata.engine_version != "0.0.0"
+        assert data.metadata.engine_version == ReplayRecorder._ENGINE_VERSION
+
+    def test_recorded_at_is_timezone_aware_iso(self):
+        recorder = ReplayRecorder()
+        recorder.start_recording(seed=1)
+        stamp = recorder.stop_recording().metadata.recorded_at
+        assert datetime.fromisoformat(stamp).tzinfo is not None
+
+    def test_double_start_recording_raises(self):
+        recorder = ReplayRecorder()
+        recorder.start_recording(seed=1)
+        with pytest.raises(RuntimeError):
+            recorder.start_recording(seed=2)
+
+    def test_event_recorded_between_frames_is_dropped(self):
+        recorder = ReplayRecorder()
+        recorder.start_recording(seed=1)
+        recorder.record_key_down(32)  # no begin_frame -> nowhere to go
+        recorder.begin_frame(0, 0.0, 0.016)
+        recorder.record_key_up(32)
+        recorder.end_frame()
+        data = recorder.stop_recording()
+        assert [e.event_type for e in data.frames[0].events] == [InputEventType.KEY_UP]
+
+    def test_gamepad_and_modifier_helpers_record_what_they_are_given(self):
+        recorder = ReplayRecorder()
+        recorder.start_recording(seed=1)
+        recorder.begin_frame(0, 0.0, 0.016)
+        recorder.record_key_down(32, modifiers=[1])
+        recorder.record_gamepad_button(3, pressed=True)
+        recorder.record_gamepad_axis(1, 0.75)
+        recorder.end_frame()
+        events = recorder.stop_recording().frames[0].events
+        assert events[0].modifiers == [1]
+        assert events[1].event_type == InputEventType.GAMEPAD_BUTTON_DOWN
+        assert events[2].event_type == InputEventType.GAMEPAD_AXIS
+        assert events[2].value == 0.75
+
+
+class TestReplayPlayerTimeline:
+    """The wall-clock update() model and peek_delta() -- untested before."""
+
+    def _replay(self):
+        return ReplayData(
+            metadata=ReplayMetadata(seed=1, frame_count=3),
+            frames=[
+                InputFrame(
+                    0,
+                    0.0,
+                    0.1,
+                    [RecordedInputEvent(InputEventType.KEY_DOWN, "keyboard", 1)],
+                ),
+                InputFrame(1, 0.1, 0.1, []),
+                InputFrame(
+                    2,
+                    0.2,
+                    0.1,
+                    [RecordedInputEvent(InputEventType.KEY_UP, "keyboard", 1)],
+                ),
+            ],
+        )
+
+    def test_update_consumes_frames_as_elapsed_time_crosses_their_timestamp(self):
+        player = ReplayPlayer(self._replay())
+        player.start_playback()
+
+        assert [f.frame_id for f in player.update(0.05)] == [0]  # only ts<=0.05
+        assert [f.frame_id for f in player.update(0.10)] == [1]  # elapsed 0.15
+        assert [f.frame_id for f in player.update(0.10)] == [2]  # elapsed 0.25
+        assert player.is_finished()
+        assert not player.is_playing
+
+    def test_update_respects_playback_speed(self):
+        player = ReplayPlayer(self._replay())
+        player.playback_speed = 4.0
+        player.start_playback()
+        # 0.05 real * 4 = 0.20 elapsed -> frames 0,1,2 all due at once.
+        assert [f.frame_id for f in player.update(0.05)] == [0, 1, 2]
+
+    def test_peek_delta_reports_the_next_frame_then_none_at_end(self):
+        player = ReplayPlayer(self._replay())
+        assert player.peek_delta() is None  # not playing yet
+        player.start_playback()
+        assert player.peek_delta() == pytest.approx(0.1)
+        while player.advance_frame() is not None:
+            pass
+        assert player.peek_delta() is None
+
+    def test_seek_out_of_range_is_rejected_without_moving(self):
+        player = ReplayPlayer(self._replay())
+        player.start_playback()
+        player.advance_frame()
+        assert player.seek_to_frame(99) is False
+        assert player.seek_to_frame(-1) is False
+        assert player.current_frame == 1
+
+    def test_a_raising_event_handler_does_not_stop_playback(self):
+        player = ReplayPlayer(self._replay())
+        seen = []
+        player.add_event_handler(lambda _e: (_ for _ in ()).throw(RuntimeError("boom")))
+        player.add_event_handler(seen.append)
+        player.start_playback()
+        while not player.is_finished():
+            player.advance_frame()
+        assert len(seen) == 2  # both KEY_DOWN and KEY_UP still reached handler 2
+
+
+class TestReplayInputWiring:
+    """Recorder <-> InputManager: gamepad capture and full raw-stream replay."""
+
+    @pytest.fixture
+    def app(self):
+        from pyguara.application.bootstrap import create_headless_application
+
+        application = create_headless_application()
+        yield application
+        application.shutdown()
+
+    def test_gamepad_button_and_axis_are_captured_when_recording(self, app):
+        from pyguara.input.events import GamepadAxisEvent, GamepadButtonEvent
+        from pyguara.input.gamepad import GamepadAxis, GamepadButton
+
+        recorder = ReplayRecorder()
+        recorder.start_recording(seed=1)
+        app._input_manager.attach_recorder(recorder)
+        recorder.begin_frame(0, 0.0, 0.016)
+        app._input_manager._on_gamepad_button(
+            GamepadButtonEvent(controller_id=0, button=GamepadButton.A, is_pressed=True)
+        )
+        app._input_manager._on_gamepad_axis(
+            GamepadAxisEvent(controller_id=0, axis=GamepadAxis.LEFT_STICK_X, value=0.8)
+        )
+        recorder.end_frame()
+        events = recorder.stop_recording().frames[0].events
+        assert [e.device for e in events] == ["gamepad", "gamepad"]
+        assert events[0].event_type == InputEventType.GAMEPAD_BUTTON_DOWN
+        assert events[1].event_type == InputEventType.GAMEPAD_AXIS
+        assert events[1].value == pytest.approx(0.8)
+
+    def test_replayed_mouse_event_restores_position_and_dispatches_onmouse(self, app):
+        from pyguara.input.events import OnMouseEvent
+
+        seen: list[OnMouseEvent] = []
+        app._event_dispatcher.subscribe(OnMouseEvent, seen.append)
+        app._input_manager.process_replayed_event(
+            RecordedInputEvent(
+                InputEventType.MOUSE_DOWN, "mouse", 1, 1.0, position=(320.0, 240.0)
+            )
+        )
+        app._input_manager.process_replayed_event(
+            RecordedInputEvent(
+                InputEventType.MOUSE_MOVE, "mouse", 0, 0.0, position=(5.0, 6.0)
+            )
+        )
+        assert seen[0].position == (320, 240) and seen[0].is_down
+        assert seen[1].position == (5, 6) and seen[1].is_motion
+
+    def test_replayed_key_event_carries_modifiers_on_onrawkey(self, app):
+        from pyguara.input.events import OnRawKeyEvent
+
+        seen: list[OnRawKeyEvent] = []
+        app._event_dispatcher.subscribe(OnRawKeyEvent, seen.append)
+        app._input_manager.process_replayed_event(
+            RecordedInputEvent(
+                InputEventType.KEY_DOWN, "keyboard", 97, 1.0, modifiers=[64]
+            )
+        )
+        assert seen[0].key_code == 97
+        assert seen[0].is_down
+        assert 64 in seen[0].modifiers


### PR DESCRIPTION
Subsystem audit — `pyguara/replay` (Tier 4). Every defect was probe-reproduced
against the real code before any fix. Full write-up in `REFACTOR_STATE.md`
(Completed table + iteration log).

## Defects fixed

- **`ReplaySerializer.save()` wrote an unloadable file on its default call.**
  It appended an extension only when the path had none, but the write branch
  was `if compress or endswith(".gz")` — `save(data, "run.replay")` (and
  `compress=True` is the default) put a gzip stream in a `.replay` file, which
  `load()` reads as text; `json.loads` chokes on the magic byte, the blanket
  `except Exception` swallows it, `load()` returns `None` after `save()`
  returned `True`. Now the on-disk format is derived from the extension and an
  explicit one wins; `load()` also refuses a `metadata.version` above
  `SUPPORTED_VERSION` (written, never read — replay has no migration).
- **`get_metadata()` returned `None` for any replay over ~10 KB** — it read
  10 KB and sliced at the last `}`. Now parses the file.
- **Gamepad input was never recorded** — `record_gamepad_button` /
  `record_gamepad_axis` had zero callers; gamepad flows through
  `GamepadManager` → `_on_gamepad_*`, which never touched the recorder. Both
  callbacks now feed it.
- **Playback dropped pointer position and the raw UI stream** —
  `process_replayed_event` rebuilt only bound actions. It now re-dispatches
  `OnRawKeyEvent` / `OnMouseEvent` with recorded position + modifiers
  (`RecordedInputEvent` gained `modifiers`) and replays MOUSE_MOVE.
- `ReplayRecorder` stamps the installed package version (was `"0.0.0"`) and a
  UTC `recorded_at` — the pair `pyguara/persistence` fixed.

## Design change (user-chosen, maximal on all three forks)

- **Playback now re-drives the loop from the recorded per-frame `delta_time`.**
  `Application.run()`, while a replay is playing, takes each frame's duration
  from `ReplayPlayer.peek_delta()` instead of the wall clock, so the
  fixed-step count, `_update()` deltas, tweens, particles and `WaitForSeconds`
  reproduce on any machine. Before this, only discrete input→action chains
  replayed. **Cross-cutting:** touches the already-closed `pyguara/application`
  loop for one guarded branch; `SandboxApplication` inherits `run()`.
- `ReplayPlayer`'s scrubbing surface (`update()`, `seek_to_frame`,
  `pause`/`resume`, `playback_speed`) kept as supported public API;
  `advance_frame()`/`update()` now share `_emit_frame()` /
  `_finish_if_exhausted()`.

## Tests

25 → 46 in `test_replay.py` + 1 determinism integration test. Phase B verdict
(the old suite was broad but shallow and uniformly set up — every serializer
test's extensionless path hid the data-loss bug; `ReplayPlayer.update()` had
zero coverage; nothing recorded gamepad) in the iteration log.

## Docs

New `docs/systems/replay.md` (the subsystem had no page), linked from
`mkdocs.yml` + `docs/index.md`.

## Phase D

A "replay production layer" follow-up issue is drafted in the iteration log —
`gh issue create` was blocked in-session, so it still needs creating (RNG
seeding on `load_replay`, a replay-library API, a `pyguara/tools` scrubbing
overlay, the input+time-only capture boundary).

## Verification

`pytest` (1893) / `ruff check .` / `ruff format --check` / `mypy pyguara` all
clean. Each of the 6 commits verified in a detached worktree at its SHA
(1868 → 1868 → 1868 → 1869 → 1891 → 1893).

Independent branch, cut from `main` after #56 merged. **PR is final — nothing
else coming.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5