### PR TITLE
feat(application): drive the loop through a Clock protocol (#9, slice 1)

### DIFF
--- a/games/asset_pipeline/bootstrap.py
+++ b/games/asset_pipeline/bootstrap.py
@@ -6,11 +6,13 @@ Configures DI with Resource Manager and Loaders.
 import os
 
 from pyguara.application.application import Application
+from pyguara.application.clock import Clock
 from pyguara.audio.audio_system import IAudioSystem
 from pyguara.audio.backends.pygame.pygame_audio import PygameAudioSystem
 from pyguara.config.manager import ConfigManager
 from pyguara.di.container import DIContainer
 from pyguara.events.dispatcher import EventDispatcher
+from pyguara.graphics.backends.pygame.clock import PygameClock
 from pyguara.graphics.backends.pygame.loaders import PygameImageLoader
 from pyguara.graphics.backends.pygame.pygame_renderer import PygameBackend
 from pyguara.graphics.backends.pygame.pygame_window import PygameWindow
@@ -71,6 +73,7 @@ def configure_game_container() -> DIContainer:
 
     container.register_instance(ResourceManager, res_manager)
 
+    container.register_instance(Clock, PygameClock())  # type: ignore[type-abstract]
     container.register_instance(IInputBackend, PygameInputBackend())  # type: ignore[type-abstract]
     container.register_singleton(InputManager, InputManager)
     container.register_instance(IAudioSystem, PygameAudioSystem())  # type: ignore[type-abstract]

--- a/games/boot_process/bootstrap.py
+++ b/games/boot_process/bootstrap.py
@@ -4,11 +4,13 @@ This file demonstrates how to manually configure the Dependency Injection (DI) c
 """
 
 from pyguara.application.application import Application
+from pyguara.application.clock import Clock
 from pyguara.audio.audio_system import IAudioSystem
 from pyguara.audio.backends.pygame.pygame_audio import PygameAudioSystem
 from pyguara.config.manager import ConfigManager
 from pyguara.di.container import DIContainer
 from pyguara.events.dispatcher import EventDispatcher
+from pyguara.graphics.backends.pygame.clock import PygameClock
 from pyguara.graphics.backends.pygame.pygame_renderer import PygameBackend
 from pyguara.graphics.backends.pygame.pygame_window import PygameWindow
 from pyguara.graphics.backends.pygame.ui_renderer import PygameUIRenderer
@@ -75,6 +77,7 @@ def configure_game_container() -> DIContainer:
     container.register_instance(UIRenderer, ui_renderer)
 
     # 5. Core Systems
+    container.register_instance(Clock, PygameClock())  # type: ignore[type-abstract]
     container.register_instance(IInputBackend, PygameInputBackend())  # type: ignore[type-abstract]
     container.register_singleton(InputManager, InputManager)
     container.register_instance(IAudioSystem, PygameAudioSystem())  # type: ignore[type-abstract]

--- a/games/ecs_mental_model/bootstrap.py
+++ b/games/ecs_mental_model/bootstrap.py
@@ -4,11 +4,13 @@ Configures the DI container.
 """
 
 from pyguara.application.application import Application
+from pyguara.application.clock import Clock
 from pyguara.audio.audio_system import IAudioSystem
 from pyguara.audio.backends.pygame.pygame_audio import PygameAudioSystem
 from pyguara.config.manager import ConfigManager
 from pyguara.di.container import DIContainer
 from pyguara.events.dispatcher import EventDispatcher
+from pyguara.graphics.backends.pygame.clock import PygameClock
 from pyguara.graphics.backends.pygame.pygame_renderer import PygameBackend
 from pyguara.graphics.backends.pygame.pygame_window import PygameWindow
 from pyguara.graphics.backends.pygame.ui_renderer import PygameUIRenderer
@@ -58,6 +60,7 @@ def configure_game_container() -> DIContainer:
     ui_renderer = PygameUIRenderer(window.native_handle)
     container.register_instance(UIRenderer, ui_renderer)
 
+    container.register_instance(Clock, PygameClock())  # type: ignore[type-abstract]
     container.register_instance(IInputBackend, PygameInputBackend())  # type: ignore[type-abstract]
     container.register_singleton(InputManager, InputManager)
     container.register_instance(IAudioSystem, PygameAudioSystem())  # type: ignore[type-abstract]

--- a/games/guara_falcao/bootstrap.py
+++ b/games/guara_falcao/bootstrap.py
@@ -4,11 +4,13 @@ Configures the DI container for the platformer game.
 """
 
 from pyguara.application.application import Application
+from pyguara.application.clock import Clock
 from pyguara.audio.audio_system import IAudioSystem
 from pyguara.audio.backends.pygame.pygame_audio import PygameAudioSystem
 from pyguara.config.manager import ConfigManager
 from pyguara.di.container import DIContainer
 from pyguara.events.dispatcher import EventDispatcher
+from pyguara.graphics.backends.pygame.clock import PygameClock
 from pyguara.graphics.backends.pygame.pygame_renderer import PygameBackend
 from pyguara.graphics.backends.pygame.pygame_window import PygameWindow
 from pyguara.graphics.backends.pygame.ui_renderer import PygameUIRenderer
@@ -73,6 +75,7 @@ def configure_game_container() -> DIContainer:
     container.register_instance(UIRenderer, ui_renderer)
 
     # Core Systems
+    container.register_instance(Clock, PygameClock())  # type: ignore[type-abstract]
     container.register_instance(IInputBackend, PygameInputBackend())  # type: ignore[type-abstract]
     container.register_singleton(InputManager, InputManager)
     container.register_instance(IAudioSystem, PygameAudioSystem())  # type: ignore[type-abstract]

--- a/games/input_events/bootstrap.py
+++ b/games/input_events/bootstrap.py
@@ -4,11 +4,13 @@ Standard DI setup.
 """
 
 from pyguara.application.application import Application
+from pyguara.application.clock import Clock
 from pyguara.audio.audio_system import IAudioSystem
 from pyguara.audio.backends.pygame.pygame_audio import PygameAudioSystem
 from pyguara.config.manager import ConfigManager
 from pyguara.di.container import DIContainer
 from pyguara.events.dispatcher import EventDispatcher
+from pyguara.graphics.backends.pygame.clock import PygameClock
 from pyguara.graphics.backends.pygame.pygame_renderer import PygameBackend
 from pyguara.graphics.backends.pygame.pygame_window import PygameWindow
 from pyguara.graphics.backends.pygame.ui_renderer import PygameUIRenderer
@@ -58,6 +60,7 @@ def configure_game_container() -> DIContainer:
     ui_renderer = PygameUIRenderer(window.native_handle)
     container.register_instance(UIRenderer, ui_renderer)
 
+    container.register_instance(Clock, PygameClock())  # type: ignore[type-abstract]
     container.register_instance(IInputBackend, PygameInputBackend())  # type: ignore[type-abstract]
     container.register_singleton(InputManager, InputManager)
     container.register_instance(IAudioSystem, PygameAudioSystem())  # type: ignore[type-abstract]

--- a/games/physics_integration/bootstrap.py
+++ b/games/physics_integration/bootstrap.py
@@ -4,11 +4,13 @@ Registers Physics Engine and related systems.
 """
 
 from pyguara.application.application import Application
+from pyguara.application.clock import Clock
 from pyguara.audio.audio_system import IAudioSystem
 from pyguara.audio.backends.pygame.pygame_audio import PygameAudioSystem
 from pyguara.config.manager import ConfigManager
 from pyguara.di.container import DIContainer
 from pyguara.events.dispatcher import EventDispatcher
+from pyguara.graphics.backends.pygame.clock import PygameClock
 from pyguara.graphics.backends.pygame.pygame_renderer import PygameBackend
 from pyguara.graphics.backends.pygame.pygame_window import PygameWindow
 from pyguara.graphics.backends.pygame.ui_renderer import PygameUIRenderer
@@ -66,6 +68,7 @@ def configure_game_container() -> DIContainer:
     ui_renderer = PygameUIRenderer(window.native_handle)
     container.register_instance(UIRenderer, ui_renderer)
 
+    container.register_instance(Clock, PygameClock())  # type: ignore[type-abstract]
     container.register_instance(IInputBackend, PygameInputBackend())  # type: ignore[type-abstract]
     container.register_singleton(InputManager, InputManager)
     container.register_instance(IAudioSystem, PygameAudioSystem())  # type: ignore[type-abstract]

--- a/games/protocolo_bandeira/bootstrap.py
+++ b/games/protocolo_bandeira/bootstrap.py
@@ -4,11 +4,13 @@ Configures the DI container for the shooter game.
 """
 
 from pyguara.application.application import Application
+from pyguara.application.clock import Clock
 from pyguara.audio.audio_system import IAudioSystem
 from pyguara.audio.backends.pygame.pygame_audio import PygameAudioSystem
 from pyguara.config.manager import ConfigManager
 from pyguara.di.container import DIContainer
 from pyguara.events.dispatcher import EventDispatcher
+from pyguara.graphics.backends.pygame.clock import PygameClock
 from pyguara.graphics.backends.pygame.pygame_renderer import PygameBackend
 from pyguara.graphics.backends.pygame.pygame_window import PygameWindow
 from pyguara.graphics.backends.pygame.ui_renderer import PygameUIRenderer
@@ -65,6 +67,7 @@ def configure_game_container() -> DIContainer:
     container.register_instance(UIRenderer, ui_renderer)
 
     # Core Systems
+    container.register_instance(Clock, PygameClock())  # type: ignore[type-abstract]
     container.register_instance(IInputBackend, PygameInputBackend())  # type: ignore[type-abstract]
     container.register_singleton(InputManager, InputManager)
     container.register_instance(IAudioSystem, PygameAudioSystem())  # type: ignore[type-abstract]

--- a/games/true_coral/bootstrap.py
+++ b/games/true_coral/bootstrap.py
@@ -4,11 +4,13 @@ Configures the DI container for the puzzle game.
 """
 
 from pyguara.application.application import Application
+from pyguara.application.clock import Clock
 from pyguara.audio.audio_system import IAudioSystem
 from pyguara.audio.backends.pygame.pygame_audio import PygameAudioSystem
 from pyguara.config.manager import ConfigManager
 from pyguara.di.container import DIContainer
 from pyguara.events.dispatcher import EventDispatcher
+from pyguara.graphics.backends.pygame.clock import PygameClock
 from pyguara.graphics.backends.pygame.pygame_renderer import PygameBackend
 from pyguara.graphics.backends.pygame.pygame_window import PygameWindow
 from pyguara.graphics.backends.pygame.ui_renderer import PygameUIRenderer
@@ -65,6 +67,7 @@ def configure_game_container() -> DIContainer:
     container.register_instance(UIRenderer, ui_renderer)
 
     # Core Systems
+    container.register_instance(Clock, PygameClock())  # type: ignore[type-abstract]
     container.register_instance(IInputBackend, PygameInputBackend())  # type: ignore[type-abstract]
     container.register_singleton(InputManager, InputManager)
     container.register_instance(IAudioSystem, PygameAudioSystem())  # type: ignore[type-abstract]

--- a/games/ui_scene_graph/bootstrap.py
+++ b/games/ui_scene_graph/bootstrap.py
@@ -1,11 +1,13 @@
 """Module 6: UI Bootstrap."""
 
 from pyguara.application.application import Application
+from pyguara.application.clock import Clock
 from pyguara.audio.audio_system import IAudioSystem
 from pyguara.audio.backends.pygame.pygame_audio import PygameAudioSystem
 from pyguara.config.manager import ConfigManager
 from pyguara.di.container import DIContainer
 from pyguara.events.dispatcher import EventDispatcher
+from pyguara.graphics.backends.pygame.clock import PygameClock
 from pyguara.graphics.backends.pygame.pygame_renderer import PygameBackend
 from pyguara.graphics.backends.pygame.pygame_window import PygameWindow
 from pyguara.graphics.backends.pygame.ui_renderer import PygameUIRenderer
@@ -55,6 +57,7 @@ def configure_game_container() -> DIContainer:
     ui_renderer = PygameUIRenderer(window.native_handle)
     container.register_instance(UIRenderer, ui_renderer)
 
+    container.register_instance(Clock, PygameClock())  # type: ignore[type-abstract]
     container.register_instance(IInputBackend, PygameInputBackend())  # type: ignore[type-abstract]
     container.register_singleton(InputManager, InputManager)
     container.register_instance(IAudioSystem, PygameAudioSystem())  # type: ignore[type-abstract]

--- a/pyguara/application/application.py
+++ b/pyguara/application/application.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 import pygame
 
+from pyguara.application.clock import Clock
 from pyguara.audio.audio_system import IAudioSystem
 from pyguara.config.manager import ConfigManager
 from pyguara.dev.asset_reload import AssetReloadWatcher
@@ -108,7 +109,7 @@ class Application:
 
         self._scene_manager.set_container(container)
 
-        self._clock = pygame.time.Clock()
+        self._clock: Clock = container.get(Clock)  # type: ignore[type-abstract]
 
         # Fixed timestep accumulator
         self._accumulator = 0.0

--- a/pyguara/application/bootstrap.py
+++ b/pyguara/application/bootstrap.py
@@ -1,6 +1,7 @@
 """Application setup and dependency wiring."""
 
 from pyguara.application.application import Application
+from pyguara.application.clock import Clock, FixedClock
 from pyguara.audio.audio_system import IAudioSystem
 from pyguara.audio.backends.pygame.loaders import PygameSoundLoader
 from pyguara.audio.backends.pygame.pygame_audio import PygameAudioSystem
@@ -254,6 +255,15 @@ def _setup_container(headless: bool = False) -> DIContainer:
             disp_cfg.screen_width, disp_cfg.screen_height
         )
         container.register_instance(RenderGraph, pygame_render_graph)
+
+    # Frame-pacing clock. Headless runs advance by a fixed, reproducible
+    # delta (no wall-clock sleep); the real backends wrap `pygame.time.Clock`.
+    if headless:
+        container.register_instance(Clock, FixedClock())  # type: ignore[type-abstract]
+    else:
+        from pyguara.graphics.backends.pygame.clock import PygameClock
+
+        container.register_instance(Clock, PygameClock())  # type: ignore[type-abstract]
 
     # 5. Core Subsystems
     container.register_instance(IInputBackend, PygameInputBackend())  # type: ignore[type-abstract]

--- a/pyguara/application/clock.py
+++ b/pyguara/application/clock.py
@@ -1,0 +1,53 @@
+"""Frame-timing abstraction for the main loop.
+
+`Application` used `pygame.time.Clock` directly, so the loop -- and therefore
+every backend, ModernGL included -- depended on pygame for its frame pacing
+and could not be driven deterministically in a test. `Clock` is the seam:
+the pygame implementation lives under `graphics/backends/pygame/`, and
+`FixedClock` gives headless runs and tests a wall-clock-free tick.
+
+Part of issue #9 (decouple pygame from the backend-agnostic core).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Clock(Protocol):
+    """A frame-pacing clock.
+
+    Modelled on `pygame.time.Clock` so the real implementation is a thin
+    wrapper: `tick()` both throttles the caller and reports elapsed time.
+    """
+
+    def tick(self, target_fps: int = 0) -> float:
+        """Advance one frame and return the time the previous frame took.
+
+        Args:
+            target_fps: Frames per second to cap at. ``0`` means no cap --
+                return immediately. A real clock sleeps as needed to hold
+                the rate; a deterministic one never sleeps.
+
+        Returns:
+            Milliseconds elapsed since the previous ``tick()`` call. The
+            caller divides by 1000 for seconds.
+        """
+        ...
+
+
+class FixedClock:
+    """A `Clock` that never sleeps and always reports the same frame time.
+
+    For headless runs and tests: the loop advances by a fixed, reproducible
+    delta regardless of how long the frame actually took.
+    """
+
+    def __init__(self, frame_time_ms: float = 1000.0 / 60.0) -> None:
+        """Create a clock whose every `tick()` reports ``frame_time_ms``."""
+        self._frame_time_ms = frame_time_ms
+
+    def tick(self, target_fps: int = 0) -> float:
+        """Return the fixed frame time. ``target_fps`` is ignored."""
+        return self._frame_time_ms

--- a/pyguara/graphics/backends/pygame/clock.py
+++ b/pyguara/graphics/backends/pygame/clock.py
@@ -1,0 +1,22 @@
+"""Pygame implementation of the `Clock` frame-pacing protocol."""
+
+from __future__ import annotations
+
+import pygame
+
+
+class PygameClock:
+    """`Clock` backed by `pygame.time.Clock`.
+
+    `tick()` blocks as needed to hold the requested frame rate and returns
+    the milliseconds the previous frame took -- exactly `pygame.time.Clock`'s
+    contract, which is what this abstraction was modelled on.
+    """
+
+    def __init__(self) -> None:
+        """Create the wrapped `pygame.time.Clock`."""
+        self._clock = pygame.time.Clock()
+
+    def tick(self, target_fps: int = 0) -> float:
+        """Cap at ``target_fps`` (0 = uncapped) and return elapsed milliseconds."""
+        return float(self._clock.tick(target_fps))

--- a/tests/integration/test_app_flow.py
+++ b/tests/integration/test_app_flow.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pyguara.application.application import Application
+from pyguara.application.clock import Clock, FixedClock
 from pyguara.audio.audio_system import IAudioSystem
 from pyguara.config.manager import ConfigManager
 from pyguara.config.types import GameConfig
@@ -59,6 +60,7 @@ def app_container() -> DIContainer:
 
     c.register_instance(InputManager, MagicMock())
     c.register_instance(UIManager, MagicMock())
+    c.register_instance(Clock, FixedClock())  # type: ignore[type-abstract]
     c.register_singleton(SceneManager, SceneManager)
 
     # SystemManager and CoroutineManager (required by Application)

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -1,0 +1,63 @@
+"""Tests for the `Clock` frame-pacing seam (issue #9).
+
+`Application` used `pygame.time.Clock` directly; the loop now takes a `Clock`
+from the DI container. These pin the contract and the wiring.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyguara.application.bootstrap import create_headless_application
+from pyguara.application.clock import Clock, FixedClock
+
+
+class TestFixedClock:
+    def test_tick_returns_the_configured_frame_time(self) -> None:
+        clock = FixedClock(frame_time_ms=20.0)
+        assert clock.tick() == 20.0
+
+    def test_default_frame_time_is_one_sixtieth_of_a_second(self) -> None:
+        assert FixedClock().tick() == pytest.approx(1000.0 / 60.0)
+
+    def test_target_fps_argument_is_ignored(self) -> None:
+        clock = FixedClock(frame_time_ms=7.0)
+        assert clock.tick(240) == 7.0
+        assert clock.tick(0) == 7.0
+
+    def test_it_never_blocks(self) -> None:
+        """A deterministic clock must not sleep, however low the target rate."""
+        import time
+
+        clock = FixedClock()
+        start = time.perf_counter()
+        for _ in range(1000):
+            clock.tick(1)  # 1 FPS would be a 1s sleep on a real clock
+        assert time.perf_counter() - start < 0.5
+
+
+class TestClockProtocol:
+    def test_fixed_clock_satisfies_the_protocol(self) -> None:
+        assert isinstance(FixedClock(), Clock)
+
+    def test_pygame_clock_satisfies_the_protocol(self) -> None:
+        pygame = pytest.importorskip("pygame")
+        pygame.init()
+        try:
+            from pyguara.graphics.backends.pygame.clock import PygameClock
+
+            assert isinstance(PygameClock(), Clock)
+        finally:
+            pygame.quit()
+
+
+class TestBootstrapWiring:
+    def test_headless_application_is_driven_by_a_fixed_clock(self) -> None:
+        """No pygame clock, no wall-clock sleep in a headless run."""
+        app = create_headless_application()
+        try:
+            resolved = app._container.get(Clock)  # type: ignore[type-abstract]
+            assert isinstance(resolved, FixedClock)
+            assert app._clock is resolved
+        finally:
+            app.shutdown()


### PR DESCRIPTION
First slice of #9 — decouple pygame from the backend-agnostic core.

## Problem

`Application` created a `pygame.time.Clock` directly and used it for all
frame pacing, so the loop — the ModernGL path included — could not run
without pygame importable, and could not be driven deterministically in a
test.

## Change

- **`pyguara.application.clock.Clock`** — a `Protocol`: `tick(target_fps) ->
  float` milliseconds, modelled on `pygame.time.Clock` so the wrapper is
  trivial. **`FixedClock`** (same module, no pygame) reports a fixed frame
  time and never sleeps.
- **`pyguara.graphics.backends.pygame.clock.PygameClock`** wraps
  `pygame.time.Clock` — the pygame dependency now sits under `backends/`
  where the architecture rule allows it.
- `bootstrap` registers `Clock` (`FixedClock` headless, `PygameClock`
  otherwise); `Application` resolves it from the container. The nine
  `games/*/bootstrap.py` composition roots register it the same way.

`application.py` still imports pygame for `event.pump()` / `pygame.QUIT` —
that is **slice 2** (engine-event translation at the window boundary),
tracked on #9.

## Verification

Clean worktree at the tip: `ruff check .`, `mypy pyguara`, `pytest` — **1936
passed** (+7), 7 visual snapshots unchanged. New `tests/test_clock.py` pins
the `FixedClock` contract, Protocol conformance for both implementations, and
that a headless `Application` runs on a `FixedClock` (no wall-clock sleep).

Part of #9 — does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5