### PR TITLE
fix(graphics): one world-to-screen transform; drop no-op camera rotation (#23)

### DIFF
--- a/docs/graphics/rendering.md
+++ b/docs/graphics/rendering.md
@@ -99,7 +99,12 @@ Effects can be enabled/disabled at runtime via `effect.enabled = False`.
 ## Components
 
 ### Camera2D
-Handles Coordinate Transformation (World Space <-> Screen Space). Supports Zoom, Rotation, and Panning.
+Handles Coordinate Transformation (World Space <-> Screen Space). Supports Zoom
+and Panning. There is one world-to-screen transform (`screen_offset`);
+`world_to_screen` / `screen_to_world` / `get_view_bounds` are conveniences
+built on it and take an optional `viewport` (defaulting to the camera's
+constructed size). Camera rotation is not supported — the render path does not
+rotate.
 
 ### Viewport
 Defines the drawable region on the screen. Used for:

--- a/pyguara/graphics/components/camera.py
+++ b/pyguara/graphics/components/camera.py
@@ -135,14 +135,20 @@ class Camera2D:
     """
     A 2D Camera component that defines the viewable area of the game world.
 
-    It handles Zoom, Rotation, and Panning math. It does NOT render anything;
-    it simply provides the transformation matrices (or equivalent logic) for the renderer.
+    It handles Zoom and Panning math. It does NOT render anything; it simply
+    provides the transformation the renderer applies.
+
+    There is one world-to-screen transform: ``screen * = world * zoom +
+    screen_offset(viewport)``. ``world_to_screen`` / ``screen_to_world`` /
+    ``get_view_bounds`` are conveniences built on that same
+    ``screen_offset``, so the picture on screen and any hit-testing against
+    it cannot disagree. Rotation is deliberately not supported -- the render
+    path never rotated, so a ``rotation`` attribute would have been a silent
+    no-op (see issue #23).
 
     Attributes:
         position (Vector2): The center of the camera in World Coordinates.
-        offset (Vector2): The center of the viewport in Screen Coordinates.
         zoom (float): The scale factor (1.0 = 100%, 2.0 = 200%).
-        rotation (float): The rotation in degrees.
     """
 
     def __init__(self, width: int, height: int):
@@ -150,13 +156,14 @@ class Camera2D:
         Initialize the Camera with a default viewport size.
 
         Args:
-            width (int): The initial width of the target viewport/screen.
-            height (int): The initial height of the target viewport/screen.
+            width (int): Width of the target viewport/screen, used as the
+                fallback viewport for ``world_to_screen`` and friends when no
+                explicit viewport is passed.
+            height (int): Height of the target viewport/screen.
         """
         self.position: Vector2 = Vector2.zero()
-        self.offset: Vector2 = Vector2(width / 2, height / 2)
+        self._default_viewport: Rect = Rect(0, 0, width, height)
         self._zoom: float = 1.0
-        self.rotation: float = 0.0
 
         # Camera effects
         self._shake: CameraShake | None = None
@@ -195,15 +202,16 @@ class Camera2D:
 
     def set_viewport_size(self, width: int, height: int) -> None:
         """
-        Recalculate the screen offset based on new dimensions.
+        Update the fallback viewport used when no explicit one is passed.
 
-        Call this when the window is resized to keep the camera centered.
+        Call this when the window is resized. Render-path callers pass the
+        real viewport to ``screen_offset`` directly and are unaffected.
 
         Args:
             width (int): New width in pixels.
             height (int): New height in pixels.
         """
-        self.offset = Vector2(width / 2, height / 2)
+        self._default_viewport = Rect(0, 0, width, height)
 
     def screen_offset(self, viewport: Rect) -> Vector2:
         """Compute the translation mapping a zoomed world point into a viewport.
@@ -216,10 +224,9 @@ class Camera2D:
         it double-counts that origin, which is what the batcher used to do;
         a fullscreen viewport hid it because its origin is (0, 0).
 
-        Note this deliberately ignores `self.rotation`, because the render
-        path does: neither the batcher nor the particle system rotates. It is
-        therefore *not* equivalent to `world_to_screen`, which does rotate and
-        centres on `self.offset` rather than the viewport.
+        This is the single world-to-screen definition. `world_to_screen`,
+        `screen_to_world` and `get_view_bounds` are all expressed in terms of
+        it, and the batcher / particle system / light pass call it directly.
 
         Args:
             viewport: The region being drawn into.
@@ -229,81 +236,64 @@ class Camera2D:
         """
         return viewport.center_vec - (self.position * self.zoom)
 
-    def world_to_screen(self, world_pos: Vector2) -> Vector2:
+    def world_to_screen(
+        self, world_pos: Vector2, viewport: Rect | None = None
+    ) -> Vector2:
         """
         Transform a point from World Space to Screen Space.
 
-        Formula: (WorldPos - CamPos) * Zoom + ScreenOffset
+        Formula: ``world_pos * zoom + screen_offset(viewport)``.
 
         Args:
             world_pos (Vector2): The coordinate in the game world.
+            viewport (Rect | None): The region being drawn into. Defaults to
+                the camera's fallback viewport (its constructed size at the
+                window origin) -- correct for a fullscreen view; pass the real
+                viewport for a letterboxed or split-screen one.
 
         Returns:
             Vector2: The pixel coordinate on the screen.
         """
-        # 1. Translate world to camera local
-        local_pos = world_pos - self.position
+        vp = viewport if viewport is not None else self._default_viewport
+        return world_pos * self.zoom + self.screen_offset(vp)
 
-        # 2. Scale (Zoom)
-        local_pos = local_pos * self.zoom
-
-        # 3. Rotate (around camera center)
-        if self.rotation != 0:
-            local_pos = local_pos.rotate_degrees(-self.rotation)
-
-        screen_pos = local_pos + self.offset
-
-        # 4. Translate to screen center
-        return screen_pos
-
-    def screen_to_world(self, screen_pos: Vector2) -> Vector2:
+    def screen_to_world(
+        self, screen_pos: Vector2, viewport: Rect | None = None
+    ) -> Vector2:
         """
         Transform a point from Screen Space (e.g., Mouse) to World Space.
 
