### PR TITLE
refactor(cli): guard the atlas generator; harden and unify the CLI

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -79,9 +79,86 @@ how the subject is *constructed*, not just what is asserted.
 
 ## Active Subsystem
 
-**None — `pyguara/dev` closed 2026-09-08 (branch `refactor/dev-audit`).**
-Next in the queue is Tier 4: `pyguara/cli` (command-line entry points). Open
-`REFACTOR_STATE.md` "How to resume" and take it.
+**None — `pyguara/cli` closed 2026-09-08 (branch `refactor/cli-audit`).**
+Last in the queue is `pyguara/tools` — the in-engine debug-overlay suite
+(inspector, hierarchy, gizmos, event monitor, perf panel; F2/F5/F6/F7), *not*
+"atlas/build tooling" as the old queue label said (that was `pyguara/cli`). It
+also absorbs the `pyguara/editor` audit's parked notes (inspector-drawer hook,
+`TransformGizmo` selection wiring). Open "How to resume" and take it.
+
+`pyguara/cli` in one slice, ~830 lines (`__init__` Click group, `build.py`,
+`atlas_generator.py`), reached only through the `pyguara = pyguara.cli:main`
+console script. No dead subsystem this time — both commands work — but the
+recurring shapes held, and every generator test used distinct-stem, in-bounds,
+uniformly-shaped fixtures, so the two real defects were structurally invisible.
+
+**The atlas generator silently dropped a sprite on a stem collision.**
+`load_images` keys each region by `file_path.stem`, so `hero.png` and
+`hero.jpg` in one folder both become `"hero"`; `pack()` builds `regions` as a
+dict keyed by name, so the second overwrote the first — but *both* images were
+still pasted into the atlas and counted, so `metadata["sprite_count"]` (3) did
+not match `len(regions)` (2) and which `hero` survived depended on the
+height-sort. Same "stem collision" shape as `resources.index_directory` and the
+persistence keys. Per the user's choice (**raise, name the files**), a duplicate
+stem is now a `ValueError` listing the offending filenames; `pack()` also
+rejects duplicate names defensively, making `sprite_count == len(regions)` an
+invariant.
+
+**A sprite wider than the atlas was silently cropped.** `pack()` raised "atlas
+too small" only on *vertical* overflow (`current_y + height > atlas_size`); a
+sprite whose padded width exceeded `atlas_size` was placed at x=0, clipped by
+`Image.paste`, and its metadata kept the full (wrong) width — a region rect
+running off the texture. "Guard that returns a wrong answer": half the size
+check was missing. Now both dimensions are guarded.
+
+Smaller: `generate()` re-ingested its own output when `-o`/`-m` landed inside
+`-i` (a re-run packed the previous `atlas.png` as a sprite) — it now excludes
+the resolved output paths from the scan. The dead `allow_rotation` param
+(accepted, stored, never read) removed. The two atlas CLIs — the Click `atlas`
+command and a hand-kept argparse `main()` for `python -m
+pyguara.cli.atlas_generator` — unified: `main()` now delegates to the Click
+command (user's choice), so one option surface, no drift. `pyguara/cli/__init__`
+imported the sub-commands under their own names, shadowing the
+`pyguara.cli.build` module attribute (`import pyguara.cli.build` handed back a
+`Command`) — aliased on import.
+
+`build.py` swept: it now launches PyInstaller as `python -m PyInstaller` rather
+than assuming a `pyinstaller` console script on `PATH` (import-succeeds ≠
+script-on-PATH inside a venv); the `if result.returncode == 0` guard after
+`subprocess.run(check=True)` (a tautology — non-zero already raised) removed;
+the `--onedir` success message pointed at the bundle directory, not the
+executable inside it; the generated `.spec` is now cleaned alongside `build/`;
+and the `\b` no-wrap markers in both `--help` example blocks never worked
+because the docstrings were raw strings (`\b` was backslash-b, not `\x08`) —
+`r"""` → `"""`.
+
+Tests +9 (1898 → 1907; the suite tips to 1909 once `test_docs_api`'s
+per-page parametrization picks up the new `docs/systems/cli.md`): the
+collision guard, both size-overflow directions
+(`test_..._pack_too_large` had been passing for the wrong reason — its 256px
+image in a 128 atlas triggers *vertical* overflow first), the
+`sprite_count`/`regions` invariant, and the output-exclusion; on the build side
+the onedir argument path, the missing-PyInstaller message, and CLI-driven asset
+auto-detection. New `docs/systems/cli.md` (the subsystem had no page); the
+`zero_to_hero.md` build section lost its stale "ImGui-based editor" line and
+gained a link. See the iteration log entry below.
+
+**Capability gaps (Phase D) → #61** ("asset pipeline production layer", sibling
+of #37 / #40 / #43 / #46 / #49 / #51 / #55 / #58): the atlas packer has no
+transparent-border trimming (a roguelike's sheets are mostly padding), square
+fixed-size output only (no shrink-to-fit / pow-of-two), errors instead of
+multi-page output, shelf packing only (no MaxRects), a flat non-recursive
+non-namespaced input scan, and emits none of the graphics layer's
+spritesheet / nine-patch / pivot / animation-frame metadata; `build` has no
+cross-compilation, no version stamping, no asset-manifest verification, and no
+project-lifecycle commands (`pyguara new` / `run` / `doctor`). **Left open:**
+`original_size` in the metadata is redundant with `width`/`height` until a trim
+step exists; `python -m pyguara.cli.atlas_generator` prints a cosmetic `runpy`
+RuntimeWarning because the package `__init__` pre-imports the submodule.
+
+---
+
+### `pyguara/dev` — closed 2026-09-08 (branch `refactor/dev-audit`)
 
 `pyguara/dev` in one slice, ~674 lines (`file_watcher`, `hot_reload`). Like
 `pyguara/editor`, **the whole subsystem had zero integration** — nothing in the
@@ -768,8 +845,10 @@ Ordered roughly by dependency depth: foundations first, leaves last.
   `refactor/replay-audit`)*
 - [x] `pyguara/dev` — dev-only helpers *(done — branch `refactor/dev-audit`;
   code reload deleted, `PollingFileWatcher` kept and wired to assets)*
-- [ ] `pyguara/cli` — command line entry points
-- [ ] `pyguara/tools` — atlas/build tooling
+- [x] `pyguara/cli` — command line entry points *(done — branch
+  `refactor/cli-audit`; `pyguara build` / `pyguara atlas`)*
+- [ ] `pyguara/tools` — in-engine debug-overlay suite (inspector, hierarchy,
+  gizmos, event monitor, perf panel); absorbs the `pyguara/editor` parked notes
 
 ---
 
@@ -777,6 +856,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/cli` | 2026-09-08 | One slice, ~830 lines (`__init__` Click group, `build.py`, `atlas_generator.py`), reached only via the `pyguara = pyguara.cli:main` console script. Both commands work — no dead subsystem — but two real defects hid behind uniform generator-test fixtures (distinct-stem, in-bounds, uniform shape). **The atlas generator silently dropped a sprite on a stem collision** — `load_images` keys regions by `file_path.stem`, so `hero.png` + `hero.jpg` both become `"hero"`; `pack()`'s `regions` dict overwrote the first, but both images were still pasted and counted, so `sprite_count` (3) ≠ `len(regions)` (2) and which survived depended on the height-sort. Same "stem collision" shape as `resources.index_directory` / persistence keys. Per the user's choice (**raise, name the files**): a duplicate stem is now a `ValueError` listing the filenames; `pack()` also rejects duplicate names, making `sprite_count == len(regions)` an invariant. **A sprite wider than the atlas was silently cropped** — `pack()` raised "atlas too small" only on *vertical* overflow; an over-wide sprite was placed at x=0, clipped by `Image.paste`, and kept the full (wrong) width in metadata ("guard that returns a wrong answer"). Now both dimensions guarded. Smaller: `generate()` re-ingested its own output when `-o`/`-m` landed inside `-i` — now excludes the resolved output paths; dead `allow_rotation` param removed; the argparse `main()` for `python -m pyguara.cli.atlas_generator` now **delegates** to the Click command (user's choice — one option surface); `pyguara/cli/__init__` aliased its sub-command imports (they shadowed the `pyguara.cli.build` *module* attribute). `build.py` swept: launches `python -m PyInstaller` not a bare `pyinstaller` on PATH; dead `if result.returncode == 0` after `subprocess.run(check=True)` removed; `--onedir` success message now points at the executable not the bundle dir; `.spec` cleaned alongside `build/`; `\b` help markers fixed (`r"""`→`"""` — `\b` was backslash-b, not `\x08`). Tests +9 (1898 → 1907; 1909 with `test_docs_api` picking up the new page): collision guard, both overflow directions (`test_..._pack_too_large` had passed for the wrong reason — vertical triggers first), the `sprite_count`/`regions` invariant, output-exclusion; onedir args, missing-PyInstaller, CLI asset auto-detection. New `docs/systems/cli.md` (no page existed); `zero_to_hero.md` lost its stale "ImGui-based editor" line. Phase D → **#61** ("asset pipeline production layer", sibling of #37/#40/#43/#46/#49/#51/#55/#58): atlas — no transparent-border trim, square fixed-size output only, errors instead of multi-page, shelf packing only (no MaxRects), flat non-namespaced input, emits none of the graphics layer's spritesheet/nine-patch/pivot/frame metadata; build — no cross-compile, no version stamping, no asset-manifest check, no `pyguara new`/`run`/`doctor` lifecycle. Left open: `original_size` metadata redundant until a trim step exists; a cosmetic `runpy` RuntimeWarning from `python -m` on the submodule. |
 | `pyguara/dev` | 2026-09-08 | One slice, ~674 lines (`file_watcher`, `hot_reload`). Like `pyguara/editor`, **the whole subsystem had zero integration** — nothing in the engine, no game, no non-test file imported `HotReloadManager` / `PollingFileWatcher` / `StatefulSystem` / `reload_system_class`. Wayfinder ticket 09 fogged it in 2026 ("whether a pre-alpha engine carries live code reload is a product-scope question deserving its own deliberate answer"). Per the user's choice (**split: delete code-reload, wire the watcher**): the Python-module reload layer (`hot_reload.py`) is **deleted** and `PollingFileWatcher` kept + wired to assets. Probes showed `HotReloadManager` wouldn't have worked as advertised: the class promised `StatefulSystem` state preservation but `reload_module()` had **no `get_state`/`set_state` path** (that protocol + `reload_system_class()` were a separate island with no callers); with the default `auto_reload=True`, `importlib.reload()` ran **on the polling thread** (module top-level code off the main thread); `watch_module("x")` twice registered a fresh lambda each call → one edit fired N reloads. **`PollingFileWatcher` kept, one defect fixed: `check_now()` held a non-reentrant lock across user callbacks** — a change callback calling `watch()`/`unwatch()`/`watched_count` deadlocked the poll thread (probe: `check_now` never returned); now snapshots under the lock and notifies with it released, and the poll loop survives a raising callback. New `AssetReloadWatcher` bridges the watcher to `ResourceManager.reload()` (the primitive the `pyguara/resources` slice built for this): the poll thread **queues** a changed asset's cache key; `Application._update()` calls `drain()` once per frame **on the main thread** (`ResourceManager` isn't safe to mutate under a running frame — same shape as `queue_event()`). Opt-in via `Application.enable_asset_hot_reload()`; `SandboxApplication` calls it. **BREAKING** (pre-alpha): `pyguara.dev.HotReloadManager` / `StatefulSystem` / `reload_system_class` removed. Tests: `test_hot_reload.py` deleted (17, all happy-path against stdlib modules — none touched the deadlock, the double-reload, the missing state path or the wrong-thread reload); new `test_dev.py` (+20 cases, 1893 → 1898). New `docs/systems/dev.md` (no page existed). Phase D → **#40** (already names "hot-reload has a `reload()` primitive but nothing watches the filesystem"): polling-only detection (no `inotify`/`FSEvents`/`ReadDirectoryChangesW`, lags by `poll_interval`, coalesces bursts); watch set follows the resource cache (no "watch the whole `assets/` tree" mode); `reload()` still leaves callers holding a stale instance (re-`load()` — documented). **Product decision recorded:** live Python-code reload is out — deleted, not deferred again. |
 | `pyguara/replay` | 2026-09-08 | One slice, ~1,030 lines (`types`, `recorder`, `player`, `serializer`); wired via `Application` + `InputManager` since wayfinder ticket 18. Defects were all "wired to nothing" / "guard returns a wrong answer", each hidden by uniform test setup. **`ReplaySerializer.save()` wrote an unloadable file on its default call** — it appended an extension only when absent, but `if compress or endswith(".gz")` still gzipped, so `save(data, "run.replay")` (default `compress=True`) put a gzip stream in a `.replay` file; `load()` reads it as text, `json.loads` chokes on the magic byte, the blanket `except Exception` swallows it, returns `None` after `save()` returned `True`. Now the format is derived from the extension (explicit wins); `load()` also refuses a `metadata.version` over `SUPPORTED_VERSION` (written, never read — no migration layer). **`get_metadata()` returned `None` for any replay over ~10 KB** — read first 10 KB, sliced at the last `}`, unbalanced JSON for a 400-frame file while the metadata sat in the first ~120 bytes; now parses the file. **Gamepad input was never recorded** — `record_gamepad_button` / `record_gamepad_axis` had zero callers (gamepad flows `GamepadManager` → `_on_gamepad_*`, never touching the recorder), so a controller session recorded empty while `process_replayed_event` carried GAMEPAD branches for events recording never produced; both callbacks now feed it. **Playback dropped pointer position + the raw UI stream** — `process_replayed_event` rebuilt only bound actions, discarding `event.position` and never re-emitting `OnRawKeyEvent` / `OnMouseEvent`; it now re-dispatches the raw key/mouse stream with recorded position + modifiers (`RecordedInputEvent` gained `modifiers`) and replays MOUSE_MOVE. `ReplayRecorder` stamps the installed package version (was `"0.0.0"`) + UTC `recorded_at` (the persistence pair). **User chose maximal on all three forks: playback now re-drives the loop from recorded per-frame `delta_time`** — `Application.run()`, while a replay plays, takes each frame's duration from `ReplayPlayer.peek_delta()` not the wall clock, so fixed-step count, tweens, particles and `WaitForSeconds` reproduce on any machine (cross-cuts the closed `pyguara/application` loop; `SandboxApplication` inherits `run()`). `ReplayPlayer`'s scrubbing surface (`update()` timestamp model, `seek`, `pause`/`resume`, `playback_speed`) kept as supported public API; `advance_frame()`/`update()` now share `_emit_frame()` / `_finish_if_exhausted()`. Tests +22 (1869 → 1891): the old 25 were broad but shallow + uniform (every player test = one fixture through `advance_frame()`; `update()` had zero coverage; every serializer test saved to an extensionless path; nothing recorded/replayed gamepad). New `docs/systems/replay.md` (no page existed). Phase D → **#58** ("replay production layer", sibling of #37/#40/#43/#46/#51/#55): recorded `seed` reseeds nothing on playback (no RNG service — #28); no replay-library API (`list_replays`/`delete`/browse, user-data-dir rooting — the #43 shape); the scrubbing API has no `pyguara/tools` overlay (#53); capture is input+time only (a game reading `time.time()`/filesystem/network directly breaks determinism silently); `record_action()` has a playback branch but no in-repo consumer. Left open: no format migration layer; a length-framed metadata line would let `get_metadata` skip frame bytes. |
 | `pyguara/scripting` | 2026-09-08 | One slice, ~310 lines (`coroutines.py` is the whole subsystem). Unlike `editor` it **is** wired in — bootstrap registers a `CoroutineManager` singleton, `Application._update()` ticks it every frame. Headline: **one scripted sequence that raised took down the frame loop and abandoned every other coroutine.** `Coroutine.update()` caught only `StopIteration`; any other exception from the generator body propagated through `CoroutineManager.update()`'s list comprehension out of `Application._update()`, and the comprehension `self._coroutines = [c for c in self._coroutines if c.update(dt)]` also skipped every coroutine ordered after the raiser and left stale entries on a re-raise. Fixed with the shared `ErrorHandlingStrategy` (as `EventDispatcher`/`DIContainer`): `CoroutineManager(error_strategy=RAISE)` default logs + stops + re-raises; `LOG`/`IGNORE` contain it; under all three the offender is stopped and dropped and siblings still run. **`Coroutine.stop()` abandoned the generator** — `finally`/`with` cleanup in a sequence only ran at GC; now `stop()` calls `generator.close()` (guarded by `gi_running` for the self-stop case). **`CoroutineManager.update()` corrupted its list when a coroutine started/stopped coroutines from inside its own body** (the comprehension iterated the list the body mutated — stopping an earlier sibling skipped a later one; `stop_all()` from a body left survivors); now iterates a frame-start snapshot and reconciles. Recurring shapes: "catch only the happy exception", "mutate the container you're iterating", "cleanup deferred to GC", and uniform test setup — all 30 existing tests built the coroutine from a benign `yield` body; none raised, stopped a sibling, or needed `finally`, which is exactly where the defects were. Tests +12 (1835 → 1847). `docs/systems/scripting.md` rewritten (was 39 lines: omitted `WaitWhile` from its concepts, non-runnable example, documented no wiring / lifecycle / error model / `stop()` semantics). Phase D → **#55** ("scripting production layer", sibling of #37/#40/#43/#46/#51): no scene scoping (a coroutine outlives its scene, no teardown hook), no coroutine tagging/grouping (kill entity → its scripted sequences keep running), no `yield from` result to a parent, no frame-count / fixed-step / scaled-time waits (time-scale is #28's). Left open: `WaitForSeconds` timing is frame-granular — yielding frame uncounted, overshoot discarded, so a long chain of short waits drifts by ~1 frame each (documented; sub-frame precision is not a goal of the variable-rate step). |
@@ -821,6 +901,7 @@ Concerns that outgrew this file, or that need a decision rather than a fix:
 | [#51](https://github.com/Wedeueis/pyguara/issues/51) | Prefab authoring & production layer (from the `pyguara/prefabs` audit, Phase D) — no spawn tables / weighted prefab pools (`create` is one at a time, no selection primitive); `PrefabData.version` declared "for migration support" and read by nothing (no prefab-schema migration, while `persistence` has a `MigrationRegistry`); no named variant library (`overrides` is per-call only); prefab children are linked `Transform`↔`Transform` only — the child entity has no parent-*entity* back-reference or shared lifetime, so despawning an enemy leaks its prefab-attached child entities (needs an ECS-hierarchy decision, cross-cutting with `pyguara/ecs`); no asset-reference validation at load. `ComponentRegistry` process-global mutable singleton parked as a CC |
 | [#53](https://github.com/Wedeueis/pyguara/issues/53) | PyGuara Studio — companion authoring app (from the `pyguara/editor` audit, which deleted a Dear ImGui editor that had never executed and rebuilt its useful parts as `UIRenderer` tools). Level/scene editor, animation editor, agentic authoring harness (grow `tools/agent_view.py`), data-table editors. Needs the build-vs-ImGui architecture decision; the "grow `pyguara/ui`" path is #49's scope. Gated on #49 / #28. In-overlay small items (custom inspector-drawer hook, `TransformGizmo` selection wiring) parked for the `pyguara/tools` slice |
 | [#55](https://github.com/Wedeueis/pyguara/issues/55) | Scripting production layer (from the `pyguara/scripting` audit, Phase D) — `CoroutineManager` is one app-global singleton with no scene scoping (a sequence outlives its scene and ticks against unloaded entities; no teardown hook, unlike `SystemManager`); no coroutine tagging / grouping (kill an entity → its scripted sequences keep running, cross-cutting with #51); no `yield from` result / return value or completion signal to a parent sequence; no frame-count / fixed-step waits (`WaitForFrames`, `WaitForFixedUpdate`) and no scaled-vs-realtime wait for a paused game (time-scale is #28's). `WaitForSeconds` frame-granular drift and missing arg validation left open, documented |
+| [#61](https://github.com/Wedeueis/pyguara/issues/61) | Asset pipeline production layer (from the `pyguara/cli` audit, Phase D) — the `pyguara atlas` packer has no transparent-border trimming (a roguelike's sheets are mostly padding; `original_size` metadata is dead until this lands), square fixed-`--size` output only (no shrink-to-fit / pow-of-two), raises instead of emitting atlas page 2/3/…, shelf packing only (MaxRects/skyline would pack denser; `allow_rotation` was a dead stub, removed), a flat non-recursive non-namespaced input scan (keys are bare filename stems), and emits none of the `pyguara/graphics` spritesheet / nine-patch / pivot / animation-frame metadata; `pyguara build` has no cross-compilation / target selection, no version or build-metadata stamping, no asset-manifest verification before shipping, and no project-lifecycle commands (`pyguara new` scaffold, `pyguara run`, `pyguara doctor`). Sibling of #37/#40/#43/#46/#49/#51/#55/#58 |
 | [#58](https://github.com/Wedeueis/pyguara/issues/58) | Replay production layer (from the `pyguara/replay` audit, Phase D) — recorded `seed` is exposed as `ReplayPlayer.seed` but nothing reseeds a random source on playback (no engine RNG service yet — cross-cut #28; replay should reseed it on `load_replay()`); no replay-library API (`list_replays` / `delete` / browse, the shape #43 names for saves) and `FileStorage`-style user-data-dir rooting; the `ReplayPlayer` scrubbing surface (`seek`, `pause`/`resume`, `playback_speed`, `update()`) has no `pyguara/tools` overlay driving it (scrub bar / step / slow-mo — cross-cut #53); capture is input+time only, so a game reading `time.time()` / the filesystem / the network directly breaks determinism silently; `record_action()` (synthetic AI/script-driven actions) has a playback branch but no in-repo consumer. Left open: format `version` validated but no migration layer; a length-framed metadata line would let `get_metadata` skip the frame bytes |
 
 ---

--- a/docs/guides/zero_to_hero.md
+++ b/docs/guides/zero_to_hero.md
@@ -396,5 +396,9 @@ uv run pyguara build games/true_coral/main.py --onefile --output dist/true_coral
 - `--windowed`: Suppresses the OS command shell terminal console on boot (default behavior).
 - `--icon`: Bundles a custom application icon (e.g. `icon.ico` for Windows or `icon.icns` for macOS).
 - `-a`, `--assets`: Explicitly specifies directories containing game assets (textures, music, shaders) to package with the executable.
+- `--dry-run`: Prints the PyInstaller command that would run, without building.
 
-Now you have all the knowledge required to bootstrap, design, script, and publish your own 2D games using the PyGuara game engine! Keep exploring the examples under the `games/` folder to study advanced scripts, spatial audio routing, and ImGui-based editor customization.
+See [Command-Line Tools](../systems/cli.md) for the full option list and for
+`pyguara atlas`, the sprite-atlas packer.
+
+Now you have all the knowledge required to bootstrap, design, script, and publish your own 2D games using the PyGuara game engine! Keep exploring the examples under the `games/` folder to study advanced scripts, spatial audio routing, and the in-engine debug overlays.

--- a/docs/systems/cli.md
+++ b/docs/systems/cli.md
@@ -1,0 +1,170 @@
+# Command-Line Tools
+
+`pyguara.cli` is the offline toolbox — things you run from a shell against a
+project on disk, never from inside a running game. It installs one console
+script:
+
+```toml
+[project.scripts]
+pyguara = "pyguara.cli:main"
+```
+
+`main` is a [Click](https://click.palletsprojects.com/) group with two
+sub-commands:
+
+| Command | What it does |
+|---------|--------------|
+| `pyguara build`  | Package a game into a standalone executable (wraps PyInstaller). |
+| `pyguara atlas`  | Pack a folder of sprites into one texture atlas + JSON metadata. |
+
+```bash
+pyguara --help
+pyguara --version
+pyguara build --help
+pyguara atlas --help
+```
+
+Both sub-commands exit non-zero on failure (`1` for a usage/tool error, the
+PyInstaller exit code for a failed build), so they compose in scripts and CI.
+
+---
+
+## `pyguara build`
+
+Compiles an entry script and its assets into a distributable bundle.
+
+```bash
+# onedir bundle (default) into dist/
+pyguara build games/guara_falcao/main.py --output dist/guara_falcao
+
+# one self-contained file, custom name and icon
+pyguara build games/true_coral/main.py --onefile --name TrueCoral \
+    --icon games/true_coral/assets/icon.ico
+```
+
+### How it runs
+
+`build` shells out to PyInstaller **through the current interpreter** —
+`python -m PyInstaller …`, not a bare `pyinstaller` on `PATH` — so it works
+inside a `uv`/venv install where the console script may not be exported.
+`import PyInstaller` failing prints an install hint and exits `1`; you need
+the `build` extra:
+
+```bash
+uv sync --extra build      # or: pip install -e .[build]
+```
+
+### Asset bundling
+
+With no `-a/--assets`, `build` looks next to the entry script for a folder
+named `assets`, `resources`, or `data` (any case) and bundles the first it
+finds. Pass `-a` one or more times to be explicit; each becomes a PyInstaller
+`--add-data` entry preserving the folder name at runtime.
+
+A default set of hidden imports (`pygame`, `pymunk`, `moderngl`, `numpy`,
+`PIL`, `msgpack`, …) is always passed so the frozen build finds the engine's
+backends; add project-specific ones with `--hidden-import`.
+
+### Options
+
+| Option | Default | Notes |
+|--------|---------|-------|
+| `-o, --output` | `dist/` | Bundle destination. |
+| `-n, --name` | entry-script stem | Executable / bundle name. |
+| `--onefile / --onedir` | `--onedir` | Single file vs. a directory. |
+| `--windowed / --console` | `--windowed` | Hide the OS console on launch. |
+| `--icon` | — | `.ico` (Windows) / `.icns` (macOS). |
+| `-a, --assets` | auto-detect | Repeatable. Asset directories to bundle. |
+| `--add-data` | — | Repeatable. Raw `src<sep>dst` PyInstaller spec. |
+| `--hidden-import` | — | Repeatable. Extra modules to force-include. |
+| `--clean` | off | Wipe the PyInstaller cache first. |
+| `--debug` | off | `--debug=all`. |
+| `--dry-run` | off | Print the PyInstaller command and stop. |
+
+After a successful build, the generated `build/` work directory and the
+`<name>.spec` file are removed from `--output`. The reported `Output:` path
+points at the executable — for `--onedir` that is
+`<output>/<name>/<name>[.exe]`, one level inside the bundle directory.
+
+Use `--dry-run` to see exactly what would be executed without needing
+PyInstaller installed:
+
+```bash
+pyguara build main.py --onefile --dry-run
+```
+
+---
+
+## `pyguara atlas`
+
+Packs every image in a directory into one atlas texture using a
+shelf-packing algorithm (sprites sorted tallest-first, laid into horizontal
+rows), and writes JSON metadata the engine's `ResourceManager.load_atlas`
+reads back.
+
+```bash
+pyguara atlas -i assets/sprites/ -o build/atlas.png -m build/atlas.json
+pyguara atlas -i assets/sprites/ -o build/atlas.png -s 4096 -p 4
+```
+
+Supported inputs: `.png`, `.jpg`, `.jpeg`, `.bmp`, `.tga` (non-`RGBA` images
+are converted). The scan is **one directory deep**, not recursive.
+
+### Options
+
+| Option | Default | Notes |
+|--------|---------|-------|
+| `-i, --input` | *(required)* | Directory of source sprites. |
+| `-o, --output` | *(required)* | Atlas PNG path. |
+| `-m, --metadata` | — | JSON metadata path. Omit to skip. |
+| `-s, --size` | `2048` | Atlas is a square `size × size`. |
+| `-p, --padding` | `2` | Transparent gutter around each sprite. |
+
+### Metadata shape
+
+```json
+{
+  "atlas_size": [2048, 2048],
+  "padding": 2,
+  "sprite_count": 3,
+  "regions": {
+    "player": { "x": 2, "y": 2, "width": 64, "height": 64,
+                "original_size": [64, 64] }
+  }
+}
+```
+
+A region's name is the source filename **without extension**. `sprite_count`
+always equals `len(regions)`.
+
+### Failures are loud
+
+The generator refuses ambiguous or impossible input rather than producing a
+subtly wrong atlas:
+
+- **Stem collision.** `hero.png` and `hero.jpg` in the same folder both want
+  the region name `hero`. This raises `ValueError` naming the offending
+  files — rename or remove one.
+- **Sprite doesn't fit.** A sprite larger than `--size` in *either*
+  dimension (plus padding) raises — increase `--size` or shrink the sprite.
+  (Width used to slip through and get silently cropped.)
+- **Output inside the input.** `generate()` excludes the resolved `-o`/`-m`
+  paths from its own scan, so re-running with the atlas written back into the
+  sprite folder does not ingest the previous atlas. Still cleaner to keep
+  build output in its own directory.
+
+### Two ways to invoke it
+
+`pyguara atlas …` and `python -m pyguara.cli.atlas_generator …` run the same
+Click command with the same options — the module entry point delegates
+straight to it.
+
+---
+
+## Testing
+
+`tests/test_build_tool.py` covers argument assembly and the `--dry-run` /
+missing-PyInstaller paths with Click's `CliRunner` (a real PyInstaller run is
+not exercised). `tests/test_atlas_tool.py` covers `load_images` / `pack` /
+`generate`, the collision and size guards, and round-tripping the metadata
+through `ResourceManager.load_atlas`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Systems:
       - Animation: systems/animation.md
       - Audio: systems/audio.md
+      - Command-Line Tools: systems/cli.md
       - Dev Tools: systems/dev.md
       - Editor Tools: systems/editor.md
       - Input: systems/input.md

--- a/pyguara/cli/__init__.py
+++ b/pyguara/cli/__init__.py
@@ -11,8 +11,12 @@ Usage:
 
 import click
 
-from pyguara.cli.atlas_generator import atlas
-from pyguara.cli.build import build
+# Alias on import: a bare ``from ... import build`` would rebind the
+# ``pyguara.cli.build`` *module* attribute to the command object, so
+# ``import pyguara.cli.build`` would hand back a Click Command instead of the
+# module. Keep the submodules reachable by dotted path.
+from pyguara.cli.atlas_generator import atlas as atlas_command
+from pyguara.cli.build import build as build_command
 
 
 @click.group()
@@ -22,8 +26,8 @@ def main() -> None:
     pass
 
 
-main.add_command(build)
-main.add_command(atlas)
+main.add_command(build_command)
+main.add_command(atlas_command)
 
 
 if __name__ == "__main__":

--- a/pyguara/cli/atlas_generator.py
+++ b/pyguara/cli/atlas_generator.py
@@ -11,7 +11,6 @@ Usage:
 
 from __future__ import annotations
 
-import argparse
 import json
 import sys
 from pathlib import Path
@@ -115,7 +114,6 @@ class AtlasGenerator:
         self,
         atlas_size: int = 2048,
         padding: int = 2,
-        allow_rotation: bool = False,
     ):
         """
         Initialize the atlas generator.
@@ -123,24 +121,30 @@ class AtlasGenerator:
         Args:
             atlas_size (int): Maximum atlas dimension (width and height).
             padding (int): Padding between sprites to prevent bleeding.
-            allow_rotation (bool): Whether to allow 90-degree rotation (not implemented).
         """
         self.atlas_size = atlas_size
         self.padding = padding
-        self.allow_rotation = allow_rotation
 
-    def load_images(self, input_path: Path) -> list[tuple[str, Image.Image]]:
+    def load_images(
+        self,
+        input_path: Path,
+        exclude: set[Path] | None = None,
+    ) -> list[tuple[str, Image.Image]]:
         """
         Load all images from a directory.
 
         Args:
             input_path (Path): Directory containing sprite images.
+            exclude (Optional[Set[Path]]): Resolved paths to skip (e.g. the
+                atlas the caller is about to write into this same directory).
 
         Returns:
             List[Tuple[str, Image.Image]]: List of (name, image) tuples.
 
         Raises:
-            ValueError: If no images found or path is invalid.
+            ValueError: If no images found, the path is invalid, or two files
+                share a stem (``hero.png`` and ``hero.jpg`` would both claim the
+                region name ``hero`` and silently overwrite each other).
         """
         if not input_path.exists():
             raise ValueError(f"Input path does not exist: {input_path}")
@@ -148,21 +152,38 @@ class AtlasGenerator:
         if not input_path.is_dir():
             raise ValueError(f"Input path is not a directory: {input_path}")
 
+        excluded = exclude or set()
         images: list[tuple[str, Image.Image]] = []
+        stems: dict[str, list[str]] = {}
         supported_formats = {".png", ".jpg", ".jpeg", ".bmp", ".tga"}
 
         for file_path in sorted(input_path.iterdir()):
-            if file_path.suffix.lower() in supported_formats:
-                try:
-                    img: Image.Image = Image.open(file_path)
-                    # Convert to RGBA to ensure consistent format
-                    if img.mode != "RGBA":
-                        img = img.convert("RGBA")
-                    name = file_path.stem  # Filename without extension
-                    images.append((name, img))
-                except Exception as e:
-                    print(f"Warning: Failed to load {file_path}: {e}")
-                    continue
+            if file_path.suffix.lower() not in supported_formats:
+                continue
+            if file_path.resolve() in excluded:
+                continue
+            try:
+                img: Image.Image = Image.open(file_path)
+                # Convert to RGBA to ensure consistent format
+                if img.mode != "RGBA":
+                    img = img.convert("RGBA")
+                name = file_path.stem  # Filename without extension
+                stems.setdefault(name, []).append(file_path.name)
+                images.append((name, img))
+            except Exception as e:
+                print(f"Warning: Failed to load {file_path}: {e}")
+                continue
+
+        collisions = {stem: files for stem, files in stems.items() if len(files) > 1}
+        if collisions:
+            detail = "; ".join(
+                f"{stem!r} <- {', '.join(sorted(files))}"
+                for stem, files in sorted(collisions.items())
+            )
+            raise ValueError(
+                f"Multiple files map to the same atlas region name in "
+                f"{input_path}: {detail}. Rename or remove the duplicates."
+            )
 
         if not images:
             raise ValueError(f"No valid images found in {input_path}")
@@ -182,8 +203,17 @@ class AtlasGenerator:
             Tuple[Image.Image, Dict[str, Any]]: The atlas image and metadata dict.
 
         Raises:
-            ValueError: If sprites don't fit in atlas size.
+            ValueError: If two sprites share a name, or a sprite does not fit
+                the atlas in either dimension.
         """
+        names = [name for name, _ in images]
+        dupes = sorted({n for n in names if names.count(n) > 1})
+        if dupes:
+            raise ValueError(
+                f"Duplicate sprite name(s) passed to pack(): {', '.join(dupes)}. "
+                f"Region names must be unique."
+            )
+
         # Sort images by height (descending) for better packing
         sorted_images = sorted(images, key=lambda x: x[1].height, reverse=True)
 
@@ -218,11 +248,15 @@ class AtlasGenerator:
 
             # Create new shelf if needed
             if not placed:
-                if current_y + height > self.atlas_size:
+                # Guard both dimensions: a sprite wider than the atlas used to
+                # slip past this check (only height was tested) and get silently
+                # clipped by Image.paste while its metadata kept the full width.
+                if width > self.atlas_size or current_y + height > self.atlas_size:
                     raise ValueError(
                         f"Atlas size {self.atlas_size}x{self.atlas_size} "
-                        f"is too small to fit all sprites. "
-                        f"Try increasing --size or reducing sprite count."
+                        f"is too small to fit all sprites "
+                        f"(sprite {name!r} needs {width}x{height}px including "
+                        f"padding). Try increasing --size or reducing sprite count."
                     )
 
                 shelf = Shelf(current_y, height, self.atlas_size)
@@ -277,8 +311,14 @@ class AtlasGenerator:
             output_path (Path): Path for output atlas image.
             metadata_path (Optional[Path]): Path for JSON metadata file.
         """
+        # Never re-ingest our own output when it is written back into the
+        # input directory (a common -i/-o overlap).
+        exclude = {output_path.resolve()}
+        if metadata_path is not None:
+            exclude.add(metadata_path.resolve())
+
         print(f"Loading images from: {input_path}")
-        images = self.load_images(input_path)
+        images = self.load_images(input_path, exclude=exclude)
         print(f"Loaded {len(images)} images")
 
         print("Packing atlas...")
@@ -344,24 +384,20 @@ def atlas(
     metadata: Path | None,
     size: int,
     padding: int,
-) -> None:
-    r"""Generate a sprite atlas from multiple images.
+) -> None:  # noqa: D301  (\b is Click's no-wrap marker; r""" would defeat it)
+    """Generate a sprite atlas from multiple images.
 
     Pack sprites from INPUT directory into a single texture atlas using
     shelf-packing algorithm.
 
+    \b
     Examples:
-        \b
-        # Basic usage
-        pyguara atlas -i assets/sprites/ -o atlas.png
-
-        \b
-        # With metadata
-        pyguara atlas -i assets/sprites/ -o atlas.png -m atlas.json
-
-        \b
-        # Custom size and padding
-        pyguara atlas -i assets/sprites/ -o atlas.png -s 4096 -p 4
+      # Basic usage
+      pyguara atlas -i assets/sprites/ -o atlas.png
+      # With metadata
+      pyguara atlas -i assets/sprites/ -o atlas.png -m atlas.json
+      # Custom size and padding
+      pyguara atlas -i assets/sprites/ -o atlas.png -s 4096 -p 4
     """
     try:
         generator = AtlasGenerator(
@@ -379,73 +415,13 @@ def atlas(
 
 
 def main() -> None:
-    """Legacy CLI entry point using argparse."""
-    parser = argparse.ArgumentParser(
-        description="Generate sprite atlas from multiple images",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  # Basic usage
-  python -m pyguara.cli.atlas_generator -i assets/sprites/ -o atlas.png
+    """Entry point for ``python -m pyguara.cli.atlas_generator``.
 
-  # With metadata
-  python -m pyguara.cli.atlas_generator -i assets/sprites/ -o atlas.png -m atlas.json
-
-  # Custom size and padding
-  python -m pyguara.cli.atlas_generator -i assets/sprites/ -o atlas.png -s 4096 -p 4
-        """,
-    )
-
-    parser.add_argument(
-        "-i",
-        "--input",
-        type=Path,
-        required=True,
-        help="Input directory containing sprite images",
-    )
-    parser.add_argument(
-        "-o",
-        "--output",
-        type=Path,
-        required=True,
-        help="Output path for atlas image (PNG)",
-    )
-    parser.add_argument(
-        "-m",
-        "--metadata",
-        type=Path,
-        help="Output path for JSON metadata (optional)",
-    )
-    parser.add_argument(
-        "-s",
-        "--size",
-        type=int,
-        default=2048,
-        help="Atlas size (width and height, default: 2048)",
-    )
-    parser.add_argument(
-        "-p",
-        "--padding",
-        type=int,
-        default=2,
-        help="Padding between sprites (default: 2)",
-    )
-
-    args = parser.parse_args()
-
-    try:
-        generator = AtlasGenerator(
-            atlas_size=args.size,
-            padding=args.padding,
-        )
-        generator.generate(
-            input_path=args.input,
-            output_path=args.output,
-            metadata_path=args.metadata,
-        )
-    except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+    Delegates straight to the :func:`atlas` Click command so the module-level
+    invocation and ``pyguara atlas`` share one option surface and one code
+    path (they used to be a hand-kept argparse copy that could drift).
+    """
+    atlas.main(prog_name="pyguara.cli.atlas_generator")
 
 
 if __name__ == "__main__":

--- a/pyguara/cli/build.py
+++ b/pyguara/cli/build.py
@@ -60,7 +60,10 @@ def _build_pyinstaller_args(
     debug: bool,
 ) -> list[str]:
     """Build the PyInstaller command arguments."""
-    args = ["pyinstaller"]
+    # Invoke via the running interpreter rather than a bare ``pyinstaller``
+    # entry script: ``import PyInstaller`` succeeding (see _check_pyinstaller)
+    # does not guarantee a console script on PATH, especially inside a venv.
+    args = [sys.executable, "-m", "PyInstaller"]
 
     # Entry point
     args.append(str(entry_point))
@@ -222,27 +225,21 @@ def build(
     clean: bool,
     debug: bool,
     dry_run: bool,
-) -> None:
-    r"""Build a standalone executable from a PyGuara game.
+) -> None:  # noqa: D301  (\b is Click's no-wrap marker; r""" would defeat it)
+    """Build a standalone executable from a PyGuara game.
 
     ENTRY_POINT is the main Python file of your game (e.g., main.py).
 
+    \b
     Examples:
-        \b
-        # Basic build
-        pyguara build main.py
-
-        \b
-        # Custom output and name
-        pyguara build main.py --output builds/ --name MyGame
-
-        \b
-        # Single file with icon
-        pyguara build main.py --onefile --icon assets/icon.ico
-
-        \b
-        # Include multiple asset directories
-        pyguara build main.py -a assets/ -a levels/
+      # Basic build
+      pyguara build main.py
+      # Custom output and name
+      pyguara build main.py --output builds/ --name MyGame
+      # Single file with icon
+      pyguara build main.py --onefile --icon assets/icon.ico
+      # Include multiple asset directories
+      pyguara build main.py -a assets/ -a levels/
     """
     # Resolve paths to absolute paths to prevent PyInstaller --specpath resolution issues
     entry_point = entry_point.resolve().absolute()
@@ -310,29 +307,9 @@ def build(
     logger.info("Running PyInstaller with args: %s", args)
 
     try:
-        result = subprocess.run(args, check=True)
-        if result.returncode == 0:
-            click.echo()
-            click.echo(click.style("Build successful!", fg="green", bold=True))
-
-            # Show output location
-            exe_name = name or entry_point.stem
-            if onefile:
-                if sys.platform == "win32":
-                    exe_path = output / f"{exe_name}.exe"
-                else:
-                    exe_path = output / exe_name
-            else:
-                exe_path = output / exe_name
-
-            click.echo(f"Output: {click.style(str(exe_path), fg='cyan')}")
-
-            # Clean up build artifacts
-            build_dir = output / "build"
-            if build_dir.exists():
-                shutil.rmtree(build_dir)
-                logger.debug("Cleaned up build directory")
-
+        # check=True: a non-zero exit raises CalledProcessError below, so
+        # reaching this point means the build succeeded.
+        subprocess.run(args, check=True)
     except subprocess.CalledProcessError as e:
         click.echo(
             click.style("Build failed!", fg="red", bold=True)
@@ -343,7 +320,29 @@ def build(
     except FileNotFoundError as e:
         click.echo(
             click.style("Error: ", fg="red", bold=True)
-            + "PyInstaller executable not found in PATH",
+            + "could not launch PyInstaller via "
+            + click.style(f"{sys.executable} -m PyInstaller", fg="cyan"),
             err=True,
         )
         raise SystemExit(1) from e
+
+    click.echo()
+    click.echo(click.style("Build successful!", fg="green", bold=True))
+
+    # Show output location. onedir nests the executable inside a bundle
+    # directory named after the app; onefile drops it directly in output/.
+    exe_name = name or entry_point.stem
+    binary = f"{exe_name}.exe" if sys.platform == "win32" else exe_name
+    exe_path = output / binary if onefile else output / exe_name / binary
+    click.echo(f"Output: {click.style(str(exe_path), fg='cyan')}")
+
+    # Clean up build artifacts: the work directory and the generated .spec,
+    # both of which PyInstaller drops in output/ (see --workpath/--specpath).
+    build_dir = output / "build"
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+        logger.debug("Cleaned up build directory")
+    spec_file = output / f"{exe_name}.spec"
+    if spec_file.exists():
+        spec_file.unlink()
+        logger.debug("Cleaned up .spec file")

--- a/tests/test_atlas_tool.py
+++ b/tests/test_atlas_tool.py
@@ -250,6 +250,101 @@ def test_atlas_generator_pack_too_large():
 
 
 @pytest.mark.skipif(not PIL_AVAILABLE, reason="PIL not available")
+def test_atlas_generator_pack_raises_when_sprite_too_wide():
+    """A sprite wider than the atlas must raise, not get silently clipped.
+
+    Only the vertical dimension used to be checked; an over-wide sprite was
+    placed at x=0 and truncated by Image.paste while its metadata kept the
+    full (wrong) width.
+    """
+    images = [("wide", Image.new("RGBA", (300, 16), (255, 0, 0, 255)))]
+    generator = AtlasGenerator(atlas_size=256, padding=0)
+
+    with pytest.raises(ValueError, match="too small to fit all sprites"):
+        generator.pack(images)
+
+
+@pytest.mark.skipif(not PIL_AVAILABLE, reason="PIL not available")
+def test_atlas_generator_pack_raises_when_sprite_too_tall():
+    """A sprite taller than the atlas must raise (the dimension that always
+    worked -- kept as an explicit companion to the too-wide case)."""
+    images = [("tall", Image.new("RGBA", (16, 300), (255, 0, 0, 255)))]
+    generator = AtlasGenerator(atlas_size=256, padding=0)
+
+    with pytest.raises(ValueError, match="too small to fit all sprites"):
+        generator.pack(images)
+
+
+@pytest.mark.skipif(not PIL_AVAILABLE, reason="PIL not available")
+def test_atlas_generator_pack_rejects_duplicate_names():
+    """pack() must reject two sprites that would claim the same region name."""
+    images = [
+        ("dup", Image.new("RGBA", (16, 16), (255, 0, 0, 255))),
+        ("dup", Image.new("RGBA", (16, 16), (0, 255, 0, 255))),
+    ]
+    generator = AtlasGenerator(atlas_size=128, padding=0)
+
+    with pytest.raises(ValueError, match="[Dd]uplicate.*dup"):
+        generator.pack(images)
+
+
+@pytest.mark.skipif(not PIL_AVAILABLE, reason="PIL not available")
+def test_atlas_generator_pack_metadata_is_internally_consistent():
+    """sprite_count must equal the number of emitted regions."""
+    images = [
+        ("a", Image.new("RGBA", (32, 32), (255, 0, 0, 255))),
+        ("b", Image.new("RGBA", (24, 24), (0, 255, 0, 255))),
+        ("c", Image.new("RGBA", (16, 16), (0, 0, 255, 255))),
+    ]
+    _, metadata = AtlasGenerator(atlas_size=128, padding=2).pack(images)
+
+    assert metadata["sprite_count"] == len(metadata["regions"]) == 3
+
+
+@pytest.mark.skipif(not PIL_AVAILABLE, reason="PIL not available")
+def test_atlas_generator_load_images_rejects_stem_collision():
+    """hero.png + hero.jpg both map to region name 'hero' -> must raise."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        Image.new("RGBA", (64, 64), (255, 0, 0, 255)).save(tmpdir_path / "hero.png")
+        Image.new("RGB", (40, 40), (0, 255, 0)).save(tmpdir_path / "hero.jpg")
+        Image.new("RGBA", (16, 16), (0, 0, 255, 255)).save(tmpdir_path / "enemy.png")
+
+        generator = AtlasGenerator()
+
+        with pytest.raises(ValueError, match="hero.jpg") as exc:
+            generator.load_images(tmpdir_path)
+        assert "hero.png" in str(exc.value)
+
+
+@pytest.mark.skipif(not PIL_AVAILABLE, reason="PIL not available")
+def test_atlas_generator_generate_excludes_own_output():
+    """Re-running generate() into the input dir must not ingest the prior atlas.
+
+    Without the exclusion the second run would either pack an extra 'atlas'
+    sprite or, once a same-stem .json/.png pair exists, raise a stem collision.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        for i in range(2):
+            Image.new("RGBA", (32, 32), (255, 0, 0, 255)).save(
+                tmpdir_path / f"s{i}.png"
+            )
+
+        generator = AtlasGenerator(atlas_size=128, padding=2)
+        out_img = tmpdir_path / "atlas.png"
+        out_meta = tmpdir_path / "atlas.json"
+
+        generator.generate(tmpdir_path, out_img, out_meta)
+        generator.generate(tmpdir_path, out_img, out_meta)  # must not raise
+
+        with open(out_meta) as f:
+            metadata = json.load(f)
+        assert metadata["sprite_count"] == 2
+        assert set(metadata["regions"]) == {"s0", "s1"}
+
+
+@pytest.mark.skipif(not PIL_AVAILABLE, reason="PIL not available")
 def test_atlas_generator_generate():
     """Atlas generator should create atlas and metadata files."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_build_tool.py
+++ b/tests/test_build_tool.py
@@ -69,7 +69,8 @@ def test_build_pyinstaller_args(tmp_path):
         debug=True,
     )
 
-    assert "pyinstaller" in args
+    # Launched through the running interpreter, not a bare `pyinstaller` script.
+    assert args[:3] == [sys.executable, "-m", "PyInstaller"]
     assert str(entry_point) in args
     assert "--onefile" in args
     assert "--windowed" in args
@@ -114,6 +115,52 @@ def test_cli_build_dry_run(tmp_path):
 
     assert result.exit_code == 0
     assert "Dry run - would execute:" in result.output
-    assert "pyinstaller" in result.output
+    assert "-m PyInstaller" in result.output
     assert "CLI_Test_Game" in result.output
     assert "--onefile" in result.output
+
+
+def test_build_pyinstaller_args_onedir(tmp_path):
+    """onedir mode should pass --onedir and never --onefile."""
+    args = _build_pyinstaller_args(
+        entry_point=tmp_path / "main.py",
+        output_dir=tmp_path / "dist",
+        name=None,
+        onefile=False,
+        windowed=True,
+        icon=None,
+        assets_dirs=[],
+        extra_data=[],
+        hidden_imports=[],
+        clean=False,
+        debug=False,
+    )
+    assert "--onedir" in args
+    assert "--onefile" not in args
+
+
+def test_cli_build_reports_missing_pyinstaller(tmp_path, monkeypatch):
+    """A real (non-dry-run) build with PyInstaller absent exits 1 with a hint."""
+    monkeypatch.setattr("pyguara.cli.build._check_pyinstaller", lambda: False)
+
+    entry_point = tmp_path / "game_main.py"
+    entry_point.touch()
+
+    result = CliRunner().invoke(build, [str(entry_point)])
+
+    assert result.exit_code == 1
+    assert "not installed" in result.output
+
+
+def test_cli_build_dry_run_auto_detects_assets(tmp_path):
+    """Without -a, an adjacent assets/ folder is auto-added as --add-data."""
+    entry_point = tmp_path / "main.py"
+    entry_point.touch()
+    (tmp_path / "assets").mkdir()
+
+    result = CliRunner().invoke(build, [str(entry_point), "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Auto-detected assets folder" in result.output
+    assert "--add-data" in result.output
+    assert str((tmp_path / "assets").resolve()) in result.output


### PR DESCRIPTION
Subsystem audit — `pyguara/cli` (Tier 4). One slice, ~830 lines
(`__init__` Click group, `build.py`, `atlas_generator.py`), reached only
through the `pyguara = pyguara.cli:main` console script. Independent branch
off `main`; not stacked.

Both commands worked — no dead subsystem this time — but two
atlas-generator defects hid behind test fixtures that were all
distinct-stem, in-bounds and uniformly shaped. Each was reproduced with a
probe before the fix.

## Phase A — defects fixed

**Atlas generator**
- **Stem collision silently dropped a sprite.** `load_images` keyed each
  region by `file_path.stem`, so `hero.png` + `hero.jpg` in one folder both
  became `"hero"`; `pack()`'s `regions` dict overwrote the first while both
  images were still pasted into the atlas and counted — `sprite_count` (3)
  did not match `len(regions)` (2), and which `hero` survived depended on
  the height-sort. Same "stem collision" shape as `resources.index_directory`
  and the persistence keys. Now `load_images` raises `ValueError` naming the
  colliding files; `pack()` also rejects duplicate names, making
  `sprite_count == len(regions)` an invariant.
- **A sprite wider than the atlas was silently cropped.** `pack()` raised
  "atlas too small" only on vertical overflow; an over-wide sprite was
  placed at x=0, clipped by `Image.paste`, and kept the full (wrong) width
  in its metadata — a region rect running off the texture. Both dimensions
  are now guarded.
- `generate()` re-ingested its own output when `-o`/`-m` landed inside `-i`
  (a re-run packed the previous `atlas.png` as a sprite) — it now excludes
  the resolved output paths from the scan.
- Removed the dead `allow_rotation` parameter.
- The argparse `main()` for `python -m pyguara.cli.atlas_generator` now
  delegates to the Click command instead of hand-keeping a duplicate option
  set that could drift.

**build**
- Launch PyInstaller as `python -m PyInstaller`, not a bare `pyinstaller` on
  `PATH` (`import PyInstaller` succeeding does not imply a console script in
  a venv).
- Dropped the tautological `if result.returncode == 0` after
  `subprocess.run(check=True)`.
- The `--onedir` success message now points at the executable, not the
  bundle directory; the generated `.spec` is cleaned alongside `build/`.
- Fixed the `\b` no-wrap markers in both `--help` example blocks — the
  docstrings were raw strings, so `\b` was backslash-b, not `\x08`, and
  Click reflowed the examples into one paragraph. (`# noqa: D301` because
  `r"""` — what pydocstyle wants — is exactly what defeats Click here.)

