### PR TITLE
refactor(tools): stop double-running tools; lifecycle teardown; wire the F9 gizmo

### DIFF
--- a/REFACTOR_STATE.md
+++ b/REFACTOR_STATE.md
@@ -79,12 +79,94 @@ how the subject is *constructed*, not just what is asserted.
 
 ## Active Subsystem
 
-**None — `pyguara/cli` closed 2026-09-08 (branch `refactor/cli-audit`).**
-Last in the queue is `pyguara/tools` — the in-engine debug-overlay suite
-(inspector, hierarchy, gizmos, event monitor, perf panel; F2/F5/F6/F7), *not*
-"atlas/build tooling" as the old queue label said (that was `pyguara/cli`). It
-also absorbs the `pyguara/editor` audit's parked notes (inspector-drawer hook,
-`TransformGizmo` selection wiring). Open "How to resume" and take it.
+**The subsystem audit is complete.** `pyguara/tools` closed 2026-09-08
+(branch `refactor/tools-audit`) was the last entry in the pending queue —
+every Tier 1–4 subsystem has now had its Phase A→D pass. What remains is the
+tracked cross-cutting work (the GitHub issues below: #9, #16, #19, #23, #28,
+#30, #37, #40, #43, #46, #49, #51, #53, #55, #58, #61) and the open
+Cross-Cutting Concerns — none of which is a single-subsystem iteration.
+
+`pyguara/tools` in one slice, ~1,750 lines (`base`, `manager`, `inspector`,
+`tweakable`, `hierarchy`, `assets_browser`, `config_inspector`, `gizmos`,
+`event_monitor`, `performance`, `debugger`, `shortcuts_panel`), driven by
+`SandboxApplication` (F12 master toggle + F1–F9). No dead subsystem — the
+overlay runs — but the recurring shapes held and `test_tools.py`'s ~40 cases
+were all `MockTool` booleans that constructed the subject one way and asserted
+nothing real.
+
+**`ToolManager` double-ran a tool on a repeat registration.** `register_tool`
+did `self._tools[name] = tool` (deduped) but `self._render_order.append(name)`
+unconditionally, so re-registering a name left a stale duplicate in the render
+list and `update()`/`render()`/`process_event()` each hit the survivor **twice
+per frame** (probe: two `Spy("dup")` → one frame → `updates=2`). The
+`pyguara/systems` "silent duplicate registration keys" shape. `register_tool`
+now drops the old name from `_render_order` and `_shortcuts` first;
+`unregister_tool(name)` / `clear()` were added, both firing a new
+`Tool.on_removed()` hook.
+
+**`PerformanceMonitor` fed a `0.0` FPS sample on any `dt <= 0`.**
+`current_fps = 1.0 / dt if dt > 0 else 0.0` — the tracked "guard that returns
+a wrong answer" pattern verbatim; one `dt==0` frame (first frame, a pause, a
+backwards clock) dragged the 60-sample rolling average from 60 to 40 (probe).
+Now a non-positive `dt` is skipped, not sampled. Dead `pygame.time.Clock()`
+attribute removed.
+
+**`AssetsTool`'s Spawn/Reload buttons rendered "disabled" but still fired.**
+`_button(enabled=…)` only changed colours; `process_event` hit-tested and
+called `_spawn_selected()` regardless (it degraded to a "Load failed" status
+rather than crashing, because `_spawn_selected` wraps `load` in
+`except Exception`). The hit rect is now dropped when the action is disabled —
+and the Spawn gate was corrected to *stay live for a not-yet-loaded path*
+(which might be data) and disable only for a loaded non-`DataResource`.
+
+**Lifecycle pass (user's choice — full in-slice).** `Tool` gained
+`on_removed()`; `EventMonitor` (which `subscribe()`s ×3 in `__init__` and
+never unsubscribed — no teardown existed) now undoes every subscription there,
+and `SandboxApplication.shutdown()` calls `ToolManager.clear()` before the
+engine tears down. `Tool._entity_manager`'s no-scene fallback returned a
+**fresh** empty `EntityManager` on every access (two per frame → two different
+worlds); it is now cached for that window, with the "read-only until a scene
+is active" caveat documented. `ShortcutsPanel` was a hard-coded key table that
+could silently drift from `sandbox.py`; it now reads
+`ToolManager.iter_shortcuts()` live (with `ToolManager` registered in the DI
+container) plus a short static "in-tool keys" block for Q/W/E/TAB/S/ESC.
+
+**`TransformGizmo` wired up (user's choice).** Registered by nothing through
+two prior audits (in `__all__`, instantiated only in tests, **zero**
+coverage). Now registered at F9 in `SandboxApplication`, given a
+`selection_provider` mirroring `EntityInspector` so it follows
+`HierarchyTool.selected_entity` (viewport click-select and ESC-clear stay for
+the no-provider case); `ConfigInspector` — registered at F6 but absent from
+`pyguara/tools/__init__` — was added to the package exports. **Left open /
+parked:** `TransformGizmo` and `PhysicsDebugger` still draw and hit-test with
+`Transform.position` as a *screen* coordinate — no camera transform, aligned
+only at camera origin/zoom 1 — gated on the world-to-screen unification
+(issue #23), now documented on both.
+
+Tests +20 (1909 → 1929): `test_tools.py` gained real lifecycle coverage
+(duplicate-registration runs once not twice, `unregister_tool`/`clear` fire
+`on_removed` and purge all three structures, `iter_shortcuts` order, the
+`_entity_manager` fallback is stable, `PerformanceMonitor` ignores `dt<=0`,
+`EventMonitor.on_removed` detaches); new `test_gizmos.py` (+8, from nothing)
+covers both selection modes, Q/W/E, stale-selection drop and per-mode render;
+`test_assets_tool.py` (+2) pins the disabled buttons as un-clickable.
+`docs/systems/editor.md` updated (F9 row, live `ShortcutsPanel`, the
+`on_removed`/`unregister_tool` lifecycle, the no-scene `_entity_manager`
+caveat, the screen-space limitation).
+
+**Capability gaps (Phase D) → folded into existing issues, no new one.**
+In-overlay authoring gaps — no scroll/clip container so the hierarchy / asset
+/ event lists just truncate (`UIRenderer` has no push/pop clip, shared with
+#49), no custom per-type inspector-drawer hook (a game's own value type always
+renders read-only via `tweakable.py`), no text-field editing (#49), no scene
+save/load button (#53) — belong to **#53** (PyGuara Studio) and **#49** (UI).
+The camera-aware gizmo/debugger is **#23**. `ConfigInspector` edits the
+`GameConfig` object but subsystems cached their config at bootstrap, so most
+edits don't take effect live — a note, not a defect.
+
+---
+
+### `pyguara/cli` — closed 2026-09-08 (branch `refactor/cli-audit`)
 
 `pyguara/cli` in one slice, ~830 lines (`__init__` Click group, `build.py`,
 `atlas_generator.py`), reached only through the `pyguara = pyguara.cli:main`
@@ -847,8 +929,11 @@ Ordered roughly by dependency depth: foundations first, leaves last.
   code reload deleted, `PollingFileWatcher` kept and wired to assets)*
 - [x] `pyguara/cli` — command line entry points *(done — branch
   `refactor/cli-audit`; `pyguara build` / `pyguara atlas`)*
-- [ ] `pyguara/tools` — in-engine debug-overlay suite (inspector, hierarchy,
-  gizmos, event monitor, perf panel); absorbs the `pyguara/editor` parked notes
+- [x] `pyguara/tools` — in-engine debug-overlay suite *(done — branch
+  `refactor/tools-audit`; dup-registration / perf-0-dt / disabled-button
+  fixes, `Tool` lifecycle hook, `TransformGizmo` wired at F9)*
+
+**Queue empty — every Tier 1–4 subsystem has had its Phase A→D pass.**
 
 ---
 
@@ -856,6 +941,7 @@ Ordered roughly by dependency depth: foundations first, leaves last.
 
 | Subsystem | Closed | Summary |
 | --- | --- | --- |
+| `pyguara/tools` | 2026-09-08 | One slice, ~1,750 lines (`base`, `manager`, `inspector`, `tweakable`, `hierarchy`, `assets_browser`, `config_inspector`, `gizmos`, `event_monitor`, `performance`, `debugger`, `shortcuts_panel`), driven by `SandboxApplication` (F12 + F1–F9). The overlay runs, but `test_tools.py`'s ~40 cases were all `MockTool` booleans. **`ToolManager` double-ran a tool on re-registration** — `_tools[name] = tool` deduped but `_render_order.append(name)` did not, so `update`/`render`/`process_event` hit the survivor twice per frame (the `pyguara/systems` "silent duplicate keys" shape); `register_tool` now purges the old name first, and `unregister_tool`/`clear` were added, firing a new `Tool.on_removed()`. **`PerformanceMonitor` fed a `0.0` FPS sample on `dt <= 0`** (`1.0/dt if dt > 0 else 0.0` — the "guard returns a wrong answer" pattern; one paused frame dragged the rolling average 60→40); non-positive `dt` is now skipped, dead `pygame.time.Clock()` removed. **`AssetsTool`'s greyed Spawn/Reload buttons still fired** — `enabled=` was cosmetic; the hit rect is now dropped when disabled (and the Spawn gate corrected to stay live for a not-yet-loaded path). Lifecycle pass (user's choice, full in-slice): `EventMonitor` now unsubscribes in `on_removed` (it `subscribe()`d ×3 and never had a teardown); `SandboxApplication.shutdown()` calls `ToolManager.clear()`; `Tool._entity_manager`'s no-scene fallback is cached instead of a fresh empty per access; `ShortcutsPanel` reads `ToolManager.iter_shortcuts()` live instead of a hard-coded table. `TransformGizmo` wired up (user's choice): registered at F9, follows `HierarchyTool` via a `selection_provider`, had **zero** prior coverage; `ConfigInspector` added to `pyguara/tools/__init__` exports. Tests +20 (1909 → 1929): real lifecycle coverage in `test_tools.py`, new `test_gizmos.py` (+8 from nothing), `test_assets_tool.py` (+2). `docs/systems/editor.md` updated. **Left open:** `TransformGizmo` + `PhysicsDebugger` draw/hit-test in screen space with no camera transform → **#23**; in-overlay authoring gaps (scroll/clip container, custom inspector-drawer hook, text input, scene save/load button) → **#53** / **#49**; `ConfigInspector` edits don't take live effect (subsystems cache config at bootstrap). No new issue. |
 | `pyguara/cli` | 2026-09-08 | One slice, ~830 lines (`__init__` Click group, `build.py`, `atlas_generator.py`), reached only via the `pyguara = pyguara.cli:main` console script. Both commands work — no dead subsystem — but two real defects hid behind uniform generator-test fixtures (distinct-stem, in-bounds, uniform shape). **The atlas generator silently dropped a sprite on a stem collision** — `load_images` keys regions by `file_path.stem`, so `hero.png` + `hero.jpg` both become `"hero"`; `pack()`'s `regions` dict overwrote the first, but both images were still pasted and counted, so `sprite_count` (3) ≠ `len(regions)` (2) and which survived depended on the height-sort. Same "stem collision" shape as `resources.index_directory` / persistence keys. Per the user's choice (**raise, name the files**): a duplicate stem is now a `ValueError` listing the filenames; `pack()` also rejects duplicate names, making `sprite_count == len(regions)` an invariant. **A sprite wider than the atlas was silently cropped** — `pack()` raised "atlas too small" only on *vertical* overflow; an over-wide sprite was placed at x=0, clipped by `Image.paste`, and kept the full (wrong) width in metadata ("guard that returns a wrong answer"). Now both dimensions guarded. Smaller: `generate()` re-ingested its own output when `-o`/`-m` landed inside `-i` — now excludes the resolved output paths; dead `allow_rotation` param removed; the argparse `main()` for `python -m pyguara.cli.atlas_generator` now **delegates** to the Click command (user's choice — one option surface); `pyguara/cli/__init__` aliased its sub-command imports (they shadowed the `pyguara.cli.build` *module* attribute). `build.py` swept: launches `python -m PyInstaller` not a bare `pyinstaller` on PATH; dead `if result.returncode == 0` after `subprocess.run(check=True)` removed; `--onedir` success message now points at the executable not the bundle dir; `.spec` cleaned alongside `build/`; `\b` help markers fixed (`r"""`→`"""` — `\b` was backslash-b, not `\x08`). Tests +9 (1898 → 1907; 1909 with `test_docs_api` picking up the new page): collision guard, both overflow directions (`test_..._pack_too_large` had passed for the wrong reason — vertical triggers first), the `sprite_count`/`regions` invariant, output-exclusion; onedir args, missing-PyInstaller, CLI asset auto-detection. New `docs/systems/cli.md` (no page existed); `zero_to_hero.md` lost its stale "ImGui-based editor" line. Phase D → **#61** ("asset pipeline production layer", sibling of #37/#40/#43/#46/#49/#51/#55/#58): atlas — no transparent-border trim, square fixed-size output only, errors instead of multi-page, shelf packing only (no MaxRects), flat non-namespaced input, emits none of the graphics layer's spritesheet/nine-patch/pivot/frame metadata; build — no cross-compile, no version stamping, no asset-manifest check, no `pyguara new`/`run`/`doctor` lifecycle. Left open: `original_size` metadata redundant until a trim step exists; a cosmetic `runpy` RuntimeWarning from `python -m` on the submodule. |
 | `pyguara/dev` | 2026-09-08 | One slice, ~674 lines (`file_watcher`, `hot_reload`). Like `pyguara/editor`, **the whole subsystem had zero integration** — nothing in the engine, no game, no non-test file imported `HotReloadManager` / `PollingFileWatcher` / `StatefulSystem` / `reload_system_class`. Wayfinder ticket 09 fogged it in 2026 ("whether a pre-alpha engine carries live code reload is a product-scope question deserving its own deliberate answer"). Per the user's choice (**split: delete code-reload, wire the watcher**): the Python-module reload layer (`hot_reload.py`) is **deleted** and `PollingFileWatcher` kept + wired to assets. Probes showed `HotReloadManager` wouldn't have worked as advertised: the class promised `StatefulSystem` state preservation but `reload_module()` had **no `get_state`/`set_state` path** (that protocol + `reload_system_class()` were a separate island with no callers); with the default `auto_reload=True`, `importlib.reload()` ran **on the polling thread** (module top-level code off the main thread); `watch_module("x")` twice registered a fresh lambda each call → one edit fired N reloads. **`PollingFileWatcher` kept, one defect fixed: `check_now()` held a non-reentrant lock across user callbacks** — a change callback calling `watch()`/`unwatch()`/`watched_count` deadlocked the poll thread (probe: `check_now` never returned); now snapshots under the lock and notifies with it released, and the poll loop survives a raising callback. New `AssetReloadWatcher` bridges the watcher to `ResourceManager.reload()` (the primitive the `pyguara/resources` slice built for this): the poll thread **queues** a changed asset's cache key; `Application._update()` calls `drain()` once per frame **on the main thread** (`ResourceManager` isn't safe to mutate under a running frame — same shape as `queue_event()`). Opt-in via `Application.enable_asset_hot_reload()`; `SandboxApplication` calls it. **BREAKING** (pre-alpha): `pyguara.dev.HotReloadManager` / `StatefulSystem` / `reload_system_class` removed. Tests: `test_hot_reload.py` deleted (17, all happy-path against stdlib modules — none touched the deadlock, the double-reload, the missing state path or the wrong-thread reload); new `test_dev.py` (+20 cases, 1893 → 1898). New `docs/systems/dev.md` (no page existed). Phase D → **#40** (already names "hot-reload has a `reload()` primitive but nothing watches the filesystem"): polling-only detection (no `inotify`/`FSEvents`/`ReadDirectoryChangesW`, lags by `poll_interval`, coalesces bursts); watch set follows the resource cache (no "watch the whole `assets/` tree" mode); `reload()` still leaves callers holding a stale instance (re-`load()` — documented). **Product decision recorded:** live Python-code reload is out — deleted, not deferred again. |
 | `pyguara/replay` | 2026-09-08 | One slice, ~1,030 lines (`types`, `recorder`, `player`, `serializer`); wired via `Application` + `InputManager` since wayfinder ticket 18. Defects were all "wired to nothing" / "guard returns a wrong answer", each hidden by uniform test setup. **`ReplaySerializer.save()` wrote an unloadable file on its default call** — it appended an extension only when absent, but `if compress or endswith(".gz")` still gzipped, so `save(data, "run.replay")` (default `compress=True`) put a gzip stream in a `.replay` file; `load()` reads it as text, `json.loads` chokes on the magic byte, the blanket `except Exception` swallows it, returns `None` after `save()` returned `True`. Now the format is derived from the extension (explicit wins); `load()` also refuses a `metadata.version` over `SUPPORTED_VERSION` (written, never read — no migration layer). **`get_metadata()` returned `None` for any replay over ~10 KB** — read first 10 KB, sliced at the last `}`, unbalanced JSON for a 400-frame file while the metadata sat in the first ~120 bytes; now parses the file. **Gamepad input was never recorded** — `record_gamepad_button` / `record_gamepad_axis` had zero callers (gamepad flows `GamepadManager` → `_on_gamepad_*`, never touching the recorder), so a controller session recorded empty while `process_replayed_event` carried GAMEPAD branches for events recording never produced; both callbacks now feed it. **Playback dropped pointer position + the raw UI stream** — `process_replayed_event` rebuilt only bound actions, discarding `event.position` and never re-emitting `OnRawKeyEvent` / `OnMouseEvent`; it now re-dispatches the raw key/mouse stream with recorded position + modifiers (`RecordedInputEvent` gained `modifiers`) and replays MOUSE_MOVE. `ReplayRecorder` stamps the installed package version (was `"0.0.0"`) + UTC `recorded_at` (the persistence pair). **User chose maximal on all three forks: playback now re-drives the loop from recorded per-frame `delta_time`** — `Application.run()`, while a replay plays, takes each frame's duration from `ReplayPlayer.peek_delta()` not the wall clock, so fixed-step count, tweens, particles and `WaitForSeconds` reproduce on any machine (cross-cuts the closed `pyguara/application` loop; `SandboxApplication` inherits `run()`). `ReplayPlayer`'s scrubbing surface (`update()` timestamp model, `seek`, `pause`/`resume`, `playback_speed`) kept as supported public API; `advance_frame()`/`update()` now share `_emit_frame()` / `_finish_if_exhausted()`. Tests +22 (1869 → 1891): the old 25 were broad but shallow + uniform (every player test = one fixture through `advance_frame()`; `update()` had zero coverage; every serializer test saved to an extensionless path; nothing recorded/replayed gamepad). New `docs/systems/replay.md` (no page existed). Phase D → **#58** ("replay production layer", sibling of #37/#40/#43/#46/#51/#55): recorded `seed` reseeds nothing on playback (no RNG service — #28); no replay-library API (`list_replays`/`delete`/browse, user-data-dir rooting — the #43 shape); the scrubbing API has no `pyguara/tools` overlay (#53); capture is input+time only (a game reading `time.time()`/filesystem/network directly breaks determinism silently); `record_action()` has a playback branch but no in-repo consumer. Left open: no format migration layer; a length-framed metadata line would let `get_metadata` skip frame bytes. |
@@ -899,7 +985,7 @@ Concerns that outgrew this file, or that need a decision rather than a fix:
 | [#43](https://github.com/Wedeueis/pyguara/issues/43) | Persistence production layer — the `pyguara/persistence` audit (Phase D) found the subsystem defect-free but thin for a shipped game: no backup / prior-version retention, no save-menu API (`list_saves`, cheap metadata-header read, `delete`/`exists` facade), `FileStorageBackend` rooted at a CWD-relative dir not the OS user-data dir. Envelope `format_version` and run/meta split (#28) noted separately |
 | [#46](https://github.com/Wedeueis/pyguara/issues/46) | AI authoring gaps (from the `pyguara/ai` audit, Phase D) — `SequenceNode`/`SelectorNode` have memory with no *reactive* variant, so a front guard `ConditionNode` stops being re-checked once the sequence advances (the "attack while visible, else patrol" pattern silently keeps attacking); `ParallelNode` re-ticks already-completed children; FSM has no transition table / event-driven transitions; every BT leaf is a hand-written closure (no stock `BlackboardCondition` / `SetBlackboard` / `Cooldown` / `RandomSelector`); `_wander_targets` is evicted only on scene exit. Navmesh funnel/portals/generation and steering-vs-physics parked separately (flow-field is #28's) |
 | [#51](https://github.com/Wedeueis/pyguara/issues/51) | Prefab authoring & production layer (from the `pyguara/prefabs` audit, Phase D) — no spawn tables / weighted prefab pools (`create` is one at a time, no selection primitive); `PrefabData.version` declared "for migration support" and read by nothing (no prefab-schema migration, while `persistence` has a `MigrationRegistry`); no named variant library (`overrides` is per-call only); prefab children are linked `Transform`↔`Transform` only — the child entity has no parent-*entity* back-reference or shared lifetime, so despawning an enemy leaks its prefab-attached child entities (needs an ECS-hierarchy decision, cross-cutting with `pyguara/ecs`); no asset-reference validation at load. `ComponentRegistry` process-global mutable singleton parked as a CC |
-| [#53](https://github.com/Wedeueis/pyguara/issues/53) | PyGuara Studio — companion authoring app (from the `pyguara/editor` audit, which deleted a Dear ImGui editor that had never executed and rebuilt its useful parts as `UIRenderer` tools). Level/scene editor, animation editor, agentic authoring harness (grow `tools/agent_view.py`), data-table editors. Needs the build-vs-ImGui architecture decision; the "grow `pyguara/ui`" path is #49's scope. Gated on #49 / #28. In-overlay small items (custom inspector-drawer hook, `TransformGizmo` selection wiring) parked for the `pyguara/tools` slice |
+| [#53](https://github.com/Wedeueis/pyguara/issues/53) | PyGuara Studio — companion authoring app (from the `pyguara/editor` audit, which deleted a Dear ImGui editor that had never executed and rebuilt its useful parts as `UIRenderer` tools). Level/scene editor, animation editor, agentic authoring harness (grow `tools/agent_view.py`), data-table editors. Needs the build-vs-ImGui architecture decision; the "grow `pyguara/ui`" path is #49's scope. Gated on #49 / #28. The `pyguara/tools` slice wired `TransformGizmo` to the hierarchy selection (F9); still open here: a custom per-type inspector-drawer hook (a game's own value type renders read-only via `tweakable.py`), a scroll/clip container for the overlay lists, and a scene save/load button. The gizmo/debugger camera transform is #23. |
 | [#55](https://github.com/Wedeueis/pyguara/issues/55) | Scripting production layer (from the `pyguara/scripting` audit, Phase D) — `CoroutineManager` is one app-global singleton with no scene scoping (a sequence outlives its scene and ticks against unloaded entities; no teardown hook, unlike `SystemManager`); no coroutine tagging / grouping (kill an entity → its scripted sequences keep running, cross-cutting with #51); no `yield from` result / return value or completion signal to a parent sequence; no frame-count / fixed-step waits (`WaitForFrames`, `WaitForFixedUpdate`) and no scaled-vs-realtime wait for a paused game (time-scale is #28's). `WaitForSeconds` frame-granular drift and missing arg validation left open, documented |
 | [#61](https://github.com/Wedeueis/pyguara/issues/61) | Asset pipeline production layer (from the `pyguara/cli` audit, Phase D) — the `pyguara atlas` packer has no transparent-border trimming (a roguelike's sheets are mostly padding; `original_size` metadata is dead until this lands), square fixed-`--size` output only (no shrink-to-fit / pow-of-two), raises instead of emitting atlas page 2/3/…, shelf packing only (MaxRects/skyline would pack denser; `allow_rotation` was a dead stub, removed), a flat non-recursive non-namespaced input scan (keys are bare filename stems), and emits none of the `pyguara/graphics` spritesheet / nine-patch / pivot / animation-frame metadata; `pyguara build` has no cross-compilation / target selection, no version or build-metadata stamping, no asset-manifest verification before shipping, and no project-lifecycle commands (`pyguara new` scaffold, `pyguara run`, `pyguara doctor`). Sibling of #37/#40/#43/#46/#49/#51/#55/#58 |
 | [#58](https://github.com/Wedeueis/pyguara/issues/58) | Replay production layer (from the `pyguara/replay` audit, Phase D) — recorded `seed` is exposed as `ReplayPlayer.seed` but nothing reseeds a random source on playback (no engine RNG service yet — cross-cut #28; replay should reseed it on `load_replay()`); no replay-library API (`list_replays` / `delete` / browse, the shape #43 names for saves) and `FileStorage`-style user-data-dir rooting; the `ReplayPlayer` scrubbing surface (`seek`, `pause`/`resume`, `playback_speed`, `update()`) has no `pyguara/tools` overlay driving it (scrub bar / step / slow-mo — cross-cut #53); capture is input+time only, so a game reading `time.time()` / the filesystem / the network directly breaks determinism silently; `record_action()` (synthetic AI/script-driven actions) has a playback branch but no in-repo consumer. Left open: format `version` validated but no migration layer; a length-framed metadata line would let `get_metadata` skip the frame bytes |

--- a/docs/systems/editor.md
+++ b/docs/systems/editor.md
@@ -32,7 +32,17 @@ Press **F12** to toggle the whole overlay, then a function key per tool.
 | F5 | `HierarchyTool` | List scene entities, click to select |
 | F6 | `ConfigInspector` | Live-edit `GameConfig`, `S` to save |
 | F7 | `AssetsTool` | Browse resources, spawn entities from data |
-| F8 | `ShortcutsPanel` | This table, in-game |
+| F8 | `ShortcutsPanel` | This table, in-game (read live from the `ToolManager`) |
+| F9 | `TransformGizmo` | Position/rotation/scale handles on the selected entity; `Q`/`W`/`E` switch mode |
+
+`ShortcutsPanel` builds its table from `ToolManager.iter_shortcuts()` at
+render time, so it stays in step with whatever `SandboxApplication`
+registered rather than a hand-kept copy.
+
+> **Screen-space only.** `TransformGizmo` and `PhysicsDebugger` currently
+> draw and hit-test using `Transform.position` as a *screen* coordinate --
+> no camera transform. They line up only with the camera at the origin at
+> zoom 1. The world-to-screen unification (issue #23) is the fix.
 
 ## Hierarchy + Inspector
 
@@ -113,9 +123,18 @@ class SpawnCounter(Tool):
 import pygame
 
 app = create_sandbox_application()
-app._tool_manager.register_tool(SpawnCounter(app._container), pygame.K_F9)
+app._tool_manager.register_tool(SpawnCounter(app._container), pygame.K_F10)
 ```
 
-`Tool._entity_manager` resolves the active scene's `EntityManager` fresh on
-every access. Return `True` from `process_event` to stop an event reaching
-the game.
+Registering a name that is already taken **replaces** the old tool (its
+render-order slot and shortcut are dropped first). `ToolManager.unregister_tool(name)`
+removes a tool and calls its `Tool.on_removed()` hook -- override that to
+undo anything `__init__` acquired, such as an `EventDispatcher` subscription
+(`EventMonitor` does). `SandboxApplication.shutdown()` clears every tool this
+way before the engine tears down.
+
+`Tool._entity_manager` resolves the active scene's `EntityManager` on every
+access. **Before the first scene switch there is no world**, so it returns a
+single throwaway empty manager -- fine to read, but a tool that *mutates* the
+world in that window is writing into an orphan no scene will ever see. Return
+`True` from `process_event` to stop an event reaching the game.

--- a/pyguara/application/sandbox.py
+++ b/pyguara/application/sandbox.py
@@ -14,6 +14,7 @@ from pyguara.tools.assets_browser import AssetsTool
 from pyguara.tools.config_inspector import ConfigInspector
 from pyguara.tools.debugger import PhysicsDebugger
 from pyguara.tools.event_monitor import EventMonitor
+from pyguara.tools.gizmos import TransformGizmo
 from pyguara.tools.hierarchy import HierarchyTool
 from pyguara.tools.inspector import EntityInspector
 from pyguara.tools.manager import ToolManager
@@ -50,13 +51,16 @@ class SandboxApplication(Application):
         self.logger.info("Initializing Developer Tools")
 
         self._tool_manager = ToolManager(self._container)
+        # Registered so tools (e.g. ShortcutsPanel) can read the live shortcut
+        # map instead of hard-coding a copy that drifts.
+        self._container.register_instance(ToolManager, self._tool_manager)
 
         # 1. Performance Monitor (F1) - FPS and Stats
         perf_monitor = PerformanceMonitor(self._container)
         self._tool_manager.register_tool(perf_monitor, pygame.K_F1)
 
         # 2. Hierarchy (F5) - entity list + selection. Built before the
-        #    inspector, which follows its selection.
+        #    inspector and gizmo, which both follow its selection.
         hierarchy = HierarchyTool(self._container)
         self._tool_manager.register_tool(hierarchy, pygame.K_F5)
 
@@ -65,6 +69,13 @@ class SandboxApplication(Application):
             self._container, selection_provider=lambda: hierarchy.selected_entity
         )
         self._tool_manager.register_tool(inspector, pygame.K_F2)
+
+        # 3b. Transform Gizmo (F9) - visual handles for the selected entity.
+        #     Q/W/E switch translate/rotate/scale. Follows the Hierarchy.
+        gizmo = TransformGizmo(
+            self._container, selection_provider=lambda: hierarchy.selected_entity
+        )
+        self._tool_manager.register_tool(gizmo, pygame.K_F9)
 
         # 4. Event Monitor (F3) - Log Viewer
         event_mon = EventMonitor(self._container)
@@ -90,6 +101,16 @@ class SandboxApplication(Application):
         self._tool_manager.toggle_global_visibility()
 
         self.logger.info("Tools loaded. Press F8 for help")
+
+    def shutdown(self) -> None:
+        """Tear tools down before the engine, then shut the engine down.
+
+        `EventMonitor` and any custom tool that subscribed to the dispatcher
+        must let go of it while it is still alive.
+        """
+        if self._tool_manager is not None:
+            self._tool_manager.clear()
+        super().shutdown()
 
     def _process_input(self, frame_time: float) -> None:
         """Process input events, prioritizing developer tools."""

--- a/pyguara/tools/__init__.py
+++ b/pyguara/tools/__init__.py
@@ -6,6 +6,7 @@ visualizing physics, and manipulating entity transforms.
 
 from pyguara.tools.assets_browser import AssetsTool
 from pyguara.tools.base import Tool
+from pyguara.tools.config_inspector import ConfigInspector
 from pyguara.tools.debugger import PhysicsDebugger
 from pyguara.tools.event_monitor import EventMonitor
 from pyguara.tools.gizmos import GizmoColors, GizmoMode, TransformGizmo
@@ -17,6 +18,7 @@ from pyguara.tools.shortcuts_panel import ShortcutsPanel
 
 __all__ = [
     "AssetsTool",
+    "ConfigInspector",
     "EntityInspector",
     "EventMonitor",
     "GizmoColors",

--- a/pyguara/tools/assets_browser.py
+++ b/pyguara/tools/assets_browser.py
@@ -146,11 +146,18 @@ class AssetsTool(Tool):
         cached = dict(self._resources.iter_cached())
         resource = cached.get(path)
         is_data = isinstance(resource, DataResource)
+        is_loaded = resource is not None
+        # Spawn is for data files; a not-yet-loaded path might be one (we find
+        # out on click), so it is only *disabled* when the loaded resource is
+        # definitively not a DataResource.
+        can_spawn = is_data or not is_loaded
 
-        self._spawn_rect = _button(renderer, "Spawn into Scene", x, y, enabled=is_data)
-        self._reload_rect = _button(
-            renderer, "Reload", x + 160, y, enabled=resource is not None
-        )
+        # Draw both buttons every frame, but only keep the hit rect for the
+        # one that is actually enabled -- a greyed-out button must not act.
+        spawn_rect = _button(renderer, "Spawn into Scene", x, y, enabled=can_spawn)
+        reload_rect = _button(renderer, "Reload", x + 160, y, enabled=is_loaded)
+        self._spawn_rect = spawn_rect if can_spawn else None
+        self._reload_rect = reload_rect if is_loaded else None
         y += 28
 
         if is_data:

--- a/pyguara/tools/base.py
+++ b/pyguara/tools/base.py
@@ -25,6 +25,10 @@ class Tool(ABC):
         self._container = container
         self._is_visible: bool = True
         self._is_active: bool = True
+        # Reused across accesses during the no-scene window (see below) so a
+        # tool that reads the world twice in one frame sees one manager, not
+        # two fresh empties.
+        self._fallback_entity_manager: EntityManager | None = None
 
     @property
     def _entity_manager(self) -> EntityManager:
@@ -32,19 +36,25 @@ class Tool(ABC):
 
         There's no global EntityManager to resolve from the container -- each
         scene owns its own world (see Scene-owned world and SystemManager).
-        Fetched fresh on every access (not cached at construction time, which
-        runs before any scene is registered/active) so tools always see
-        whichever scene is currently on top, same as `editor/layer.py`'s
-        `scene_manager.current_scene.entity_manager` pattern. Falls back to a
-        throwaway empty manager if no scene is active yet (e.g. a tool
-        rendering during the brief window before the first scene switch).
+        Resolved on every access (not cached at construction time, which runs
+        before any scene is registered/active) so tools always see whichever
+        scene is currently on top, same as `editor/layer.py`'s
+        `scene_manager.current_scene.entity_manager` pattern.
+
+        Before the first scene switch there is no world, so this returns a
+        single throwaway empty manager (reused across accesses, not a new one
+        each time). A tool that *mutates* the world in that window is writing
+        into an orphan that no scene will ever see -- read-only use only until
+        a scene is active.
         """
         from pyguara.scene.manager import SceneManager
 
         current_scene = self._container.get(SceneManager).current_scene
         if current_scene is not None:
             return current_scene.entity_manager
-        return EntityManager()
+        if self._fallback_entity_manager is None:
+            self._fallback_entity_manager = EntityManager()
+        return self._fallback_entity_manager
 
     @property
     def is_visible(self) -> bool:
@@ -99,3 +109,12 @@ class Tool(ABC):
             True if the event was consumed by the tool, False otherwise.
         """
         return False
+
+    def on_removed(self) -> None:
+        """Release anything acquired in ``__init__`` (subscriptions, handles).
+
+        Called by :meth:`ToolManager.unregister_tool`. The default is a no-op;
+        a tool that subscribes to the ``EventDispatcher`` (or holds any other
+        resource that outlives it) must override this to undo that, or the
+        handler keeps firing against a dead tool.
+        """

--- a/pyguara/tools/event_monitor.py
+++ b/pyguara/tools/event_monitor.py
@@ -2,6 +2,7 @@
 
 import time
 from collections import deque
+from typing import Any
 
 from pyguara.common.types import Color, Rect, Vector2
 from pyguara.di.container import DIContainer
@@ -24,13 +25,26 @@ class EventMonitor(Tool):
         self._log: deque[str] = deque(maxlen=20)
         self._panel_rect = Rect(10, 600, 400, 200)
 
-        # Subscribe to interesting events
+        # Subscribe to interesting events. The (type, handler) pairs are kept
+        # so on_removed() can undo every one -- an EventMonitor that is
+        # unregistered must stop receiving events, not keep appending to a
+        # log nobody renders. (MouseMotion omitted to avoid spamming.)
+        self._subscriptions: list[tuple[type, Any]] = [
+            (OnRawKeyEvent, self._on_key_down),
+            (OnActionEvent, self._on_action),
+            (QuitEvent, self._on_quit),
+        ]
         self._dispatcher.subscribe(
             OnRawKeyEvent, self._on_key_down, filter_func=lambda e: e.is_down
         )
         self._dispatcher.subscribe(OnActionEvent, self._on_action)
         self._dispatcher.subscribe(QuitEvent, self._on_quit)
-        # We omit MouseMotion to avoid spamming the log, or we could sample it
+
+    def on_removed(self) -> None:
+        """Drop every dispatcher subscription this monitor made."""
+        for event_type, handler in self._subscriptions:
+            self._dispatcher.unsubscribe(event_type, handler)
+        self._subscriptions.clear()
 
     def _log_msg(self, category: str, msg: str) -> None:
         """Add a formatted message to the log.

--- a/pyguara/tools/gizmos.py
+++ b/pyguara/tools/gizmos.py
@@ -5,6 +5,7 @@ and entity selection highlighting.
 """
 
 import math
+from collections.abc import Callable
 from enum import Enum, auto
 from typing import Any
 
@@ -48,17 +49,38 @@ class TransformGizmo(Tool):
     - Selection bounding box
 
     Toggle modes with Q (translate), W (rotate), E (scale).
-    Click entities to select them.
+
+    Selection has two modes, matching `EntityInspector`:
+
+    - **Provided**: pass `selection_provider` (the sandbox wires it to
+      `HierarchyTool.selected_entity`) and the gizmo follows that entity;
+      clicking the viewport and pressing ESC do nothing.
+    - **Click** (no provider): click an entity to select it, ESC to clear.
+
+    .. note::
+       Drawing and hit-testing currently treat ``Transform.position`` as a
+       *screen* coordinate -- there is no camera transform, so the gizmo is
+       only aligned when the camera sits at the origin at zoom 1. Fixing this
+       is gated on the world-to-screen unification (issue #23); the same
+       caveat applies to ``PhysicsDebugger``.
     """
 
-    def __init__(self, container: DIContainer) -> None:
+    def __init__(
+        self,
+        container: DIContainer,
+        selection_provider: Callable[[], Entity | None] | None = None,
+    ) -> None:
         """Initialize the transform gizmo.
 
         Args:
             container: DI Container for resolving dependencies.
+            selection_provider: Optional callable returning the entity to
+                manipulate. When given, viewport click-select and ESC-clear
+                are disabled and the gizmo follows this selection.
         """
         super().__init__("transform_gizmo", container)
 
+        self._selection_provider = selection_provider
         self._selected_entity: Entity | None = None
         self._mode = GizmoMode.TRANSLATE
 
@@ -117,12 +139,15 @@ class TransformGizmo(Tool):
         return None
 
     def update(self, dt: float) -> None:
-        """Update gizmo state.
+        """Refresh the selection and drop it if it is no longer valid.
 
         Args:
             dt: Delta time in seconds.
         """
-        # Validate selection still exists
+        if self._selection_provider is not None:
+            self._selected_entity = self._selection_provider()
+
+        # Validate selection still exists and still has a Transform
         if self._selected_entity is not None:
             try:
                 if not self._selected_entity.has_component(Transform):
@@ -299,6 +324,8 @@ class TransformGizmo(Tool):
         if not hasattr(event, "type"):
             return False
 
+        provided = self._selection_provider is not None
+
         # Mode switching with Q, W, E keys
         if event.type == pygame.KEYDOWN:
             if event.key == pygame.K_q:
@@ -310,12 +337,13 @@ class TransformGizmo(Tool):
             elif event.key == pygame.K_e:
                 self._mode = GizmoMode.SCALE
                 return True
-            elif event.key == pygame.K_ESCAPE:
+            elif event.key == pygame.K_ESCAPE and not provided:
                 self._selected_entity = None
                 return True
 
-        # Entity selection on mouse click
-        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+        # Entity selection on mouse click -- only when this gizmo owns the
+        # selection (no external provider driving it).
+        if not provided and event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             mouse_pos = Vector2(event.pos[0], event.pos[1])
             self.select_at_position(mouse_pos)
             # Don't consume - let the click propagate

--- a/pyguara/tools/manager.py
+++ b/pyguara/tools/manager.py
@@ -35,14 +35,23 @@ class ToolManager:
     def register_tool(self, tool: Tool, shortcut_key: int | None = None) -> None:
         """Register a new tool with the manager.
 
+        Registering a name that is already taken *replaces* the old tool: its
+        render-order slot and any shortcut it held are dropped first, so the
+        replacement is not run twice per frame (a bare ``append`` used to
+        leave a stale duplicate in the render order).
+
         Args:
             tool: The tool instance to register.
             shortcut_key: Optional pygame key code to toggle this tool.
         """
+        if tool.name in self._tools:
+            logger.debug("Replacing already-registered tool '%s'", tool.name)
+            self._forget(tool.name)
+
         self._tools[tool.name] = tool
         self._render_order.append(tool.name)
 
-        if shortcut_key:
+        if shortcut_key is not None:
             self._shortcuts[shortcut_key] = tool.name
 
         # By default, tools start hidden until the global toggle (F12) is active
@@ -50,6 +59,44 @@ class ToolManager:
         tool.hide()
 
         logger.debug("Registered tool '%s' (Key: %s)", tool.name, shortcut_key)
+
+    def unregister_tool(self, name: str) -> bool:
+        """Remove a tool, calling its :meth:`Tool.on_removed` hook.
+
+        Drops the tool from the registry, the render order and any shortcut
+        binding. Returns ``True`` if a tool by that name was found.
+        """
+        tool = self._tools.get(name)
+        if tool is None:
+            return False
+        self._forget(name)
+        tool.on_removed()
+        logger.debug("Unregistered tool '%s'", name)
+        return True
+
+    def _forget(self, name: str) -> None:
+        """Drop every reference to ``name`` from the manager's own bookkeeping.
+
+        Does not touch the tool object itself (no ``on_removed`` call) -- that
+        is ``unregister_tool``'s job; a replacing ``register_tool`` keeps the
+        old instance alive on purpose.
+        """
+        self._tools.pop(name, None)
+        self._render_order = [n for n in self._render_order if n != name]
+        self._shortcuts = {k: v for k, v in self._shortcuts.items() if v != name}
+
+    def iter_shortcuts(self) -> list[tuple[int, str]]:
+        """Return the ``(key_code, tool_name)`` bindings, in key order."""
+        return sorted(self._shortcuts.items())
+
+    def clear(self) -> None:
+        """Unregister every tool, firing each one's ``on_removed`` hook.
+
+        Used on application shutdown so tools that subscribed to the event
+        dispatcher let go of it before it is torn down.
+        """
+        for name in list(self._tools):
+            self.unregister_tool(name)
 
     def get_tool(self, name: str) -> Tool | None:
         """Retrieve a registered tool by name.

--- a/pyguara/tools/performance.py
+++ b/pyguara/tools/performance.py
@@ -2,8 +2,6 @@
 
 from collections import deque
 
-import pygame
-
 from pyguara.common.types import Color, Rect, Vector2
 from pyguara.di.container import DIContainer
 from pyguara.graphics.protocols import UIRenderer
@@ -23,20 +21,21 @@ class PerformanceMonitor(Tool):
             container: The DI container.
         """
         super().__init__("performance_monitor", container)
-        self._clock = pygame.time.Clock()
         self._fps_history: deque[float] = deque(maxlen=60)
         self._avg_fps = 0.0
 
     def update(self, dt: float) -> None:
-        """Calculate FPS statistics.
+        """Fold this frame's duration into the rolling FPS average.
 
         Args:
-            dt: Delta time.
+            dt: Delta time in seconds.
         """
-        # Note: In a real app, you'd get the actual clock from the container
-        # This is just an estimation for the tool's update cycle
-        current_fps = 1.0 / dt if dt > 0 else 0.0
-        self._fps_history.append(current_fps)
+        # A non-positive dt (first frame, a pause, a clock that went
+        # backwards) has no meaningful FPS -- skip it rather than feeding a
+        # 0.0 sample that would drag the average down for a full second.
+        if dt <= 0:
+            return
+        self._fps_history.append(1.0 / dt)
         self._avg_fps = sum(self._fps_history) / len(self._fps_history)
 
     def render(self, renderer: UIRenderer) -> None:

--- a/pyguara/tools/shortcuts_panel.py
+++ b/pyguara/tools/shortcuts_panel.py
@@ -1,13 +1,32 @@
 """Keyboard shortcuts reference panel."""
 
+import pygame
+
 from pyguara.common.types import Color, Rect, Vector2
 from pyguara.di.container import DIContainer
 from pyguara.graphics.protocols import UIRenderer
 from pyguara.tools.base import Tool
+from pyguara.tools.manager import ToolManager
+
+# Keys a tool handles internally (not global toggles), so they never appear in
+# ToolManager's shortcut map. Kept as a short static list rather than left
+# undocumented.
+_IN_TOOL_KEYS = [
+    ("TAB", "Entity Inspector: cycle entities (when standalone)"),
+    ("S", "Config Inspector: save"),
+    ("Q / W / E", "Transform Gizmo: translate / rotate / scale"),
+    ("ESC", "Transform Gizmo: clear selection (when standalone)"),
+]
 
 
 class ShortcutsPanel(Tool):
-    """Displays a list of available tool shortcuts."""
+    """Lists the live tool shortcuts, read from the `ToolManager` itself.
+
+    The toggle table is built from `ToolManager.iter_shortcuts()` at render
+    time, so it cannot drift from what `SandboxApplication` actually
+    registered. Falls back to just F12 if no `ToolManager` is in the
+    container.
+    """
 
     def __init__(self, container: DIContainer) -> None:
         """Initialize the shortcuts panel.
@@ -17,22 +36,23 @@ class ShortcutsPanel(Tool):
         """
         super().__init__("shortcuts_panel", container)
         # Centered Panel (approximate)
-        self._rect = Rect(300, 200, 400, 300)
-
-        self._shortcuts = [
-            ("F1", "Performance Monitor"),
-            ("F2", "Entity Inspector"),
-            ("F3", "Event Monitor"),
-            ("F4", "Physics Debugger"),
-            ("F5", "Hierarchy"),
-            ("F6", "Config Inspector"),
-            ("F7", "Assets Browser"),
-            ("F8", "Shortcuts Panel (This)"),
-            ("F12", "Toggle ALL Tools"),
-        ]
+        self._rect = Rect(300, 180, 440, 400)
+        try:
+            self._manager: ToolManager | None = container.get(ToolManager)
+        except Exception:  # noqa: BLE001 -- ToolManager not registered (bare tests)
+            self._manager = None
 
     def update(self, dt: float) -> None:
         """No-op -- this panel has nothing to update per frame."""
+
+    def _toggle_rows(self) -> list[tuple[str, str]]:
+        rows = [("F12", "Toggle ALL Tools")]
+        if self._manager is None:
+            return rows
+        for key_code, tool_name in self._manager.iter_shortcuts():
+            label = pygame.key.name(key_code).upper()
+            rows.append((label, tool_name.replace("_", " ").title()))
+        return rows
 
     def render(self, renderer: UIRenderer) -> None:
         """Render the help overlay.
@@ -50,12 +70,15 @@ class ShortcutsPanel(Tool):
         renderer.draw_text("Developer Tools", Vector2(x, y), Color(255, 255, 0), 24)
         y += 40
 
-        for key, desc in self._shortcuts:
-            # Key Column
+        for key, desc in self._toggle_rows():
             renderer.draw_text(key, Vector2(x, y), Color(100, 255, 100), 18)
-            # Desc Column
-            renderer.draw_text(desc, Vector2(x + 80, y), Color(255, 255, 255), 18)
-            y += 30
+            renderer.draw_text(desc, Vector2(x + 90, y), Color(255, 255, 255), 18)
+            y += 28
 
-        y += 20
-        renderer.draw_text("Press F8 to Close", Vector2(x, y), Color(150, 150, 150), 16)
+        y += 16
+        renderer.draw_text("In-tool keys", Vector2(x, y), Color(255, 255, 0), 16)
+        y += 24
+        for key, desc in _IN_TOOL_KEYS:
+            renderer.draw_text(key, Vector2(x, y), Color(100, 200, 255), 14)
+            renderer.draw_text(desc, Vector2(x + 90, y), Color(200, 200, 200), 14)
+            y += 20

--- a/tests/test_assets_tool.py
+++ b/tests/test_assets_tool.py
@@ -124,6 +124,51 @@ def test_spawn_without_an_active_scene_reports_and_returns_none(tmp_path) -> Non
     app.shutdown()
 
 
+def test_reload_button_is_not_clickable_when_resource_is_not_loaded(tmp_path) -> None:
+    """An indexed-but-unloaded path: Reload is greyed AND has no hit rect,
+    so clicking where it draws does nothing (the 'enabled' flag used to be
+    cosmetic only)."""
+    app, _ = _app_with_scene()
+    path = _write_goblin(tmp_path)
+    from pyguara.resources.manager import ResourceManager
+
+    app._container.get(ResourceManager).index_directory(str(tmp_path))
+    tool = AssetsTool(app._container)
+    tool._selected_path = path
+    tool.render(_renderer())
+
+    assert tool._reload_rect is None  # not loaded -> no Reload
+    assert tool._spawn_rect is not None  # might be data -> Spawn stays live
+    app.shutdown()
+
+
+def test_spawn_button_is_not_clickable_for_a_loaded_non_data_resource(
+    tmp_path,
+) -> None:
+    app, _ = _app_with_scene()
+    tool = AssetsTool(app._container)
+    tool._selected_path = "/some/sprite.png"
+
+    class _FakeTexture:
+        native_handle = object()
+
+    tool._resources.iter_cached = lambda: iter(  # type: ignore[method-assign]
+        [("/some/sprite.png", _FakeTexture())]
+    )
+    tool.render(_renderer())
+
+    assert tool._spawn_rect is None  # loaded and not a DataResource -> dead
+    assert tool._reload_rect is not None  # loaded -> Reload is fine
+
+    # And a click where the (now absent) Spawn button drew is a no-op.
+    event = MagicMock()
+    event.type = pygame.MOUSEBUTTONDOWN
+    event.button = 1
+    event.pos = (tool._panel_rect.x + 20, tool._panel_rect.y + 400)
+    assert tool.process_event(event) is False
+    app.shutdown()
+
+
 def test_clicking_a_row_selects_it(tmp_path) -> None:
     app, _ = _app_with_scene()
     (tmp_path / "goblin.json").write_text("{}")

--- a/tests/test_gizmos.py
+++ b/tests/test_gizmos.py
@@ -1,0 +1,172 @@
+"""Tests for TransformGizmo -- the visual transform-handle tool.
+
+Wired into `SandboxApplication` (F9) by the pyguara/tools audit; it had zero
+coverage before. Uses the real `create_headless_application()` bootstrap so
+the tool resolves its SceneManager through the actual composition root.
+"""
+
+import os
+
+os.environ["SDL_VIDEODRIVER"] = "dummy"
+os.environ["SDL_AUDIODRIVER"] = "dummy"
+
+from unittest.mock import MagicMock
+
+import pygame
+import pytest
+
+from pyguara.application.bootstrap import create_headless_application
+from pyguara.common.components import Transform
+from pyguara.common.types import Vector2
+from pyguara.graphics.protocols import UIRenderer
+from pyguara.scene.base import Scene
+from pyguara.tools.gizmos import GizmoMode, TransformGizmo
+
+
+class _Scene(Scene):
+    def on_enter(self) -> None:
+        pass
+
+    def on_exit(self) -> None:
+        pass
+
+    def update(self, dt: float) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _quit_pygame():
+    yield
+    pygame.quit()
+
+
+@pytest.fixture
+def app_scene():
+    app = create_headless_application()
+    scene = _Scene("s", app._event_dispatcher)
+    app._scene_manager.register(scene)
+    app._scene_manager.switch_to(scene.name)
+    yield app, scene
+    app.shutdown()
+
+
+def _key(code: int) -> MagicMock:
+    ev = MagicMock()
+    ev.type = pygame.KEYDOWN
+    ev.key = code
+    return ev
+
+
+def _entity_with_transform(scene, x=0.0, y=0.0):
+    e = scene.entity_manager.create_entity()
+    e.add_component(Transform(position=Vector2(x, y), interpolate=False))
+    return e
+
+
+class TestModeSwitching:
+    def test_qwe_switch_modes_and_consume(self, app_scene) -> None:
+        app, _ = app_scene
+        gizmo = TransformGizmo(app._container)
+
+        assert gizmo.mode is GizmoMode.TRANSLATE
+        assert gizmo.process_event(_key(pygame.K_w)) is True
+        assert gizmo.mode is GizmoMode.ROTATE
+        assert gizmo.process_event(_key(pygame.K_e)) is True
+        assert gizmo.mode is GizmoMode.SCALE
+        assert gizmo.process_event(_key(pygame.K_q)) is True
+        assert gizmo.mode is GizmoMode.TRANSLATE
+
+
+class TestClickSelectionMode:
+    """No selection_provider: the gizmo owns selection via viewport clicks."""
+
+    def test_click_selects_entity_under_cursor(self, app_scene) -> None:
+        app, scene = app_scene
+        entity = _entity_with_transform(scene, 100, 100)
+        gizmo = TransformGizmo(app._container)
+
+        click = MagicMock()
+        click.type = pygame.MOUSEBUTTONDOWN
+        click.button = 1
+        click.pos = (100, 100)
+        gizmo.process_event(click)
+
+        assert gizmo.selected_entity is entity
+
+    def test_escape_clears_selection(self, app_scene) -> None:
+        app, scene = app_scene
+        gizmo = TransformGizmo(app._container)
+        gizmo.selected_entity = _entity_with_transform(scene)
+
+        assert gizmo.process_event(_key(pygame.K_ESCAPE)) is True
+        assert gizmo.selected_entity is None
+
+
+class TestProvidedSelectionMode:
+    """With a selection_provider (the sandbox wiring), the gizmo follows it."""
+
+    def test_update_pulls_selection_from_provider(self, app_scene) -> None:
+        app, scene = app_scene
+        entity = _entity_with_transform(scene)
+        current = {"e": entity}
+        gizmo = TransformGizmo(app._container, selection_provider=lambda: current["e"])
+
+        gizmo.update(0.016)
+        assert gizmo.selected_entity is entity
+
+        current["e"] = None
+        gizmo.update(0.016)
+        assert gizmo.selected_entity is None
+
+    def test_click_and_escape_are_inert_when_provided(self, app_scene) -> None:
+        app, scene = app_scene
+        entity = _entity_with_transform(scene, 50, 50)
+        gizmo = TransformGizmo(app._container, selection_provider=lambda: entity)
+        gizmo.update(0.016)
+
+        # ESC must not clear a provider-driven selection
+        assert gizmo.process_event(_key(pygame.K_ESCAPE)) is False
+        assert gizmo.selected_entity is entity
+
+        # A viewport click must not hijack selection
+        click = MagicMock()
+        click.type = pygame.MOUSEBUTTONDOWN
+        click.button = 1
+        click.pos = (50, 50)
+        gizmo.process_event(click)
+        assert gizmo.selected_entity is entity
+
+
+class TestValidationAndRender:
+    def test_update_drops_selection_that_lost_its_transform(self, app_scene) -> None:
+        app, scene = app_scene
+        entity = _entity_with_transform(scene)
+        gizmo = TransformGizmo(app._container)
+        gizmo.selected_entity = entity
+
+        entity.remove_component(Transform)
+        gizmo.update(0.016)
+
+        assert gizmo.selected_entity is None
+
+    def test_render_is_a_noop_without_a_selection(self, app_scene) -> None:
+        app, _ = app_scene
+        gizmo = TransformGizmo(app._container)
+        renderer = MagicMock(spec=UIRenderer)
+
+        gizmo.render(renderer)
+
+        renderer.draw_line.assert_not_called()
+        renderer.draw_rect.assert_not_called()
+
+    def test_render_draws_handles_for_each_mode(self, app_scene) -> None:
+        app, scene = app_scene
+        gizmo = TransformGizmo(app._container)
+        gizmo.selected_entity = _entity_with_transform(scene, 200, 150)
+        renderer = MagicMock(spec=UIRenderer)
+
+        for mode in GizmoMode:
+            gizmo.mode = mode
+            renderer.reset_mock()
+            gizmo.render(renderer)
+            assert renderer.draw_line.called or renderer.draw_circle.called

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -420,3 +420,179 @@ class TestMultipleTools:
         manager.update(0.016)
 
         assert all(tool.update_called for tool in tools)
+
+
+class _CountingTool(Tool):
+    """Counts how many times each lifecycle hook fired."""
+
+    def __init__(self, name: str, container: DIContainer) -> None:
+        super().__init__(name, container)
+        self.updates = 0
+        self.renders = 0
+        self.events = 0
+        self.removed = 0
+
+    def update(self, dt: float) -> None:
+        self.updates += 1
+
+    def render(self, renderer: UIRenderer) -> None:
+        self.renders += 1
+
+    def process_event(self, event: Any) -> bool:
+        self.events += 1
+        return False
+
+    def on_removed(self) -> None:
+        self.removed += 1
+
+
+class TestToolManagerLifecycle:
+    """Duplicate registration, unregistration, and the shortcut accessor."""
+
+    def test_reregistering_a_name_replaces_without_double_running(
+        self, container: DIContainer, mock_renderer: MagicMock
+    ) -> None:
+        """A bare append used to leave a stale name in _render_order, so the
+        replacement ran update/render/process_event twice per frame."""
+        manager = ToolManager(container)
+        manager._is_globally_visible = True
+
+        first = _CountingTool("dup", container)
+        second = _CountingTool("dup", container)
+        manager.register_tool(first)
+        manager.register_tool(second)
+
+        assert manager._render_order == ["dup"]
+        assert manager.get_tool("dup") is second
+
+        second.show()
+        manager.update(0.016)
+        manager.render(mock_renderer)
+        ev = MagicMock()
+        ev.type = pygame.MOUSEBUTTONDOWN
+        manager.process_event(ev)
+
+        assert (second.updates, second.renders, second.events) == (1, 1, 1)
+        assert first.updates == 0  # the replaced instance is dropped
+
+    def test_reregistering_drops_the_old_shortcut(self, container: DIContainer) -> None:
+        manager = ToolManager(container)
+        tool = MockTool("dup", container)
+        manager.register_tool(tool, pygame.K_F1)
+        manager.register_tool(MockTool("dup", container), pygame.K_F2)
+
+        assert pygame.K_F1 not in manager._shortcuts
+        assert manager._shortcuts[pygame.K_F2] == "dup"
+
+    def test_unregister_removes_from_every_structure_and_calls_hook(
+        self, container: DIContainer
+    ) -> None:
+        manager = ToolManager(container)
+        tool = _CountingTool("gone", container)
+        manager.register_tool(tool, pygame.K_F4)
+
+        assert manager.unregister_tool("gone") is True
+
+        assert manager.get_tool("gone") is None
+        assert "gone" not in manager._render_order
+        assert pygame.K_F4 not in manager._shortcuts
+        assert tool.removed == 1
+
+    def test_unregister_unknown_tool_returns_false(
+        self, container: DIContainer
+    ) -> None:
+        assert ToolManager(container).unregister_tool("nope") is False
+
+    def test_clear_unregisters_everything(self, container: DIContainer) -> None:
+        manager = ToolManager(container)
+        tools = [_CountingTool(f"t{i}", container) for i in range(3)]
+        for t in tools:
+            manager.register_tool(t)
+
+        manager.clear()
+
+        assert manager._tools == {}
+        assert manager._render_order == []
+        assert all(t.removed == 1 for t in tools)
+
+    def test_iter_shortcuts_is_sorted_by_key(self, container: DIContainer) -> None:
+        manager = ToolManager(container)
+        manager.register_tool(MockTool("b", container), pygame.K_F5)
+        manager.register_tool(MockTool("a", container), pygame.K_F1)
+
+        assert manager.iter_shortcuts() == [
+            (pygame.K_F1, "a"),
+            (pygame.K_F5, "b"),
+        ]
+
+
+class TestToolEntityManagerFallback:
+    """The no-scene fallback must be one manager, not a fresh empty each time."""
+
+    def test_fallback_manager_is_stable_across_accesses(
+        self, container: DIContainer
+    ) -> None:
+        from pyguara.scene.manager import SceneManager
+
+        container.register_instance(SceneManager, SceneManager())
+        tool = MockTool("t", container)
+
+        assert tool._entity_manager is tool._entity_manager
+
+
+class TestPerformanceMonitor:
+    def test_non_positive_dt_does_not_pollute_the_average(
+        self, container: DIContainer
+    ) -> None:
+        from pyguara.tools.performance import PerformanceMonitor
+
+        pm = PerformanceMonitor(container)
+        pm.update(1 / 60)
+        pm.update(1 / 60)
+        good = pm._avg_fps
+        assert good == pytest.approx(60.0)
+
+        pm.update(0.0)  # paused / first frame
+        pm.update(-0.5)  # clock went backwards
+
+        assert pm._avg_fps == pytest.approx(good)
+        assert 0.0 not in pm._fps_history
+
+
+class TestEventMonitorTeardown:
+    def test_on_removed_unsubscribes_from_the_dispatcher(
+        self, container: DIContainer
+    ) -> None:
+        from pyguara.events.dispatcher import EventDispatcher
+        from pyguara.input.events import OnRawKeyEvent
+        from pyguara.tools.event_monitor import EventMonitor
+
+        dispatcher = EventDispatcher()
+        container.register_instance(EventDispatcher, dispatcher)
+        monitor = EventMonitor(container)
+
+        dispatcher.dispatch(OnRawKeyEvent(key_code=97, is_down=True, modifiers=set()))
+        assert len(monitor._log) == 1
+
+        monitor.on_removed()
+        dispatcher.dispatch(OnRawKeyEvent(key_code=98, is_down=True, modifiers=set()))
+        assert len(monitor._log) == 1  # no new line -- handler is gone
+
+    def test_tool_manager_unregister_fires_on_removed(
+        self, container: DIContainer
+    ) -> None:
+        from pyguara.events.dispatcher import EventDispatcher
+        from pyguara.input.events import OnRawKeyEvent
+        from pyguara.tools.event_monitor import EventMonitor
+
+        dispatcher = EventDispatcher()
+        container.register_instance(EventDispatcher, dispatcher)
+        manager = ToolManager(container)
+        manager.register_tool(EventMonitor(container), pygame.K_F3)
+
+        manager.unregister_tool("event_monitor")
+
+        dispatcher.dispatch(OnRawKeyEvent(key_code=97, is_down=True, modifiers=set()))
+        # Nothing observes the log now, but the point is no exception and the
+        # handler is detached -- assert via a fresh monitor being the only one.
+        assert manager.get_tool("event_monitor") is None


### PR DESCRIPTION
Subsystem audit — **`pyguara/tools`**, the last entry in the pending queue.
~1,750 lines: `base`, `manager`, `inspector`, `tweakable`, `hierarchy`,
`assets_browser`, `config_inspector`, `gizmos`, `event_monitor`,
`performance`, `debugger`, `shortcuts_panel`; driven by `SandboxApplication`
(F12 master toggle + F1–F9). Independent branch off `main`, not stacked.

The overlay runs, but `test_tools.py`'s ~40 cases were all `MockTool`
booleans that built the subject one way and asserted nothing real, so the
defects were invisible. Each was reproduced with a probe first.

## Phase A — defects fixed

| Defect | Probe |
|--------|-------|
| **`ToolManager` double-ran a tool on re-registration.** `_tools[name] = tool` deduped but `_render_order.append(name)` did not → `update`/`render`/`process_event` each hit the survivor **twice per frame**. The `pyguara/systems` "silent duplicate keys" shape. `register_tool` now purges the old name from `_render_order` and `_shortcuts` first. | two `Spy("dup")` → `_render_order == ['dup','dup']`, one frame → `updates=2` |
| **`PerformanceMonitor` fed a `0.0` FPS sample on any `dt <= 0`** (`1.0/dt if dt > 0 else 0.0` — the tracked "guard returns a wrong answer" pattern). One paused / first / backwards-clock frame dragged the 60-sample average down for a full second. Now skipped, not sampled. Dead `pygame.time.Clock()` removed. | 2 good frames → 60 fps; one `dt=0.0` → **40**; one `dt=-0.5` → **30** |
| **`AssetsTool`'s greyed Spawn/Reload buttons still fired** — `_button(enabled=…)` only changed colours; `process_event` hit-tested and acted regardless (degraded to a "Load failed" status, didn't crash). Hit rect is now dropped when disabled; the Spawn gate was corrected to stay live for a not-yet-loaded path and disable only for a loaded non-`DataResource`. | click greyed "Spawn" on a `.png` → `consumed=True, status='Load failed…'` |

## Phase A — lifecycle pass (full in-slice, per the fork answer)

- `Tool.on_removed()` hook + `ToolManager.unregister_tool()` / `clear()`.
- `EventMonitor` `subscribe()`d ×3 in `__init__` with no teardown path; it
  now unsubscribes every handler in `on_removed()`.
- `SandboxApplication.shutdown()` calls `ToolManager.clear()` before the
  engine tears down.
- `Tool._entity_manager`'s no-scene fallback returned a **fresh** empty
  `EntityManager` on every access (two per frame → two different worlds);
  now cached for that window, with the "read-only until a scene is active"
  caveat documented.
- `ShortcutsPanel` was a hard-coded key table that could drift from
  `sandbox.py`; it now reads `ToolManager.iter_shortcuts()` live
  (`ToolManager` is registered in the DI container) plus a small static
  "in-tool keys" block.

## Phase A — `TransformGizmo` wired up (per the fork answer)

Registered by nothing through two prior audits (in `__all__`, instantiated
only in tests, **zero** coverage). Now registered at **F9** in
`SandboxApplication` with a `selection_provider` following
`HierarchyTool.selected_entity` (mirrors `EntityInspector`; viewport
click-select and ESC-clear remain for the no-provider case).
`ConfigInspector` — registered at F6 but missing from `pyguara/tools/__init__`
— was added to the exports.

**Left open / parked:** `TransformGizmo` and `PhysicsDebugger` draw and
hit-test with `Transform.position` as a *screen* coordinate — no camera
transform, aligned only at camera origin/zoom 1 — gated on the world↔screen
unification (**#23**), now documented on both.

## Phase B — tests

`+20` (1909 → 1929). `test_tools.py` gained real lifecycle coverage
(duplicate-registration runs once not twice; `unregister_tool`/`clear` fire
`on_removed` and purge all three structures; `iter_shortcuts` order; the
`_entity_manager` fallback is stable; `PerformanceMonitor` ignores `dt<=0`;
`EventMonitor.on_removed` detaches). New **`test_gizmos.py`** (+8, from
nothing): both selection modes, Q/W/E, stale-selection drop, per-mode render.
`test_assets_tool.py` (+2): the disabled buttons are un-clickable.

## Phase C — docs

`docs/systems/editor.md`: F9 gizmo row + Q/W/E, live `ShortcutsPanel`, the
`on_removed`/`unregister_tool` lifecycle, the honest no-scene
`_entity_manager` caveat, the screen-space limitation.

## Phase D — capability gaps → folded into existing issues, no new one

In-overlay authoring gaps (no scroll/clip container so the lists truncate;
no custom per-type inspector-drawer hook; no text-field editing; no scene
save/load button) belong to **#53** (PyGuara Studio) and **#49** (UI). The
camera-aware gizmo/debugger is **#23**. `ConfigInspector` edits the config
object but subsystems cache their config at bootstrap, so most edits don't
take live effect — a note, not a defect.

## Verification

`pytest && ruff check . && mypy pyguara && mkdocs build --strict` all pass,
verified in a clean `git worktree` checkout of **each** commit (1929 passed).

`REFACTOR_STATE.md` logged. **This closes the subsystem audit** — every
Tier 1–4 subsystem has had its Phase A→D pass; what remains is the tracked
cross-cutting issues and CCs.

**PR is final — nothing else coming for this iteration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5