### PR TITLE
docs(guides): fix drifted physics references (#30)

### DIFF
--- a/docs/guides/Archictecture & Style Guide.md
+++ b/docs/guides/Archictecture & Style Guide.md
@@ -134,42 +134,42 @@ class Transform(BaseComponent):
 
     # NO METHODS (data only)
     # Logic goes in Systems, not Components
+
+
+@dataclass
+class Velocity(BaseComponent):
+    """Linear velocity in units per second."""
+    value: Vector2 = Vector2(0, 0)
 ```
 
 ### 3.2. System Definition
 
 ```python
 from pyguara.ecs.manager import EntityManager
-from pyguara.common.components import Transform
-from pyguara.physics.components import RigidBody
 
-class PhysicsSystem:
-    """Synchronizes physics engine with ECS transform components.
+class MovementSystem:
+    """Integrates each entity's velocity into its Transform every frame.
 
-    Runs during the physics update phase, before rendering.
+    A system is stateless: it owns no game data, only references to the
+    services it queries. All state lives in the components it reads
+    (`Transform` and `Velocity` from 3.1).
     """
 
-    def __init__(self, entity_manager: EntityManager, physics_engine: IPhysicsEngine):
+    def __init__(self, entity_manager: EntityManager):
         self._entities = entity_manager
-        self._physics = physics_engine
 
     def update(self, dt: float) -> None:
-        """Update all physics-enabled entities."""
-        for entity in self._entities.get_entities_with(Transform, RigidBody):
+        for entity in self._entities.get_entities_with(Transform, Velocity):
             transform = entity.get_component(Transform)
-            rigidbody = entity.get_component(RigidBody)
-
-            # Sync physics -> ECS (for dynamic bodies)
-            if rigidbody.body_type == BodyType.DYNAMIC:
-                physics_body = self._physics.get_body(entity.id)
-                transform.position = physics_body.position
-                transform.rotation = physics_body.rotation
-            # Sync ECS -> physics (for kinematic bodies)
-            else:
-                physics_body = self._physics.get_body(entity.id)
-                physics_body.position = transform.position
-                physics_body.rotation = transform.rotation
+            velocity = entity.get_component(Velocity)
+            transform.position += velocity.value * dt
 ```
+
+For simulated rigid bodies, do not hand-roll this: add `RigidBody` /
+`Collider` components and let the engine's `PhysicsSystem` own the
+Transform↔body sync. For player and NPC movement, use `CharacterBody` with
+`CharacterMover`. See `docs/physics/simulation.md` and
+`docs/physics/character-movement.md`.
 
 ### 3.3. Service Registration
 
@@ -186,10 +186,14 @@ def _setup_container() -> DIContainer:
     container.register_transient(ParticleEmitter, ParticleEmitter)
 
     # Scoped: Shared within a scene/scope
-    container.register_scoped(PhysicsSystem, PhysicsSystem)
+    container.register_scoped(SceneResources, SceneResources)
 
     return container
 ```
+
+Bootstrap registers the core services (see `pyguara/application/bootstrap.py`).
+Gameplay systems such as `PhysicsSystem` are not registered here — a scene
+constructs the ones it needs and ticks them itself.
 
 ### 3.4. Event Definition and Usage
 

--- a/docs/guides/ONBOARDING.md
+++ b/docs/guides/ONBOARDING.md
@@ -102,9 +102,9 @@ Before diving into individual systems, it's crucial to understand the three core
     ```python
     # In your GameplayScene's on_enter method
     player_entity = self.entity_manager.create_entity()
-    self.entity_manager.add_component(player_entity, Transform(position=Vector2(100, 100)))
-    self.entity_manager.add_component(player_entity, PlayerInput())
-    self.entity_manager.add_component(player_entity, Sprite(texture=...))
+    player_entity.add_component(Transform(position=Vector2(100, 100)))
+    player_entity.add_component(PlayerInput())
+    player_entity.add_component(Sprite(texture=...))
     ```
 
 ---
@@ -133,8 +133,8 @@ Before diving into individual systems, it's crucial to understand the three core
     # In a scene's on_enter method
     texture = self.resource_manager.load("sprites/my_sprite.png", Texture)
     my_entity = self.entity_manager.create_entity()
-    self.entity_manager.add_component(my_entity, Transform(position=Vector2(50, 50)))
-    self.entity_manager.add_component(my_entity, Sprite(texture=texture, layer=10))
+    my_entity.add_component(Transform(position=Vector2(50, 50)))
+    my_entity.add_component(Sprite(texture=texture, layer=10))
     ```
 
 ---
@@ -147,17 +147,28 @@ Before diving into individual systems, it's crucial to understand the three core
     *   **PhysicsSystem**: The ECS system that synchronizes data between the game world (`Transform` components) and the physics world (`Pymunk.Body`).
     *   **CollisionSystem**: Receives callbacks from the backend and dispatches high-level `OnCollisionBegin`, `OnTriggerEnter`, etc., events.
 *   **Features:**
-    *   Static, Kinematic, and Dynamic rigid bodies.
-    *   Circle and Box colliders.
+    *   Static, Kinematic, and Dynamic rigid bodies, with per-body sleeping.
+    *   Circle and Box colliders; one-way (pass-through) platforms.
     *   Physics materials (friction, restitution).
     *   Triggers (non-solid colliders).
     *   A rich set of joints (Pin, Spring, Slider).
-    *   Raycasting.
+    *   Spatial queries: `raycast` / `raycast_all`, `point_query`,
+        `overlap_box` / `overlap_box_all`, `overlap_circle`, `region_query`.
+    *   `CharacterMover` / `CharacterBody` for kinematic character control
+        (see `docs/physics/character-movement.md`).
 *   **How to Use:**
     1.  Add a `RigidBody` component to an entity to give it physics properties.
     2.  Add a `Collider` component to give it a physical shape.
     3.  The `PhysicsSystem` will automatically create the body in the Pymunk world.
     4.  For dynamic bodies, the `PhysicsSystem` will update the entity's `Transform` component each frame based on the simulation.
+    5.  For a player or NPC, prefer `CharacterBody` driven by `CharacterMover`
+        instead of a dynamic `RigidBody` — it gives responsive, non-bouncy
+        movement with ground/wall probes. See
+        `docs/physics/character-movement.md`.
+
+    `PhysicsSystem` is not registered by `bootstrap.py`; a scene creates it
+    and calls `PhysicsSystem.update()` (or routes it through the
+    `SystemManager`) itself.
 
     ```python
     from pyguara.physics.components import RigidBody, Collider
@@ -165,9 +176,9 @@ Before diving into individual systems, it's crucial to understand the three core
 
     # Create a dynamic, falling box
     box = self.entity_manager.create_entity()
-    self.entity_manager.add_component(box, Transform())
-    self.entity_manager.add_component(box, RigidBody(body_type=BodyType.DYNAMIC))
-    self.entity_manager.add_component(box, Collider(shape_type=ShapeType.BOX, dimensions=[32, 32]))
+    box.add_component(Transform())
+    box.add_component(RigidBody(body_type=BodyType.DYNAMIC))
+    box.add_component(Collider(shape_type=ShapeType.BOX, dimensions=[32, 32]))
     ```
 
 ---

--- a/docs/guides/PROJECT_STRUCTURE.md
+++ b/docs/guides/PROJECT_STRUCTURE.md
@@ -148,7 +148,7 @@ To add a new feature (e.g., "Stamina") to your game, follow this strict flow:
 | **State** | Store state in `Components`. | Store state in `System` classes (Systems should be stateless logic processors). |
 | **Testing** | Write tests in `tests/` mocking the DI Container. | Test logic by running the game manually. |
 | **Assets** | Load assets via `ResourceManager`. | Hardcode file paths (e.g., `"C:/Users/..."`). |
-| **Physics** | Use `PhysicsSystem` for movement. | Manually update `transform.position` for physics objects. |
+| **Physics** | Use `RigidBody` + `PhysicsSystem` for simulated bodies, and `CharacterBody` + `CharacterMover` for characters. | Manually update `transform.position` for physics objects. |
 
 ## 5. Testing Architecture
 

--- a/docs/guides/zero_to_hero.md
+++ b/docs/guides/zero_to_hero.md
@@ -295,6 +295,11 @@ class PlayerSystem:
 
 For advanced simulation, PyGuara wraps the **Pymunk** rigid body library. Rather than calculating gravity manually, physical objects register `RigidBody` and `Collider` components. The `PhysicsSystem` automatically simulates rigid body calculations and mirrors the resulting coordinates back onto `Transform` components.
 
+> For a **player or NPC**, use `CharacterBody` with `CharacterMover` instead of
+> a dynamic `RigidBody` — it gives crisp, non-bouncy movement with ground and
+> wall detection. See [`docs/physics/character-movement.md`](../physics/character-movement.md).
+> The dynamic-body example below is for props and projectiles.
+
 ### 1. Attaching Physical Components
 ```python
 from pyguara.physics.components import RigidBody, Collider
@@ -303,10 +308,11 @@ from pyguara.physics.types import BodyType, ShapeType
 # Create a dynamic falling circle
 ball = self.entity_manager.create_entity("ball")
 ball.add_component(Transform(position=Vector2(400, 100)))
-# RigidBody declares dynamic mass, friction, and moment parameters
+# RigidBody carries mass and body type; friction/restitution live on the
+# Collider's PhysicsMaterial.
 ball.add_component(RigidBody(body_type=BodyType.DYNAMIC, mass=1.0))
-# Collider sets up the geometry bounds for collision resolver
-ball.add_component(Collider(shape_type=ShapeType.CIRCLE, radius=20.0))
+# Collider dimensions are [radius] for a circle, [width, height] for a box.
+ball.add_component(Collider(shape_type=ShapeType.CIRCLE, dimensions=[20.0]))
 ```
 
 ### 2. Managing Static Ground Boundaries


### PR DESCRIPTION
Closes #30.

The subsystem reference under `docs/physics/` is current; the **guide-level**
docs that mention physics in passing had drifted pre-`CharacterMover`, and one
sample called a method that never existed.

| File | Was | Now |
| --- | --- | --- |
| `Architecture & Style Guide.md` §3.2/3.3 | fake `PhysicsSystem` calling `self._physics.get_body(entity.id)` (no such method on `IPhysicsEngine`/`PymunkEngine`); §3.3 claimed `PhysicsSystem` is `register_scoped`'d in bootstrap | self-contained `MovementSystem` (velocity integration), `Velocity` component added to §3.1, pointer to `docs/physics/` for real physics; §3.3 note that gameplay systems aren't bootstrap-registered |
| `ONBOARDING.md` | `self.entity_manager.add_component(entity, comp)` ×6 — `add_component` is on `Entity` | `entity.add_component(comp)`; §4 capability list expanded (spatial-query family, sleeping, one-way platforms, `CharacterMover`); note to use `CharacterBody` for characters |
| `zero_to_hero.md` Part 4 | `Collider(shape_type=ShapeType.CIRCLE, radius=20.0)` — `Collider` has no `radius` | `dimensions=[20.0]`; corrected the RigidBody/material comment; `CharacterBody` pointer |
| `PROJECT_STRUCTURE.md:151` | "Use `PhysicsSystem` for movement" | reconciled with `CharacterBody`/`CharacterMover` |

**Deliberately out of scope:** the filename typo (`Archictecture`) — it touches
the mkdocs nav and is tracked separately in `REFACTOR_STATE.md`. A doc-fence
smoke check (catching `Foo(bad_kwarg=…)` / attribute calls the way
`test_docs_api.py` catches bad imports) remains a follow-up.

## Verification

`pytest tests/test_docs_api.py` (62 passed) and `mkdocs build --strict` both
pass. Docs-only change — nothing in the Python suite exercises `docs/`.

PR is final — nothing else coming on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5