-        This is the inverse of world_to_screen.
-        Formula: (ScreenPos - ScreenOffset) / Zoom + CamPos
+        The exact inverse of `world_to_screen`:
+        ``(screen_pos - screen_offset(viewport)) / zoom``.
 
         Args:
-            screen_pos (Vector2): The pixel coordinate (e.g., pygame.mouse.get_pos()).
+            screen_pos (Vector2): The pixel coordinate (e.g. the mouse position).
+            viewport (Rect | None): See `world_to_screen`.
 
         Returns:
             Vector2: The coordinate in the game world.
         """
-        # 1. Translate screen to center relative
-        local_pos = screen_pos - self.offset
+        vp = viewport if viewport is not None else self._default_viewport
+        # No zero guard needed: the zoom setter rejects non-positive values.
+        return (screen_pos - self.screen_offset(vp)) * (1.0 / self.zoom)
 
-        # 2. Inverse Rotate
-        if self.rotation != 0:
-            local_pos = local_pos.rotate_degrees(self.rotation)
-
-        # 3. Inverse scale. No zero guard needed: the zoom setter rejects
-        # non-positive values, so this cannot divide by zero.
-        local_pos = local_pos * (1.0 / self.zoom)
-        world_pos = local_pos + self.position
-
-        # 4. Translate back to world
-        return world_pos
-
-    def get_view_bounds(self) -> Rect:
+    def get_view_bounds(self, viewport: Rect | None = None) -> Rect:
         """
         Calculate the visible rectangle of the world in World Coordinates.
 
         Useful for Culling (not rendering objects outside this rect) or
         keeping the player inside bounds.
 