`pyguara/cli/__init__` aliased its sub-command imports so
`import pyguara.cli.build` resolves to the module, not the `Command` object.

## Phase B — tests

`+9` new cases (suite 1898 → 1907; tips to 1909 once `test_docs_api`'s
per-page parametrization picks up the new page). The old generator tests
all used distinct-stem, in-bounds, uniform fixtures, so both defects were
structurally invisible and `test_atlas_generator_pack_too_large` passed for
the wrong reason (its 256px image in a 128 atlas triggers vertical overflow
first). New: the collision guard, both overflow directions, the
`sprite_count`/`regions` invariant, output exclusion; on the build side the
onedir argument path, the missing-PyInstaller message, and CLI-driven asset
auto-detection.

## Phase C — docs

New `docs/systems/cli.md` (the subsystem had no page): entry point, both
commands with full option tables, the metadata shape, the "failures are
loud" guarantees. Added to the mkdocs nav. `zero_to_hero.md` lost its stale
"ImGui-based editor customization" line (that editor was deleted in the
`pyguara/editor` audit) and gained `--dry-run` plus a link.

## Phase D — capability gaps → #61

"Asset pipeline production layer" (sibling of #37/#40/#43/#46/#49/#51/#55/#58):
the atlas packer has no transparent-border trimming, square fixed-`--size`
output only, raises instead of emitting multi-page atlases, shelf packing
only, a flat non-recursive non-namespaced input scan, and emits none of the
`pyguara/graphics` spritesheet/nine-patch/pivot/frame metadata; `build` has
no cross-compilation, no version stamping, no asset-manifest verification,
and no project-lifecycle commands (`pyguara new`/`run`/`doctor`).

## Verification

`pytest && ruff check . && mypy pyguara && mkdocs build --strict` all pass,
verified in a clean `git worktree` checkout of the tip (1909 passed). Each
commit passes on its own.

`REFACTOR_STATE.md` logged; `pyguara/cli` ticked; the queue label for the
last subsystem corrected (`pyguara/tools` is the in-engine debug-overlay
suite, not "atlas/build tooling").

**PR is final — nothing else coming for this iteration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5