### PR TITLE
refactor(input): SDL→engine event translation at the window boundary (#9, slice 2)

### DIFF
--- a/pyguara/application/application.py
+++ b/pyguara/application/application.py
@@ -8,11 +8,8 @@ regardless of frame rate variations.
 
 from __future__ import annotations
 
-import contextlib
 from collections.abc import Callable
 from typing import TYPE_CHECKING
-
-import pygame
 
 from pyguara.application.clock import Clock
 from pyguara.audio.audio_system import IAudioSystem
@@ -22,6 +19,7 @@ from pyguara.di.container import DIContainer
 from pyguara.di.exceptions import ServiceNotFoundException
 from pyguara.events.dispatcher import EventDispatcher
 from pyguara.events.lifecycle import ApplicationStartEvent, QuitEvent
+from pyguara.events.window import WindowResizeEvent
 from pyguara.graphics.protocols import IRenderer, UIRenderer
 from pyguara.graphics.window import Window
 from pyguara.input.manager import InputManager
@@ -190,13 +188,6 @@ class Application:
         )
 
         self._event_dispatcher.dispatch(ApplicationStartEvent(source=self))
-
-        # Force an initial event pump to show the window immediately. No-op
-        # (raises pygame.error) under a backend that never initializes SDL's
-        # video subsystem at all, e.g. the headless test backend -- which has
-        # no window to show in the first place.
-        with contextlib.suppress(pygame.error):
-            pygame.event.pump()
 
         try:
             while self._is_running and self._window.is_open:
@@ -377,15 +368,21 @@ class Application:
         """
         self._begin_replay_frame(frame_time)
 
-        # This call is CRITICAL. It keeps the OS window responsive.
+        # poll_events() pumps the OS event queue (keeping the window
+        # responsive) and hands back engine events, never raw SDL structs.
         for event in self._window.poll_events():
-            if hasattr(event, "type") and event.type == pygame.QUIT:
+            if isinstance(event, QuitEvent):
                 self._is_running = False
-                # Publish the close request so game code and tools can react
-                # before shutdown() runs. QuitEvent had no publisher at all,
-                # which left tools/event_monitor.py subscribed to something
-                # that could never fire.
+                # Re-publish with this app as the source so game code and
+                # tools can react before shutdown() runs.
                 self._event_dispatcher.dispatch(QuitEvent(source=self))
+                continue
+
+            if isinstance(event, WindowResizeEvent):
+                # The window boundary is the only place a resize is detected;
+                # nothing else could give WindowResizeEvent a publisher.
+                self._event_dispatcher.dispatch(event)
+                continue
 
             # While a replay drives the game, real input is swallowed rather
             # than dispatched, so both runs see exactly the same events.

--- a/pyguara/application/sandbox.py
+++ b/pyguara/application/sandbox.py
@@ -6,10 +6,11 @@ with the developer tool suite (Inspector, Debugger, Profiler, etc.).
 It is intended for use during development and testing phases.
 """
 
-import pygame
-
 from pyguara.application.application import Application
 from pyguara.di.container import DIContainer
+from pyguara.events.lifecycle import QuitEvent
+from pyguara.events.window import WindowResizeEvent
+from pyguara.input import keys
 from pyguara.tools.assets_browser import AssetsTool
 from pyguara.tools.config_inspector import ConfigInspector
 from pyguara.tools.debugger import PhysicsDebugger
@@ -57,45 +58,45 @@ class SandboxApplication(Application):
 
         # 1. Performance Monitor (F1) - FPS and Stats
         perf_monitor = PerformanceMonitor(self._container)
-        self._tool_manager.register_tool(perf_monitor, pygame.K_F1)
+        self._tool_manager.register_tool(perf_monitor, keys.F1)
 
         # 2. Hierarchy (F5) - entity list + selection. Built before the
         #    inspector and gizmo, which both follow its selection.
         hierarchy = HierarchyTool(self._container)
-        self._tool_manager.register_tool(hierarchy, pygame.K_F5)
+        self._tool_manager.register_tool(hierarchy, keys.F5)
 
         # 3. Entity Inspector (F2) - inspects whatever the Hierarchy selects.
         inspector = EntityInspector(
             self._container, selection_provider=lambda: hierarchy.selected_entity
         )
-        self._tool_manager.register_tool(inspector, pygame.K_F2)
+        self._tool_manager.register_tool(inspector, keys.F2)
 
         # 3b. Transform Gizmo (F9) - visual handles for the selected entity.
         #     Q/W/E switch translate/rotate/scale. Follows the Hierarchy.
         gizmo = TransformGizmo(
             self._container, selection_provider=lambda: hierarchy.selected_entity
         )
-        self._tool_manager.register_tool(gizmo, pygame.K_F9)
+        self._tool_manager.register_tool(gizmo, keys.F9)
 
         # 4. Event Monitor (F3) - Log Viewer
         event_mon = EventMonitor(self._container)
-        self._tool_manager.register_tool(event_mon, pygame.K_F3)
+        self._tool_manager.register_tool(event_mon, keys.F3)
 
         # 5. Physics Debugger (F4) - Collision Wireframes
         debugger = PhysicsDebugger(self._container)
-        self._tool_manager.register_tool(debugger, pygame.K_F4)
+        self._tool_manager.register_tool(debugger, keys.F4)
 
         # 6. Config Inspector (F6) - Live GameConfig Editor
         config_inspector = ConfigInspector(self._container)
-        self._tool_manager.register_tool(config_inspector, pygame.K_F6)
+        self._tool_manager.register_tool(config_inspector, keys.F6)
 
         # 7. Assets Browser (F7) - resource list + spawn from data
         assets = AssetsTool(self._container)
-        self._tool_manager.register_tool(assets, pygame.K_F7)
+        self._tool_manager.register_tool(assets, keys.F7)
 
         # 8. Shortcuts Panel (F8) - Help Overlay
         shortcuts = ShortcutsPanel(self._container)
-        self._tool_manager.register_tool(shortcuts, pygame.K_F8)
+        self._tool_manager.register_tool(shortcuts, keys.F8)
 
         # Enable global visibility by default in Sandbox mode
         self._tool_manager.toggle_global_visibility()
@@ -117,9 +118,15 @@ class SandboxApplication(Application):
         self._begin_replay_frame(frame_time)
 
         for event in self._window.poll_events():
-            # 1. Update Internal State (Quit, etc.)
-            if hasattr(event, "type") and event.type == pygame.QUIT:
+            # 1. Update Internal State (Quit, resize)
+            if isinstance(event, QuitEvent):
                 self._is_running = False
+                self._event_dispatcher.dispatch(QuitEvent(source=self))
+                continue
+
+            if isinstance(event, WindowResizeEvent):
+                self._event_dispatcher.dispatch(event)
+                continue
 
             # 2. Tool Manager (High Priority)
             if self._tool_manager and self._tool_manager.process_event(event):

--- a/pyguara/events/input.py
+++ b/pyguara/events/input.py
@@ -1,5 +1,11 @@
 """Keyboard and mouse input events.
 
+These are the engine's backend-neutral input events. A window backend
+translates its native events (SDL, via pygame) into these in `poll_events()`,
+so nothing above the backend boundary imports pygame or reads its constants
+(issue #9). Key codes are still SDL values -- the same integers
+`pyguara.input.keys` names.
+
 `KeyDownEvent` and `KeyUpEvent` share the `KeyboardEvent` base, so a handler
 subscribed to `KeyboardEvent` receives both -- see `EventDispatcher.dispatch`.
 """
@@ -14,12 +20,15 @@ class KeyboardEvent:
     """Base for key press and release events.
 
     Attributes:
-        key_code: Backend scan code for the key, e.g. `pygame.K_SPACE`.
+        key_code: SDL key code for the key (see `pyguara.input.keys`).
+        modifiers: The shift/ctrl/alt flags held when the event fired, as
+            SDL `KMOD_*` values.
         timestamp: Unix time the event was created.
         source: Whatever raised the event, if it identified itself.
     """
 
     key_code: int
+    modifiers: set[int] = field(default_factory=set)
     timestamp: float = field(default_factory=time.time)
     source: Any = None
 