-        Note:
-            This approximation assumes no rotation for the bounding box calculation.
-            If rotation is used, this returns a generic AABB that fits the view.
+        Args:
+            viewport (Rect | None): See `world_to_screen`.
 
         Returns:
             Rect: The rectangle representing the visible world area.
         """
-        # Calculate the size of the view in world units
-        # ScreenSize / Zoom
-        view_width = (self.offset.x * 2) / self.zoom
-        view_height = (self.offset.y * 2) / self.zoom
+        vp = viewport if viewport is not None else self._default_viewport
+        view_width = vp.width / self.zoom
+        view_height = vp.height / self.zoom
 
-        # Top-left corner in world space
         left = self.position.x - (view_width / 2)
         top = self.position.y - (view_height / 2)
 

--- a/pyguara/graphics/pipeline/passes/light_pass.py
+++ b/pyguara/graphics/pipeline/passes/light_pass.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from pyguara.common.types import Vector2
 from pyguara.graphics.components.camera import Camera2D
 from pyguara.graphics.pipeline.render_pass import BaseRenderPass
 from pyguara.graphics.pipeline.viewport import Viewport
@@ -178,15 +177,15 @@ class LightPass(BaseRenderPass):
             # No camera, can't render lights
             return
 
-        # Calculate viewport offset
-        viewport_center = Vector2(viewport.width / 2, viewport.height / 2)
-        viewport_offset = viewport_center - (self._camera.position * self._camera.zoom)
+        # World-to-screen offset -- the same definition the batcher and the
+        # particle system use, so lit geometry lines up with drawn geometry.
+        screen_offset = self._camera.screen_offset(viewport)
 
         # Get lights in screen space
         lights = self._lighting_system.collect_lights_screen_space(
             self._camera.position,
             self._camera.zoom,
-            viewport_offset + viewport.position,
+            screen_offset,
         )
 
         if not lights:

--- a/tests/test_graphics.py
+++ b/tests/test_graphics.py
@@ -79,6 +79,60 @@ def test_camera_world_to_screen():
     assert screen_pos.x == 600
 
 
+def test_world_to_screen_matches_the_batcher_transform():
+    """One definition: `world_to_screen` is exactly what the batcher applies.
+
+    The batcher does `screen = world * zoom + camera.screen_offset(viewport)`
+    (batch.py). If `world_to_screen` computes anything else, hit-testing
+    against `screen_to_world` silently disagrees with what is drawn -- issue
+    #23. This pins them together for a fullscreen *and* an offset viewport.
+    """
+    camera = Camera2D(800, 600)
+    camera.position = Vector2(120, -40)
+    camera.zoom = 1.5
+
+    for viewport in (
+        Viewport(0, 0, 800, 600),  # fullscreen
+        Viewport(100, 50, 600, 400),  # letterboxed / split-screen
+    ):
+        offset = camera.screen_offset(viewport)
+        for point in (Vector2(0, 0), Vector2(250, 90), Vector2(-30, 400)):
+            expected = point * camera.zoom + offset
+            assert camera.world_to_screen(point, viewport) == expected
+
+
+def test_world_to_screen_round_trips_with_an_explicit_viewport():
+    camera = Camera2D(800, 600)
+    camera.position = Vector2(50, 50)
+    camera.zoom = 2.0
+    viewport = Viewport(100, 50, 600, 400)
+
+    point = Vector2(123, 456)
+    restored = camera.screen_to_world(camera.world_to_screen(point, viewport), viewport)
+
+    assert abs(restored.x - point.x) < 1e-6
+    assert abs(restored.y - point.y) < 1e-6
+
+
+def test_camera_has_no_rotation():
+    """Regression guard for #23: `rotation` was a public attribute the render
+    path ignored, so setting it silently did nothing. It is gone."""
+    camera = Camera2D(800, 600)
+    assert not hasattr(camera, "rotation")
+
+
+def test_get_view_bounds_honours_an_explicit_viewport():
+    camera = Camera2D(800, 600)
+    camera.position = Vector2(0, 0)
+    camera.zoom = 2.0
+
+    bounds = camera.get_view_bounds(Viewport(0, 0, 400, 200))
+
+    # 400x200 viewport at zoom 2 sees 200x100 world units, centred on (0, 0).
+    assert (bounds.width, bounds.height) == (200, 100)
+    assert (bounds.centerx, bounds.centery) == (0, 0)
+
+
 def test_viewport_aspect_ratio():
     # 100x100 window, target 2.0 (should be 100x50)
     vp = Viewport.create_best_fit(100, 100, 2.0)


### PR DESCRIPTION
Closes #23.

`Camera2D.rotation` was a public attribute that changed what
`world_to_screen` / `screen_to_world` / `get_view_bounds` reported but had
**no effect on what was drawn** — the render path never rotated. There were
also four inline copies of the world-to-screen formula (`world_to_screen`,
the batcher, the particle system, `light_pass`), two of which disagreed on
the centre (`self.offset` vs `viewport.center_vec`) for any non-fullscreen
viewport. Same shape as the drift bug fixed in #22.

## Approach — the issue's option 2 (chosen: cheapest, honest)

A rotating camera was never a goal: `rotation` had zero setters anywhere in
`pyguara/` or `games/`, and `world_to_screen`/`screen_to_world` had zero
production callers.

- Removed `Camera2D.rotation` and both `rotate_degrees` branches.
- `screen_offset(viewport)` is now the **single** definition.
  `world_to_screen` / `screen_to_world` / `get_view_bounds` are expressed in
  terms of it and take an optional `viewport` (default: the camera's
  constructed size at the window origin — the old fullscreen behaviour).
- `self.offset` / `set_viewport_size`'s screen-centre role is gone; the
  camera keeps a private `_default_viewport` for the no-arg convenience calls.
- `light_pass` had its own `viewport.width / 2 - pos * zoom` copy → now calls
  `camera.screen_offset(viewport)`, so lit geometry lines up with drawn
  geometry. For odd viewport sizes this shifts lighting by <1px onto the
  sprite grid — a fix, not a regression.

## Verification

Clean worktree at the tip: `ruff check .`, `mypy pyguara`, `pytest` — **1933
passed**, 7 visual snapshots unchanged (the batcher and particle system
already shared `screen_offset` from #22, so the render path is byte-identical).

New tests pin `world_to_screen` to the **exact** batcher formula for a
fullscreen *and* an offset viewport, check the `screen_to_world` round-trip
with an explicit viewport, and guard that `rotation` is gone.

PR is final — nothing else coming on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5