@@ -32,6 +41,34 @@ class KeyDownEvent(KeyboardEvent):
 @dataclass
 class KeyUpEvent(KeyboardEvent):
     """Fired when a key is released."""
+
+
+@dataclass
+class MouseButtonEvent:
+    """Fired when a mouse button is pressed or released.
+
+    Attributes:
+        button: Button index (1 left, 2 middle, 3 right, 4/5 wheel).
+        x: Cursor X position in window pixels.
+        y: Cursor Y position in window pixels.
+        is_down: True on press, False on release.
+        modifiers: The shift/ctrl/alt flags held when the event fired.
+        timestamp: Unix time the event was created.
+        source: Whatever raised the event, if it identified itself.
+    """
+
+    button: int
+    x: int
+    y: int
+    is_down: bool
+    modifiers: set[int] = field(default_factory=set)
+    timestamp: float = field(default_factory=time.time)
+    source: Any = None
+
+    @property
+    def pos(self) -> tuple[int, int]:
+        """The cursor position as an ``(x, y)`` tuple."""
+        return (self.x, self.y)
 
 
 @dataclass
@@ -53,3 +90,8 @@ class MouseMotionEvent:
     rel_y: int
     timestamp: float = field(default_factory=time.time)
     source: Any = None
+
+    @property
+    def pos(self) -> tuple[int, int]:
+        """The cursor position as an ``(x, y)`` tuple."""
+        return (self.x, self.y)

--- a/pyguara/graphics/backends/moderngl/window.py
+++ b/pyguara/graphics/backends/moderngl/window.py
@@ -1,13 +1,14 @@
 """Pygame-based OpenGL window implementation for ModernGL backend."""
 
 from collections.abc import Iterable
-from typing import Any, cast
+from typing import Any
 
 import pygame
 
 import moderngl
 from pyguara.common.types import Color
 from pyguara.config.types import WindowConfig
+from pyguara.graphics.backends.pygame.events import translate_events
 
 
 class PygameGLWindow:
@@ -120,21 +121,17 @@ class PygameGLWindow:
         self._ctx.clear(r, g, b, a)
 
     def poll_events(self) -> Iterable[Any]:
-        """Fetch pygame events and handle internal window state.
-
-        Returns:
-            Iterable of pygame event objects.
-        """
+        """Pump SDL and return engine events (see `pygame.events`)."""
         if not self._is_open:
             return []
 
-        events = pygame.event.get()
+        raw_events = pygame.event.get()
 
-        for event in events:
+        for event in raw_events:
             if event.type == pygame.QUIT:
                 self._is_open = False
 
-        return cast(Iterable[Any], events)
+        return translate_events(raw_events)
 
     def get_screen(self) -> moderngl.Context:
         """Return the ModernGL context.

--- a/pyguara/graphics/backends/pygame/events.py
+++ b/pyguara/graphics/backends/pygame/events.py
@@ -1,0 +1,79 @@
+"""Translate SDL (pygame) events into the engine's backend-neutral events.
+
+The pygame and ModernGL window backends both pump SDL via `pygame.event.get()`
+and call this to hand the rest of the engine `QuitEvent` / `KeyDownEvent` /
+`KeyUpEvent` / `MouseButtonEvent` / `MouseMotionEvent` / `WindowResizeEvent`
+instead of raw SDL structs -- so `application.py`, `InputManager`,
+`pyguara/tools/*` and `sandbox.py` stop importing pygame (issue #9).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pygame
+
+from pyguara.events.input import (
+    KeyDownEvent,
+    KeyUpEvent,
+    MouseButtonEvent,
+    MouseMotionEvent,
+)
+from pyguara.events.lifecycle import QuitEvent
+from pyguara.events.window import WindowResizeEvent
+
+_KMOD = ((pygame.KMOD_SHIFT,), (pygame.KMOD_CTRL,), (pygame.KMOD_ALT,))
+
+
+def _held_modifiers() -> set[int]:
+    """Return the shift/ctrl/alt masks held now, or empty if SDL video is down."""
+    try:
+        mods = pygame.key.get_mods()
+    except pygame.error:
+        return set()
+    return {mask for (mask,) in _KMOD if mods & mask}
+
+
+def translate_event(raw: Any) -> object | None:
+    """Map one pygame event to an engine event, or ``None`` to drop it."""
+    etype = getattr(raw, "type", None)
+
+    if etype == pygame.QUIT:
+        return QuitEvent()
+
+    if etype == pygame.KEYDOWN:
+        return KeyDownEvent(key_code=raw.key, modifiers=_held_modifiers())
+    if etype == pygame.KEYUP:
+        return KeyUpEvent(key_code=raw.key, modifiers=_held_modifiers())
+
+    if etype in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP):
+        return MouseButtonEvent(
+            button=raw.button,
+            x=raw.pos[0],
+            y=raw.pos[1],
+            is_down=etype == pygame.MOUSEBUTTONDOWN,
+            modifiers=_held_modifiers(),
+        )
+
+    if etype == pygame.MOUSEMOTION:
+        return MouseMotionEvent(
+            x=raw.pos[0],
+            y=raw.pos[1],
+            rel_x=raw.rel[0],
+            rel_y=raw.rel[1],
+        )
+
+    if etype == pygame.VIDEORESIZE:
+        return WindowResizeEvent(width=raw.w, height=raw.h)
+
+    return None
+
+
+def translate_events(raw_events: list[Any]) -> list[object]:
+    """Translate a batch of pygame events, dropping the ones with no mapping."""
+    out: list[object] = []
+    for raw in raw_events:
+        engine_event = translate_event(raw)
+        if engine_event is not None:
+            out.append(engine_event)
+    return out

--- a/pyguara/graphics/backends/pygame/pygame_window.py
+++ b/pyguara/graphics/backends/pygame/pygame_window.py
@@ -1,13 +1,14 @@
 """Pygame implementation of the Window Backend."""
 
 from collections.abc import Iterable
-from typing import Any, cast
+from typing import Any
 
 import pygame
 
 from pyguara.common.types import Color
 from pyguara.config.types import WindowConfig
 from pyguara.graphics.backends.pygame.conversions import to_pygame_color
+from pyguara.graphics.backends.pygame.events import translate_events
 from pyguara.log import get_logger
 
 logger = get_logger(__name__)
@@ -120,18 +121,18 @@ class PygameWindow:
             self._screen.fill(to_pygame_color(fill_color))
 
     def poll_events(self) -> Iterable[Any]:
-        """Fetch pygame events and handle internal window state."""
+        """Pump SDL and return engine events (see `pygame.events`)."""
         if not self._is_open:
             return []
 
-        events = pygame.event.get()
+        raw_events = pygame.event.get()
 
         # Check for quit event internally to update state
-        for event in events:
+        for event in raw_events:
             if event.type == pygame.QUIT:
                 self._is_open = False
 
-        return cast(Iterable[Any], events)
+        return translate_events(raw_events)
 
     def get_screen(self) -> Any:
         """Return the native OS window."""

--- a/pyguara/graphics/protocols.py
+++ b/pyguara/graphics/protocols.py
@@ -280,19 +280,14 @@ class IWindowBackend(Protocol):
         ...
 
     def poll_events(self) -> Iterable[Any]:
-        """Poll system events and hand them on for interpretation.
+        """Pump the OS event queue and return this frame's engine events.
 
         Returns:
-            Backend-native event objects, opaque to the engine.
-
-        Note:
-            These are the backend's own event objects -- SDL events under
-            pygame -- so every consumer has to know the backend's constants to
-            read them. That is why `Application` and `InputManager` still
-            import pygame despite the engine being nominally backend-agnostic.
-            Translating here, into engine events, is tracked as issue #9; it
-            spans graphics, input and application, so it is not something this
-            protocol can fix alone.
+            Engine events from `pyguara.events` -- `QuitEvent`, `KeyDownEvent`,
+            `KeyUpEvent`, `MouseButtonEvent`, `MouseMotionEvent`,
+            `WindowResizeEvent`. The backend owns the translation from its
+            native events (SDL, under pygame); nothing above this boundary
+            reads a backend constant (issue #9).
         """
         ...
 

--- a/pyguara/graphics/window.py
+++ b/pyguara/graphics/window.py
@@ -59,12 +59,13 @@ class Window:
         self._backend.present()
 
     def poll_events(self) -> Iterable[Any]:
-        """Drain the OS event queue.
+        """Pump the OS event queue and return this frame's engine events.
 
         Returns:
-            Backend-native event objects. See `IWindowBackend.poll_events` and
-            issue #9: these are not yet engine events, which is why callers
-            still compare against pygame constants.
+            Engine events (`pyguara.events.input` / `.lifecycle` / `.window`) --
+            `QuitEvent`, `KeyDownEvent`, `KeyUpEvent`, `MouseButtonEvent`,
+            `MouseMotionEvent`, `WindowResizeEvent`. The backend translates its
+            native events into these (issue #9), so no caller touches SDL.
         """
         return self._backend.poll_events()
 

--- a/pyguara/input/keys.py
+++ b/pyguara/input/keys.py
@@ -103,3 +103,18 @@ COMMA = 44
 PERIOD = 46
 SLASH = 47
 TILDE = 96
+
+
+# Reverse lookup: key code -> the constant's own name (e.g. 1073741882 -> "F1").
+# Built from this module so it never drifts from the constants above. Used by
+# the shortcuts panel instead of `pygame.key.name()`.
+_NAMES: dict[int, str] = {
+    value: name
+    for name, value in list(globals().items())
+    if name.isupper() and not name.startswith("_") and isinstance(value, int)
+}
+
+
+def key_name(code: int) -> str:
+    """Return a display name for a key code, e.g. ``"F1"`` or ``"KEY_1073742000"``."""
+    return _NAMES.get(code, f"KEY_{code}")

--- a/pyguara/input/manager.py
+++ b/pyguara/input/manager.py
@@ -2,9 +2,13 @@
 
 from typing import Any
 
-import pygame
-
 from pyguara.events.dispatcher import EventDispatcher
+from pyguara.events.input import (
+    KeyDownEvent,
+    KeyUpEvent,
+    MouseButtonEvent,
+    MouseMotionEvent,
+)
 from pyguara.input.binding import KeyBindingManager
 from pyguara.input.events import (
     GamepadAxisEvent,
@@ -262,12 +266,18 @@ class InputManager:
         self._bindings.bind(device, code, action, context)
 
     def process_event(self, event: Any) -> None:
-        """Ingest raw Pygame events."""
+        """Ingest one engine input event from the window backend.
+
+        Accepts `KeyDownEvent` / `KeyUpEvent` / `MouseButtonEvent` /
+        `MouseMotionEvent`; anything else is ignored. The backend has already
+        translated SDL into these (see `graphics/backends/pygame/events.py`),
+        so this method -- and everything downstream -- is pygame-free.
+        """
         # --- Keyboard ---
-        if event.type in (pygame.KEYDOWN, pygame.KEYUP):
-            is_down = event.type == pygame.KEYDOWN
-            modifiers = self._current_modifiers()
-            self._handle_input(InputDevice.KEYBOARD, event.key, is_down=is_down)
+        if isinstance(event, (KeyDownEvent, KeyUpEvent)):
+            is_down = isinstance(event, KeyDownEvent)
+            modifiers = set(event.modifiers)
+            self._handle_input(InputDevice.KEYBOARD, event.key_code, is_down=is_down)
 
             if self._recorder is not None and self._recorder.is_recording:
                 record_key = (
@@ -275,39 +285,41 @@ class InputManager:
                     if is_down
                     else self._recorder.record_key_up
                 )
-                record_key(event.key, sorted(modifiers))
+                record_key(event.key_code, sorted(modifiers))
 
             # Dispatch raw key event for UI system
             raw_key_event = OnRawKeyEvent(
-                key_code=event.key, is_down=is_down, modifiers=modifiers, source=self
+                key_code=event.key_code,
+                is_down=is_down,
+                modifiers=modifiers,
+                source=self,
             )
             self._dispatcher.dispatch(raw_key_event)
 
         # --- Mouse Buttons ---
-        elif event.type in (pygame.MOUSEBUTTONDOWN, pygame.MOUSEBUTTONUP):
-            is_down = event.type == pygame.MOUSEBUTTONDOWN
-            self._handle_input(InputDevice.MOUSE, event.button, is_down=is_down)
+        elif isinstance(event, MouseButtonEvent):
+            self._handle_input(InputDevice.MOUSE, event.button, is_down=event.is_down)
 
             if self._recorder is not None and self._recorder.is_recording:
                 record_mouse = (
                     self._recorder.record_mouse_down
-                    if is_down
+                    if event.is_down
                     else self._recorder.record_mouse_up
                 )
-                record_mouse(event.button, event.pos, sorted(self._current_modifiers()))
+                record_mouse(event.button, event.pos, sorted(event.modifiers))
 
             # Dispatch mouse event for UI system
             mouse_event = OnMouseEvent(
                 position=event.pos,
                 button=event.button,
-                is_down=is_down,
+                is_down=event.is_down,
                 is_motion=False,
                 source=self,
             )
             self._dispatcher.dispatch(mouse_event)
 
         # --- Mouse Motion ---
-        elif event.type == pygame.MOUSEMOTION:
+        elif isinstance(event, MouseMotionEvent):
             if self._recorder is not None and self._recorder.is_recording:
                 self._recorder.record_mouse_move(event.pos)
 
@@ -320,27 +332,11 @@ class InputManager:
             )
             self._dispatcher.dispatch(mouse_event)
 
-        # Gamepad input isn't read from pygame events at all: GamepadManager
+        # Gamepad input isn't read from window events at all: GamepadManager
         # polls device/button/axis state directly (see update(), called once
         # per frame from Application.run() before poll_events()), and its
         # GamepadButtonEvent/GamepadAxisEvent drive bound Actions via
         # _on_gamepad_button()/_on_gamepad_axis() above.
-
-    @staticmethod
-    def _current_modifiers() -> set[int]:
-        """Return the held shift/ctrl/alt flags, empty if SDL video is down."""
-        modifiers: set[int] = set()
-        try:
-            mods = pygame.key.get_mods()
-        except pygame.error:
-            return modifiers
-        if mods & pygame.KMOD_SHIFT:
-            modifiers.add(pygame.KMOD_SHIFT)
-        if mods & pygame.KMOD_CTRL:
-            modifiers.add(pygame.KMOD_CTRL)
-        if mods & pygame.KMOD_ALT:
-            modifiers.add(pygame.KMOD_ALT)
-        return modifiers
 
     def _handle_input(self, device: InputDevice, code: int, is_down: bool) -> None:
         """Handle binary inputs (Buttons/Keys)."""

--- a/pyguara/tools/assets_browser.py
+++ b/pyguara/tools/assets_browser.py
@@ -2,12 +2,11 @@
 
 from typing import Any
 
-import pygame
-
 from pyguara.common.components import ResourceLink
 from pyguara.common.types import Color, Rect, Vector2
 from pyguara.di.container import DIContainer
 from pyguara.ecs.entity import Entity
+from pyguara.events.input import MouseButtonEvent
 from pyguara.graphics.protocols import UIRenderer
 from pyguara.log import get_logger
 from pyguara.prefabs.registry import ComponentRegistry
@@ -186,7 +185,9 @@ class AssetsTool(Tool):
         Args:
             event: Pygame event.
         """
-        if not (event.type == pygame.MOUSEBUTTONDOWN and event.button == 1):
+        if not (
+            isinstance(event, MouseButtonEvent) and event.is_down and event.button == 1
+        ):
             return False
 
         mx, my = event.pos

--- a/pyguara/tools/base.py
+++ b/pyguara/tools/base.py
@@ -97,13 +97,14 @@ class Tool(ABC):
         ...
 
     def process_event(self, event: Any) -> bool:
-        """Process a raw input event.
+        """Process one engine input event.
 
         Override this to intercept inputs (e.g., stopping a click from
         reaching the game world).
 
         Args:
-            event: The raw event (e.g., pygame.event.Event).
+            event: An engine input event (`pyguara.events.input` /
+                `pyguara.events.lifecycle`), never a raw SDL struct.
 
         Returns:
             True if the event was consumed by the tool, False otherwise.

--- a/pyguara/tools/config_inspector.py
+++ b/pyguara/tools/config_inspector.py
@@ -2,12 +2,12 @@
 
 from typing import Any
 
-import pygame
-
 from pyguara.common.types import Color, Rect, Vector2
 from pyguara.config.manager import ConfigManager
 from pyguara.di.container import DIContainer
+from pyguara.events.input import KeyDownEvent, MouseButtonEvent
 from pyguara.graphics.protocols import UIRenderer
+from pyguara.input import keys
 from pyguara.tools.base import Tool
 from pyguara.tools.tweakable import (
     TweakableLeaf,
@@ -98,12 +98,12 @@ class ConfigInspector(Tool):
         Args:
             event: Pygame event.
         """
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_s:
+        if isinstance(event, KeyDownEvent) and event.key_code == keys.S:
             if self._config_manager.save():
                 self._saved_flash_timer = 1.5
             return True
 
-        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+        if isinstance(event, MouseButtonEvent) and event.is_down and event.button == 1:
             mx, my = event.pos
             for rect, leaf in self._tweakable_rows:
                 if (

--- a/pyguara/tools/gizmos.py
+++ b/pyguara/tools/gizmos.py
@@ -9,13 +9,13 @@ from collections.abc import Callable
 from enum import Enum, auto
 from typing import Any
 
-import pygame  # Only for event handling key constants
-
 from pyguara.common.components import Transform
 from pyguara.common.types import Color, Rect, Vector2
 from pyguara.di.container import DIContainer
 from pyguara.ecs.entity import Entity
+from pyguara.events.input import KeyDownEvent, MouseButtonEvent
 from pyguara.graphics.protocols import UIRenderer
+from pyguara.input import keys
 from pyguara.tools.base import Tool
 
 
@@ -316,34 +316,36 @@ class TransformGizmo(Tool):
         """Process input events for gizmo interaction.
 
         Args:
-            event: Raw pygame event.
+            event: An engine input event.
 
         Returns:
             True if the event was consumed, False otherwise.
         """
-        if not hasattr(event, "type"):
-            return False
-
         provided = self._selection_provider is not None
 
         # Mode switching with Q, W, E keys
-        if event.type == pygame.KEYDOWN:
-            if event.key == pygame.K_q:
+        if isinstance(event, KeyDownEvent):
+            if event.key_code == keys.Q:
                 self._mode = GizmoMode.TRANSLATE
                 return True
-            elif event.key == pygame.K_w:
+            elif event.key_code == keys.W:
                 self._mode = GizmoMode.ROTATE
                 return True
-            elif event.key == pygame.K_e:
+            elif event.key_code == keys.E:
                 self._mode = GizmoMode.SCALE
                 return True
-            elif event.key == pygame.K_ESCAPE and not provided:
+            elif event.key_code == keys.ESCAPE and not provided:
                 self._selected_entity = None
                 return True
 
         # Entity selection on mouse click -- only when this gizmo owns the
         # selection (no external provider driving it).
-        if not provided and event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+        if (
+            not provided
+            and isinstance(event, MouseButtonEvent)
+            and event.is_down
+            and event.button == 1
+        ):
             mouse_pos = Vector2(event.pos[0], event.pos[1])
             self.select_at_position(mouse_pos)
             # Don't consume - let the click propagate

--- a/pyguara/tools/hierarchy.py
+++ b/pyguara/tools/hierarchy.py
@@ -2,12 +2,11 @@
 
 from typing import Any
 
-import pygame
-
 from pyguara.common.components import Tag
 from pyguara.common.types import Color, Rect, Vector2
 from pyguara.di.container import DIContainer
 from pyguara.ecs.entity import Entity
+from pyguara.events.input import MouseButtonEvent
 from pyguara.graphics.protocols import UIRenderer
 from pyguara.tools.base import Tool
 
@@ -104,7 +103,7 @@ class HierarchyTool(Tool):
         Args:
             event: Pygame event.
         """
-        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+        if isinstance(event, MouseButtonEvent) and event.is_down and event.button == 1:
             mx, my = event.pos
             for rect, entity_id in self._rows:
                 if (

--- a/pyguara/tools/inspector.py
+++ b/pyguara/tools/inspector.py
@@ -3,13 +3,13 @@
 from collections.abc import Callable
 from typing import Any
 
-import pygame
-
 from pyguara.common.components import Tag
 from pyguara.common.types import Color, Rect, Vector2
 from pyguara.di.container import DIContainer
 from pyguara.ecs.entity import Entity
+from pyguara.events.input import KeyDownEvent, MouseButtonEvent
 from pyguara.graphics.protocols import UIRenderer
+from pyguara.input import keys
 from pyguara.tools.base import Tool
 from pyguara.tools.tweakable import (
     TweakableLeaf,
@@ -186,19 +186,19 @@ class EntityInspector(Tool):
         """Handle cycling selection and clicks on editable field rows.
 
         Args:
-            event: Pygame event.
+            event: An engine input event.
         """
         if (
             self._selection_provider is None
-            and event.type == pygame.KEYDOWN
-            and event.key == pygame.K_TAB
+            and isinstance(event, KeyDownEvent)
+            and event.key_code == keys.TAB
         ):
             count = sum(1 for _ in self._entity_manager.get_all_entities())
             if count > 0:
                 self._selected_index = (self._selected_index + 1) % count
                 return True
 
-        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+        if isinstance(event, MouseButtonEvent) and event.is_down and event.button == 1:
             mx, my = event.pos
             for rect, leaf in self._tweakable_rows:
                 if (

--- a/pyguara/tools/manager.py
+++ b/pyguara/tools/manager.py
@@ -2,10 +2,10 @@
 
 from typing import Any
 
-import pygame
-
 from pyguara.di.container import DIContainer
+from pyguara.events.input import KeyDownEvent
 from pyguara.graphics.protocols import UIRenderer
+from pyguara.input import keys
 from pyguara.log import get_logger
 from pyguara.tools.base import Tool
 
@@ -142,20 +142,20 @@ class ToolManager:
         debug panel shouldn't fire a gun in the game).
 
         Args:
-            event: The raw input event.
+            event: An engine input event (see `events/input.py`).
 
         Returns:
             True if the event was consumed, False otherwise.
         """
-        if event.type == pygame.KEYDOWN:
+        if isinstance(event, KeyDownEvent):
             # F12: Toggle Master Switch
-            if event.key == pygame.K_F12:
+            if event.key_code == keys.F12:
                 self.toggle_global_visibility()
                 return True
 
             # Tool Specific Toggles (Only if master switch is ON)
-            if self._is_globally_visible and event.key in self._shortcuts:
-                tool_name = self._shortcuts[event.key]
+            if self._is_globally_visible and event.key_code in self._shortcuts:
+                tool_name = self._shortcuts[event.key_code]
                 if tool := self._tools.get(tool_name):
                     tool.toggle()
                     logger.debug("Toggled tool '%s': %s", tool_name, tool.is_visible)

--- a/pyguara/tools/shortcuts_panel.py
+++ b/pyguara/tools/shortcuts_panel.py
@@ -1,10 +1,9 @@
 """Keyboard shortcuts reference panel."""
 
-import pygame
-
 from pyguara.common.types import Color, Rect, Vector2
 from pyguara.di.container import DIContainer
 from pyguara.graphics.protocols import UIRenderer
+from pyguara.input.keys import key_name
 from pyguara.tools.base import Tool
 from pyguara.tools.manager import ToolManager
 
@@ -50,7 +49,7 @@ class ShortcutsPanel(Tool):
         if self._manager is None:
             return rows
         for key_code, tool_name in self._manager.iter_shortcuts():
-            label = pygame.key.name(key_code).upper()
+            label = key_name(key_code).upper()
             rows.append((label, tool_name.replace("_", " ").title()))
         return rows
 

--- a/tests/integration/test_app_flow.py
+++ b/tests/integration/test_app_flow.py
@@ -1,5 +1,5 @@
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -118,8 +118,7 @@ def test_app_lifecycle_run_once(app_container: DIContainer) -> None:
     app._clock.tick.side_effect = stop_app
 
     # ACT
-    with patch("pygame.event.pump"):
-        app.run(scene)
+    app.run(scene)
 
     # ASSERT
     assert scene.enter_called
@@ -279,18 +278,14 @@ def test_quit_event_is_dispatched_when_the_window_closes(
 ) -> None:
     """QuitEvent had no publisher, so tools/event_monitor.py was subscribed to
     something that could never fire."""
-    import pygame
-
     from pyguara.events.lifecycle import QuitEvent
 
     dispatcher = app_container.get(EventDispatcher)
     seen = []
     dispatcher.subscribe(QuitEvent, lambda e: seen.append(e))
 
-    quit_event = MagicMock()
-    quit_event.type = pygame.QUIT
     window = app_container.get(Window)
-    window.poll_events.return_value = [quit_event]
+    window.poll_events.return_value = [QuitEvent()]
 
     app = Application(app_container)
     app.run(MockScene("s", dispatcher))
@@ -300,17 +295,38 @@ def test_quit_event_is_dispatched_when_the_window_closes(
 
 
 def test_a_quit_event_stops_the_loop(app_container: DIContainer) -> None:
-    import pygame
+    from pyguara.events.lifecycle import QuitEvent
 
-    quit_event = MagicMock()
-    quit_event.type = pygame.QUIT
     window = app_container.get(Window)
-    window.poll_events.return_value = [quit_event]
+    window.poll_events.return_value = [QuitEvent()]
 
     app = Application(app_container)
     app.run(MockScene("s", app_container.get(EventDispatcher)))
 
     assert not app._is_running
+
+
+def test_a_window_resize_event_is_published(app_container: DIContainer) -> None:
+    """`WindowResizeEvent` had no publisher before #9; the loop now forwards
+    the one the window backend translates from SDL."""
+    from pyguara.events.lifecycle import QuitEvent
+    from pyguara.events.window import WindowResizeEvent
+
+    dispatcher = app_container.get(EventDispatcher)
+    seen: list[WindowResizeEvent] = []
+    dispatcher.subscribe(WindowResizeEvent, seen.append)
+
+    window = app_container.get(Window)
+    # One resize this frame, then quit so the loop unwinds.
+    window.poll_events.return_value = [
+        WindowResizeEvent(width=1024, height=768),
+        QuitEvent(),
+    ]
+
+    app = Application(app_container)
+    app.run(MockScene("s", dispatcher))
+
+    assert [(e.width, e.height) for e in seen] == [(1024, 768)]
 
 
 # -- Fixed timestep --

--- a/tests/integration/test_replay_wiring.py
+++ b/tests/integration/test_replay_wiring.py
@@ -13,7 +13,6 @@ Deliberately left unmarked, like `test_bootstrap_smoke.py`, so it runs under
 """
 
 import os
-from types import SimpleNamespace
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 os.environ["SDL_AUDIODRIVER"] = "dummy"
@@ -27,10 +26,12 @@ from pyguara.application.bootstrap import create_application
 from pyguara.common.components import Transform
 from pyguara.common.types import Vector2
 from pyguara.ecs.entity import Entity
+from pyguara.events.input import KeyDownEvent, KeyUpEvent
+from pyguara.input import keys as key_codes
 from pyguara.input.events import OnActionEvent
 from pyguara.input.types import ActionType, InputContext, InputDevice
 
-MOVE_KEY = pygame.K_d
+MOVE_KEY = key_codes.D
 MOVE_STEP = 10.0
 FIXED_DT = 1.0 / 60.0
 NUM_FRAMES = 10
@@ -40,21 +41,21 @@ NUM_FRAMES = 10
 SCRIPTED_PRESSES = {0: [MOVE_KEY], 4: [MOVE_KEY], 7: [MOVE_KEY]}
 
 
-def _key_event(key: int, down: bool) -> SimpleNamespace:
-    return SimpleNamespace(type=pygame.KEYDOWN if down else pygame.KEYUP, key=key)
+def _key_event(key: int, down: bool) -> KeyDownEvent | KeyUpEvent:
+    return KeyDownEvent(key_code=key) if down else KeyUpEvent(key_code=key)
 
 
-def _scripted_frames() -> list[list[SimpleNamespace]]:
-    """Build a fixed schedule of pygame-shaped key events, one list per frame."""
-    frames: list[list[SimpleNamespace]] = [[] for _ in range(NUM_FRAMES)]
-    for frame_id, keys in SCRIPTED_PRESSES.items():
-        for key in keys:
+def _scripted_frames() -> list[list[object]]:
+    """Build a fixed schedule of engine key events, one list per frame."""
+    frames: list[list[object]] = [[] for _ in range(NUM_FRAMES)]
+    for frame_id, codes in SCRIPTED_PRESSES.items():
+        for key in codes:
             frames[frame_id].append(_key_event(key, down=True))
             frames[frame_id + 1].append(_key_event(key, down=False))
     return frames
 
 
-def _make_poll_events(frames: list[list[SimpleNamespace]]):
+def _make_poll_events(frames: list[list[object]]):
     iterator = iter(frames)
     return lambda: next(iterator, [])
 

--- a/tests/test_assets_tool.py
+++ b/tests/test_assets_tool.py
@@ -18,6 +18,7 @@ import pytest
 
 from pyguara.application.bootstrap import create_headless_application
 from pyguara.common.components import ResourceLink, Tag, Transform
+from pyguara.events.input import MouseButtonEvent
 from pyguara.graphics.protocols import UIRenderer
 from pyguara.scene.base import Scene
 from pyguara.tools.assets_browser import AssetsTool
@@ -161,10 +162,9 @@ def test_spawn_button_is_not_clickable_for_a_loaded_non_data_resource(
     assert tool._reload_rect is not None  # loaded -> Reload is fine
 
     # And a click where the (now absent) Spawn button drew is a no-op.
-    event = MagicMock()
-    event.type = pygame.MOUSEBUTTONDOWN
-    event.button = 1
-    event.pos = (tool._panel_rect.x + 20, tool._panel_rect.y + 400)
+    event = MouseButtonEvent(
+        button=1, x=tool._panel_rect.x + 20, y=tool._panel_rect.y + 400, is_down=True
+    )
     assert tool.process_event(event) is False
     app.shutdown()
 
@@ -179,10 +179,7 @@ def test_clicking_a_row_selects_it(tmp_path) -> None:
     tool.render(_renderer())
     rect, path = tool._rows[0]
 
-    event = MagicMock()
-    event.type = pygame.MOUSEBUTTONDOWN
-    event.button = 1
-    event.pos = (rect.x + 2, rect.y + 2)
+    event = MouseButtonEvent(button=1, x=rect.x + 2, y=rect.y + 2, is_down=True)
 
     assert tool.process_event(event) is True
     assert tool._selected_path == path

--- a/tests/test_engine_events.py
+++ b/tests/test_engine_events.py
@@ -1,0 +1,104 @@
+"""SDL -> engine event translation at the window boundary (issue #9).
+
+The window backends pump SDL and hand the rest of the engine
+`pyguara.events` objects, never raw pygame structs. These pin the mapping,
+the key-code constants, and that `Application` now publishes
+`WindowResizeEvent` (which previously had no publisher at all).
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+import pygame
+import pytest
+
+from pyguara.events.input import (
+    KeyDownEvent,
+    KeyUpEvent,
+    MouseButtonEvent,
+    MouseMotionEvent,
+)
+from pyguara.events.lifecycle import QuitEvent
+from pyguara.events.window import WindowResizeEvent
+from pyguara.graphics.backends.pygame.events import translate_event, translate_events
+from pyguara.input import keys
+
+
+@pytest.fixture(autouse=True)
+def _pygame_ready():
+    pygame.init()
+    yield
+    pygame.quit()
+
+
+class TestTranslateEvent:
+    def test_quit_becomes_quit_event(self) -> None:
+        assert isinstance(translate_event(pygame.event.Event(pygame.QUIT)), QuitEvent)
+
+    def test_keydown_carries_the_key_code(self) -> None:
+        raw = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_SPACE)
+        out = translate_event(raw)
+        assert isinstance(out, KeyDownEvent)
+        assert out.key_code == pygame.K_SPACE == keys.SPACE
+
+    def test_keyup_is_distinct_from_keydown(self) -> None:
+        out = translate_event(pygame.event.Event(pygame.KEYUP, key=pygame.K_a))
+        assert isinstance(out, KeyUpEvent)
+        assert not isinstance(out, KeyDownEvent)
+
+    def test_mouse_button_down_carries_button_and_position(self) -> None:
+        raw = pygame.event.Event(pygame.MOUSEBUTTONDOWN, button=1, pos=(120, 45))
+        out = translate_event(raw)
+        assert isinstance(out, MouseButtonEvent)
+        assert (out.button, out.pos, out.is_down) == (1, (120, 45), True)
+
+    def test_mouse_button_up_sets_is_down_false(self) -> None:
+        raw = pygame.event.Event(pygame.MOUSEBUTTONUP, button=3, pos=(0, 0))
+        out = translate_event(raw)
+        assert isinstance(out, MouseButtonEvent)
+        assert out.is_down is False
+
+    def test_mouse_motion_carries_position_and_delta(self) -> None:
+        raw = pygame.event.Event(pygame.MOUSEMOTION, pos=(10, 20), rel=(3, -4))
+        out = translate_event(raw)
+        assert isinstance(out, MouseMotionEvent)
+        assert (out.pos, out.rel_x, out.rel_y) == ((10, 20), 3, -4)
+
+    def test_videoresize_becomes_window_resize_event(self) -> None:
+        raw = pygame.event.Event(pygame.VIDEORESIZE, w=800, h=600, size=(800, 600))
+        out = translate_event(raw)
+        assert isinstance(out, WindowResizeEvent)
+        assert (out.width, out.height) == (800, 600)
+
+    def test_an_unmapped_event_is_dropped(self) -> None:
+        assert translate_event(pygame.event.Event(pygame.USEREVENT)) is None
+
+    def test_translate_events_drops_the_unmapped_ones(self) -> None:
+        raw = [
+            pygame.event.Event(pygame.KEYDOWN, key=pygame.K_a),
+            pygame.event.Event(pygame.USEREVENT),
+            pygame.event.Event(pygame.QUIT),
+        ]
+        out = translate_events(raw)
+        assert [type(e) for e in out] == [KeyDownEvent, QuitEvent]
+
+
+class TestKeyConstants:
+    """`pyguara.input.keys` values must stay equal to pygame's, since key
+    codes pass straight through the translator."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["F1", "F5", "F9", "F12", "ESCAPE", "SPACE", "TAB", "Q", "W", "E", "S"],
+    )
+    def test_matches_pygame(self, name: str) -> None:
+        pygame_name = "K_" + (name if len(name) > 1 else name.lower())
+        assert getattr(keys, name) == getattr(pygame, pygame_name)
+
+    def test_key_name_round_trips(self) -> None:
+        assert keys.key_name(keys.F9) == "F9"
+        assert keys.key_name(-1).startswith("KEY_")

--- a/tests/test_gizmos.py
+++ b/tests/test_gizmos.py
@@ -18,7 +18,9 @@ import pytest
 from pyguara.application.bootstrap import create_headless_application
 from pyguara.common.components import Transform
 from pyguara.common.types import Vector2
+from pyguara.events.input import KeyDownEvent, MouseButtonEvent
 from pyguara.graphics.protocols import UIRenderer
+from pyguara.input import keys
 from pyguara.scene.base import Scene
 from pyguara.tools.gizmos import GizmoMode, TransformGizmo
 
@@ -50,11 +52,8 @@ def app_scene():
     app.shutdown()
 
 
-def _key(code: int) -> MagicMock:
-    ev = MagicMock()
-    ev.type = pygame.KEYDOWN
-    ev.key = code
-    return ev
+def _key(code: int) -> KeyDownEvent:
+    return KeyDownEvent(key_code=code)
 
 
 def _entity_with_transform(scene, x=0.0, y=0.0):
@@ -69,11 +68,11 @@ class TestModeSwitching:
         gizmo = TransformGizmo(app._container)
 
         assert gizmo.mode is GizmoMode.TRANSLATE
-        assert gizmo.process_event(_key(pygame.K_w)) is True
+        assert gizmo.process_event(_key(keys.W)) is True
         assert gizmo.mode is GizmoMode.ROTATE
-        assert gizmo.process_event(_key(pygame.K_e)) is True
+        assert gizmo.process_event(_key(keys.E)) is True
         assert gizmo.mode is GizmoMode.SCALE
-        assert gizmo.process_event(_key(pygame.K_q)) is True
+        assert gizmo.process_event(_key(keys.Q)) is True
         assert gizmo.mode is GizmoMode.TRANSLATE
 
 
@@ -85,10 +84,7 @@ class TestClickSelectionMode:
         entity = _entity_with_transform(scene, 100, 100)
         gizmo = TransformGizmo(app._container)
 
-        click = MagicMock()
-        click.type = pygame.MOUSEBUTTONDOWN
-        click.button = 1
-        click.pos = (100, 100)
+        click = MouseButtonEvent(button=1, x=100, y=100, is_down=True)
         gizmo.process_event(click)
 
         assert gizmo.selected_entity is entity
@@ -98,7 +94,7 @@ class TestClickSelectionMode:
         gizmo = TransformGizmo(app._container)
         gizmo.selected_entity = _entity_with_transform(scene)
 
-        assert gizmo.process_event(_key(pygame.K_ESCAPE)) is True
+        assert gizmo.process_event(_key(keys.ESCAPE)) is True
         assert gizmo.selected_entity is None
 
 
@@ -125,14 +121,11 @@ class TestProvidedSelectionMode:
         gizmo.update(0.016)
 
         # ESC must not clear a provider-driven selection
-        assert gizmo.process_event(_key(pygame.K_ESCAPE)) is False
+        assert gizmo.process_event(_key(keys.ESCAPE)) is False
         assert gizmo.selected_entity is entity
 
         # A viewport click must not hijack selection
-        click = MagicMock()
-        click.type = pygame.MOUSEBUTTONDOWN
-        click.button = 1
-        click.pos = (50, 50)
+        click = MouseButtonEvent(button=1, x=50, y=50, is_down=True)
         gizmo.process_event(click)
         assert gizmo.selected_entity is entity
 

--- a/tests/test_hierarchy_tool.py
+++ b/tests/test_hierarchy_tool.py
@@ -16,6 +16,7 @@ import pytest
 
 from pyguara.application.bootstrap import create_headless_application
 from pyguara.common.components import Tag
+from pyguara.events.input import MouseButtonEvent
 from pyguara.graphics.protocols import UIRenderer
 from pyguara.scene.base import Scene
 from pyguara.tools.hierarchy import HierarchyTool
@@ -45,10 +46,7 @@ def _renderer() -> MagicMock:
 
 
 def _click(tool: HierarchyTool, x: int, y: int) -> bool:
-    event = MagicMock()
-    event.type = pygame.MOUSEBUTTONDOWN
-    event.button = 1
-    event.pos = (x, y)
+    event = MouseButtonEvent(button=1, x=x, y=y, is_down=True)
     return tool.process_event(event)
 
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,10 +1,9 @@
-from types import SimpleNamespace
 from typing import Any
 
-# We need to mock pygame constants since we mocked the module
-import pygame
 import pytest
 
+from pyguara.events.input import KeyDownEvent
+from pyguara.input import keys
 from pyguara.input.events import (
     GamepadAxisEvent,
     GamepadButtonEvent,
@@ -22,12 +21,6 @@ from pyguara.input.types import (
     InputContext,
     InputDevice,
 )
-
-pygame.KEYDOWN = 1
-pygame.KEYUP = 2
-pygame.MOUSEBUTTONDOWN = 3
-pygame.MOUSEBUTTONUP = 4
-pygame.K_SPACE = 32
 
 
 class _StubJoystick:
@@ -113,12 +106,12 @@ def test_input_registration(event_dispatcher: Any) -> None:
 
     # Bind Space -> Jump
     manager._bindings.bind(
-        InputDevice.KEYBOARD, pygame.K_SPACE, "jump", InputContext.GAMEPLAY
+        InputDevice.KEYBOARD, keys.SPACE, "jump", InputContext.GAMEPLAY
     )
 
     # Verify internal state
     actions = manager._bindings.get_actions(
-        InputDevice.KEYBOARD, pygame.K_SPACE, InputContext.GAMEPLAY
+        InputDevice.KEYBOARD, keys.SPACE, InputContext.GAMEPLAY
     )
     assert "jump" in actions
 
@@ -129,7 +122,7 @@ def test_keyboard_event_processing(event_dispatcher: Any) -> None:
     # Register "jump"
     action = InputAction("jump", ActionType.PRESS)
     manager._registered_actions["jump"] = action
-    manager._bindings.bind(InputDevice.KEYBOARD, pygame.K_SPACE, "jump")
+    manager._bindings.bind(InputDevice.KEYBOARD, keys.SPACE, "jump")
 
     # Spy on events
     events = []
@@ -137,7 +130,7 @@ def test_keyboard_event_processing(event_dispatcher: Any) -> None:
 
     # Simulate KeyDown
 
-    mock_event = SimpleNamespace(type=pygame.KEYDOWN, key=pygame.K_SPACE)
+    mock_event = KeyDownEvent(key_code=keys.SPACE)
 
     manager.process_event(mock_event)
 
@@ -153,17 +146,13 @@ def test_context_switching(event_dispatcher: Any) -> None:
     manager.register_action("jump", ActionType.PRESS)
     manager.register_action("select", ActionType.PRESS)
 
-    manager.bind_input(
-        InputDevice.KEYBOARD, pygame.K_SPACE, "jump", InputContext.GAMEPLAY
-    )
-    manager.bind_input(
-        InputDevice.KEYBOARD, pygame.K_SPACE, "select", InputContext.MENU
-    )
+    manager.bind_input(InputDevice.KEYBOARD, keys.SPACE, "jump", InputContext.GAMEPLAY)
+    manager.bind_input(InputDevice.KEYBOARD, keys.SPACE, "select", InputContext.MENU)
 
     events = []
     event_dispatcher.subscribe(OnActionEvent, lambda e: events.append(e.action_name))
 
-    mock_event = SimpleNamespace(type=pygame.KEYDOWN, key=pygame.K_SPACE)
+    mock_event = KeyDownEvent(key_code=keys.SPACE)
 
     # Default is GAMEPLAY
     assert manager.context is InputContext.GAMEPLAY
@@ -184,11 +173,11 @@ def test_non_gameplay_binding_is_dead_until_context_switched(
     context is made active -- the regression that motivated exposing the API."""
     manager = InputManager(event_dispatcher, _StubInputBackend())
     manager.register_action("confirm", ActionType.PRESS)
-    manager.bind_input(InputDevice.KEYBOARD, pygame.K_SPACE, "confirm", InputContext.UI)
+    manager.bind_input(InputDevice.KEYBOARD, keys.SPACE, "confirm", InputContext.UI)
 
     fired: list[str] = []
     event_dispatcher.subscribe(OnActionEvent, lambda e: fired.append(e.action_name))
-    key_down = SimpleNamespace(type=pygame.KEYDOWN, key=pygame.K_SPACE)
+    key_down = KeyDownEvent(key_code=keys.SPACE)
 
     manager.process_event(key_down)
     assert fired == []  # GAMEPLAY is active; the UI binding is dormant
@@ -245,13 +234,13 @@ def test_dispatched_input_events_carry_a_real_timestamp(event_dispatcher: Any) -
 
     manager = InputManager(event_dispatcher, _StubInputBackend())
     manager.register_action("jump", ActionType.PRESS)
-    manager.bind_input(InputDevice.KEYBOARD, pygame.K_SPACE, "jump")
+    manager.bind_input(InputDevice.KEYBOARD, keys.SPACE, "jump")
 
     events: list[OnActionEvent] = []
     event_dispatcher.subscribe(OnActionEvent, events.append)
 
     before = time.time()
-    manager.process_event(SimpleNamespace(type=pygame.KEYDOWN, key=pygame.K_SPACE))
+    manager.process_event(KeyDownEvent(key_code=keys.SPACE))
 
     assert len(events) == 1
     assert before <= events[0].timestamp <= time.time()

--- a/tests/test_inspector_tools.py
+++ b/tests/test_inspector_tools.py
@@ -19,7 +19,9 @@ from pyguara.application.bootstrap import create_headless_application
 from pyguara.common.components import Transform
 from pyguara.common.types import Vector2
 from pyguara.config.manager import ConfigManager
+from pyguara.events.input import KeyDownEvent, MouseButtonEvent
 from pyguara.graphics.protocols import UIRenderer
+from pyguara.input import keys
 from pyguara.physics.platformer_controller import PlatformerController
 from pyguara.scene.base import Scene
 from pyguara.tools.config_inspector import ConfigInspector
@@ -46,10 +48,7 @@ def _quit_pygame():
 
 
 def _click_at(tool, x: int, y: int) -> bool:
-    event = MagicMock()
-    event.type = pygame.MOUSEBUTTONDOWN
-    event.button = 1
-    event.pos = (x, y)
+    event = MouseButtonEvent(button=1, x=x, y=y, is_down=True)
     return tool.process_event(event)
 
 
@@ -145,9 +144,7 @@ class TestEntityInspectorSelectionProvider:
         assert inspector._selected_entity is b
 
         # TAB is ignored in provided mode.
-        tab = MagicMock()
-        tab.type = pygame.KEYDOWN
-        tab.key = pygame.K_TAB
+        tab = KeyDownEvent(key_code=keys.TAB)
         assert inspector.process_event(tab) is False
 
         picked[0] = a
@@ -197,9 +194,7 @@ class TestConfigInspectorEditing:
 
         assert config_manager.config.audio.master_volume == original + 1.0
 
-        save_event = MagicMock()
-        save_event.type = pygame.KEYDOWN
-        save_event.key = pygame.K_s
+        save_event = KeyDownEvent(key_code=keys.S)
         assert inspector.process_event(save_event) is True
 
         assert config_manager._file_path.exists()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3,11 +3,12 @@
 from typing import Any
 from unittest.mock import MagicMock, create_autospec
 
-import pygame
 import pytest
 
 from pyguara.di.container import DIContainer
+from pyguara.events.input import KeyDownEvent, MouseButtonEvent
 from pyguara.graphics.protocols import UIRenderer
+from pyguara.input import keys
 from pyguara.tools.base import Tool
 from pyguara.tools.manager import ToolManager
 
@@ -136,10 +137,10 @@ class TestToolManager:
         manager = ToolManager(container)
         tool = MockTool("test_tool", container)
 
-        manager.register_tool(tool, shortcut_key=pygame.K_F1)
+        manager.register_tool(tool, shortcut_key=keys.F1)
 
-        assert pygame.K_F1 in manager._shortcuts
-        assert manager._shortcuts[pygame.K_F1] == "test_tool"
+        assert keys.F1 in manager._shortcuts
+        assert manager._shortcuts[keys.F1] == "test_tool"
 
     def test_registered_tool_starts_hidden(self, container: DIContainer) -> None:
         """Registered tools start hidden by default."""
@@ -251,9 +252,7 @@ class TestToolManagerEvents:
     def test_f12_toggles_global_visibility(self, container: DIContainer) -> None:
         """F12 key toggles global visibility."""
         manager = ToolManager(container)
-        event = MagicMock()
-        event.type = pygame.KEYDOWN
-        event.key = pygame.K_F12
+        event = KeyDownEvent(key_code=keys.F12)
 
         assert manager._is_globally_visible is False
 
@@ -268,12 +267,10 @@ class TestToolManagerEvents:
         """Shortcut key toggles tool when overlay is visible."""
         manager = ToolManager(container)
         tool = MockTool("test_tool", container)
-        manager.register_tool(tool, shortcut_key=pygame.K_F1)
+        manager.register_tool(tool, shortcut_key=keys.F1)
         manager._is_globally_visible = True
 
-        event = MagicMock()
-        event.type = pygame.KEYDOWN
-        event.key = pygame.K_F1
+        event = KeyDownEvent(key_code=keys.F1)
 
         # Tool starts hidden after registration
         assert tool.is_visible is False
@@ -289,12 +286,10 @@ class TestToolManagerEvents:
         """Shortcut keys are ignored when global overlay is hidden."""
         manager = ToolManager(container)
         tool = MockTool("test_tool", container)
-        manager.register_tool(tool, shortcut_key=pygame.K_F1)
+        manager.register_tool(tool, shortcut_key=keys.F1)
         manager._is_globally_visible = False
 
-        event = MagicMock()
-        event.type = pygame.KEYDOWN
-        event.key = pygame.K_F1
+        event = KeyDownEvent(key_code=keys.F1)
 
         result = manager.process_event(event)
 
@@ -316,8 +311,7 @@ class TestToolManagerEvents:
         tool1.show()
         tool2.show()
 
-        event = MagicMock()
-        event.type = pygame.MOUSEBUTTONDOWN
+        event = MouseButtonEvent(button=1, x=0, y=0, is_down=True)
 
         result = manager.process_event(event)
 
@@ -337,8 +331,7 @@ class TestToolManagerEvents:
         tool.show()
         tool._is_active = False
 
-        event = MagicMock()
-        event.type = pygame.MOUSEBUTTONDOWN
+        event = MouseButtonEvent(button=1, x=0, y=0, is_down=True)
 
         result = manager.process_event(event)
 
@@ -401,13 +394,13 @@ class TestMultipleTools:
         tool2 = MockTool("inspector", container)
         tool3 = MockTool("events", container)
 
-        manager.register_tool(tool1, pygame.K_F1)
-        manager.register_tool(tool2, pygame.K_F2)
-        manager.register_tool(tool3, pygame.K_F3)
+        manager.register_tool(tool1, keys.F1)
+        manager.register_tool(tool2, keys.F2)
+        manager.register_tool(tool3, keys.F3)
 
-        assert manager._shortcuts[pygame.K_F1] == "perf"
-        assert manager._shortcuts[pygame.K_F2] == "inspector"
-        assert manager._shortcuts[pygame.K_F3] == "events"
+        assert manager._shortcuts[keys.F1] == "perf"
+        assert manager._shortcuts[keys.F2] == "inspector"
+        assert manager._shortcuts[keys.F3] == "events"
 
     def test_update_multiple_tools(self, container: DIContainer) -> None:
         """Update is called on all active tools."""
@@ -468,8 +461,7 @@ class TestToolManagerLifecycle:
         second.show()
         manager.update(0.016)
         manager.render(mock_renderer)
-        ev = MagicMock()
-        ev.type = pygame.MOUSEBUTTONDOWN
+        ev = MouseButtonEvent(button=1, x=0, y=0, is_down=True)
         manager.process_event(ev)
 
         assert (second.updates, second.renders, second.events) == (1, 1, 1)
@@ -478,24 +470,24 @@ class TestToolManagerLifecycle:
     def test_reregistering_drops_the_old_shortcut(self, container: DIContainer) -> None:
         manager = ToolManager(container)
         tool = MockTool("dup", container)
-        manager.register_tool(tool, pygame.K_F1)
-        manager.register_tool(MockTool("dup", container), pygame.K_F2)
+        manager.register_tool(tool, keys.F1)
+        manager.register_tool(MockTool("dup", container), keys.F2)
 
-        assert pygame.K_F1 not in manager._shortcuts
-        assert manager._shortcuts[pygame.K_F2] == "dup"
+        assert keys.F1 not in manager._shortcuts
+        assert manager._shortcuts[keys.F2] == "dup"
 
     def test_unregister_removes_from_every_structure_and_calls_hook(
         self, container: DIContainer
     ) -> None:
         manager = ToolManager(container)
         tool = _CountingTool("gone", container)
-        manager.register_tool(tool, pygame.K_F4)
+        manager.register_tool(tool, keys.F4)
 
         assert manager.unregister_tool("gone") is True
 
         assert manager.get_tool("gone") is None
         assert "gone" not in manager._render_order
-        assert pygame.K_F4 not in manager._shortcuts
+        assert keys.F4 not in manager._shortcuts
         assert tool.removed == 1
 
     def test_unregister_unknown_tool_returns_false(
@@ -517,12 +509,12 @@ class TestToolManagerLifecycle:
 
     def test_iter_shortcuts_is_sorted_by_key(self, container: DIContainer) -> None:
         manager = ToolManager(container)
-        manager.register_tool(MockTool("b", container), pygame.K_F5)
-        manager.register_tool(MockTool("a", container), pygame.K_F1)
+        manager.register_tool(MockTool("b", container), keys.F5)
+        manager.register_tool(MockTool("a", container), keys.F1)
 
         assert manager.iter_shortcuts() == [
-            (pygame.K_F1, "a"),
-            (pygame.K_F5, "b"),
+            (keys.F1, "a"),
+            (keys.F5, "b"),
         ]
 
 
@@ -588,7 +580,7 @@ class TestEventMonitorTeardown:
         dispatcher = EventDispatcher()
         container.register_instance(EventDispatcher, dispatcher)
         manager = ToolManager(container)
-        manager.register_tool(EventMonitor(container), pygame.K_F3)
+        manager.register_tool(EventMonitor(container), keys.F3)
 
         manager.unregister_tool("event_monitor")
 


### PR DESCRIPTION
**Closes #9.** Second and final slice — pygame is now confined to `backends/`.

Slice 1 (#79, merged) added the `Clock` protocol. `application.py` still
imported pygame for `event.pump()` / `pygame.QUIT`, and `InputManager` + all
of `pyguara/tools/*` + `sandbox.py` parsed raw SDL events.

## The boundary

`Window.poll_events()` now returns **engine events**, never SDL structs. New
`graphics/backends/pygame/events.py` maps SDL →

| SDL | engine |
| --- | --- |
| `QUIT` | `QuitEvent` |
| `KEYDOWN` / `KEYUP` | `KeyDownEvent` / `KeyUpEvent` (+ held modifiers) |
| `MOUSEBUTTONDOWN` / `UP` | `MouseButtonEvent` |
| `MOUSEMOTION` | `MouseMotionEvent` |
| `VIDEORESIZE` | `WindowResizeEvent` |

Both the pygame and ModernGL window backends call it; the headless one
already returns `[]`. `events/input.py` gains `MouseButtonEvent` and a
`modifiers` field on `KeyboardEvent`; `input/keys.py` gains `key_name()`.

## The consumers

- **`application.py`** — drops `import pygame`, the `pygame.event.pump()`
  primer (poll_events pumps), and the `pygame.QUIT` check → `isinstance`. Now
  also forwards **`WindowResizeEvent`**, which had *no publisher at all*.
- **`InputManager`** — `process_event` switches on engine event types;
  `_current_modifiers()` (`pygame.key.get_mods()`) is gone, the backend puts
  modifiers on the event. Key codes still pass through as SDL values, so
  bindings and replays are unchanged.
- **`ToolManager`**, the six event-handling tools, **`sandbox.py`** — consume
  engine events, hotkeys from `pyguara.input.keys`.

## Verification

`tests/test_engine_events.py` (new) covers the translator, guards that
`keys.*` still equals pygame's values (pygame-ce drift → CI failure), and
pins the resize publisher. ~8 tests that fed `SimpleNamespace`/`MagicMock`
pygame events now build real engine events.

Clean worktree: `ruff`, `mypy`, full suite **1962 passed**, 7 visual
snapshots unchanged, plus an `agent_view` render check of two demos.

Rebased onto `main` after #79 merged — single commit, no stack.

PR is final — nothing else coming on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrKShjnJeydtGXC6YFMJU5